### PR TITLE
feat(PageId): Specify PageId when page published to Confluence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"punycode": "^1.4.1",
 				"react": "^16.14.0",
 				"react-dom": "^16.14.0",
+				"react-intl-next": "npm:react-intl@^5.18.1",
 				"spark-md5": "^3.0.2",
 				"uuid": "^9.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
 		"react": "^16.14.0",
 		"react-dom": "^16.14.0",
 		"spark-md5": "^3.0.2",
-		"uuid": "^9.0.0"
+		"uuid": "^9.0.0",
+		"react-intl-next": "npm:react-intl@^5.18.1"
 	},
 	"lint-staged": {
 		"src/**/*": "prettier --write --ignore-unknown"

--- a/src/AdfView.ts
+++ b/src/AdfView.ts
@@ -1,5 +1,6 @@
 import {
 	EventRef,
+	FileSystemAdapter,
 	ItemView,
 	Menu,
 	Vault,
@@ -11,6 +12,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { ReactRenderer } from "@atlaskit/renderer";
 import MdToADF from "./mdToADF";
+import { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import { traverse, filter } from "@atlaskit/adf-utils/traverse";
+import { IntlProvider } from "react-intl-next";
 
 export const ADF_VIEW_TYPE = "AtlassianDocumentFormatView";
 
@@ -55,11 +59,58 @@ export default class AdfView extends ItemView {
 
 		let md = await this.app.vault.adapter.read(this.filePath);
 		const adf = this.mdToADF.parse(md);
-		ReactDOM.render(
+		const renderADF = this.convertMediaFilesToLocalPath(adf);
+
+		const locale = "en";
+		const messages = {
+			// Your localized messages
+		};
+
+		const intlProvider = React.createElement(
+			IntlProvider,
+			{
+				locale: locale,
+				messages: messages,
+			},
 			// @ts-ignore
-			React.createElement(ReactRenderer, { document: adf }),
-			container
+			React.createElement(ReactRenderer, { document: renderADF })
 		);
+
+		ReactDOM.render(intlProvider, container);
+	}
+
+	convertMediaFilesToLocalPath(adf: JSONDocNode): JSONDocNode {
+		const basePath = this.getBasePath();
+		return traverse(adf, {
+			media: (node, parent) => {
+				if (node?.attrs?.type === "file") {
+					console.log({ node });
+					const currentUrl = node?.attrs?.url as string;
+					const test = this.app.vault.adapter as FileSystemAdapter;
+					const vaultPath =
+						this.app.metadataCache.getFirstLinkpathDest(
+							currentUrl.replace("file://", ""),
+							this.filePath
+						);
+					if (!vaultPath) {
+						return false;
+					}
+					const path = test.getResourcePath(vaultPath.path);
+					console.log({ path });
+					node.attrs.type = "external";
+					node.attrs.url = path; // currentUrl.replace("file://", `file://${basePath}`);
+					return node;
+				}
+			},
+		}) as JSONDocNode;
+	}
+
+	getBasePath() {
+		let adapter = app.vault.adapter;
+		if (adapter instanceof FileSystemAdapter) {
+			return adapter.getBasePath();
+		}
+		throw new Error("No Path???");
 	}
 
 	async onClose() {

--- a/src/MarkdownTransformer/media.ts
+++ b/src/MarkdownTransformer/media.ts
@@ -79,7 +79,7 @@ function createRule() {
 					: undefined;
 
 			return [
-				["url", `localfile:${filename}`],
+				["url", `file://${filename}`],
 				["type", "file"],
 				...(width ? [["width", `${width}`]] : []),
 				...(height ? [["height", `${height}`]] : []),

--- a/src/adaptors/obsidian.ts
+++ b/src/adaptors/obsidian.ts
@@ -1,4 +1,4 @@
-import { Vault, MetadataCache } from "obsidian";
+import { Vault, MetadataCache, App, TFile } from "obsidian";
 import { MyPluginSettings } from "src/Settings";
 import { BinaryFile, FilesToUpload, LoaderAdaptor } from "./types";
 import { lookup } from "mime-types";
@@ -7,15 +7,18 @@ export default class ObsidianAdaptor implements LoaderAdaptor {
 	vault: Vault;
 	metadataCache: MetadataCache;
 	settings: MyPluginSettings;
+	app: App;
 
 	constructor(
 		vault: Vault,
 		metadataCache: MetadataCache,
-		settings: MyPluginSettings
+		settings: MyPluginSettings,
+		app: App
 	) {
 		this.vault = vault;
 		this.metadataCache = metadataCache;
 		this.settings = settings;
+		this.app = app;
 	}
 
 	async getMarkdownFilesToUpload(): Promise<FilesToUpload> {
@@ -52,9 +55,9 @@ export default class ObsidianAdaptor implements LoaderAdaptor {
 
 			const pageTitle =
 				frontMatter &&
-				frontMatter["title"] &&
-				typeof frontMatter["title"] === "string"
-					? frontMatter["title"]
+				frontMatter["connie-title"] &&
+				typeof frontMatter["connie-title"] === "string"
+					? frontMatter["connie-title"]
 					: file.basename;
 
 			const parsedFrontMatter: Record<string, any> = {};
@@ -102,5 +105,17 @@ export default class ObsidianAdaptor implements LoaderAdaptor {
 		}
 
 		return false;
+	}
+
+	async updateMarkdownPageId(
+		absoluteFilePath: string,
+		pageId: string
+	): Promise<void> {
+		let file = this.app.vault.getAbstractFileByPath(absoluteFilePath);
+		if (file instanceof TFile) {
+			this.app.fileManager.processFrontMatter(file, (fm) => {
+				fm["connie-page-id"] = pageId;
+			});
+		}
 	}
 }

--- a/src/adaptors/types.ts
+++ b/src/adaptors/types.ts
@@ -20,6 +20,7 @@ export interface BinaryFile {
 }
 
 export interface LoaderAdaptor {
+	updateMarkdownPageId(absoluteFilePath: string, id: string): Promise<void>;
 	getMarkdownFilesToUpload(): Promise<FilesToUpload>;
 	readBinary(
 		path: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ export default class MyPlugin extends Plugin {
 		});
 
 		this.publisher = new Publisher(
-			new ObsidianAdaptor(vault, metadataCache, this.settings),
+			new ObsidianAdaptor(vault, metadataCache, this.settings, this.app),
 			this.settings,
 			confluenceClient,
 			mermaidRenderer


### PR DESCRIPTION
Read and add the PageId to Markdown files when published to Confluence to enable speeding up of publishes and also moving the page outside the page tree. When file is moved outside of file tree need to set `connie-dont-change-parent-page: true` to prevent plugin from moving the file back into our file tree.

This will also mean that file renames will now rename the page in Confluence. You can also use the `connie-title` YAML to specify the title of the page to be different to the file name and it will rename the previous published file.

This also includes an improvement to ADF Preview. 
Loads the files via the `app://local` schema which enables them to be loaded as "external" files in the ADF Renderer component.
