### PR TITLE
docs: amended the broken readme image paths for obsidian package

### DIFF
--- a/packages/obsidian/README.md
+++ b/packages/obsidian/README.md
@@ -32,7 +32,7 @@ Copyright (c) 2022 Atlassian US, Inc.
 - `Atlassian API Token`: Your Atlassian API token. You can generate one from your [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 - `Folder To Publish`: The name of the folder in Obsidian containing the notes you want to publish (default: "Confluence Pages")
 
-![Settings](./docs/screenshots/settings.png)
+![Settings](../../docs/screenshots/settings.png)
 
 ## Usage
 
@@ -40,14 +40,14 @@ Copyright (c) 2022 Atlassian US, Inc.
 
 Click the cloud icon in the ribbon to publish the notes from the configured folder to Confluence.
 
-![Ribbon icon](./docs/screenshots/ribbon.png)
+![Ribbon icon](../../docs/screenshots/ribbon.png)
 
 
 ### Commands
 
 Use the command palette (`Ctrl/Cmd + P`) to execute the "Publish All to Confluence" command, which publishes all the notes from the configured folder to Confluence.
 
-![Commands](./docs/screenshots/commands.png)
+![Commands](../../docs/screenshots/commands.png)
 
 ### connie-publish Frontmatter
 


### PR DESCRIPTION
Image paths weren't updated when the packages were moved around.

_Also making this PR to test the waters._