### PR TITLE
Fix character after wikilinks is deleted

### DIFF
--- a/packages/lib/src/MarkdownTransformer/wikilinks.ts
+++ b/packages/lib/src/MarkdownTransformer/wikilinks.ts
@@ -63,7 +63,7 @@ export function wikilinks(state: StateInline): boolean {
 	state.md.inline.tokenize(state);
 	token = state.push("link_close", "a", -1);
 
-	state.pos = wikiLinkEnd + 3;
+	state.pos = wikiLinkEnd + 2;
 	state.posMax = max;
 	return true;
 }


### PR DESCRIPTION
## Input
[[hoge]]fuga

## Current
[hoge]()uga

## This PR
[hoge]()fuga
 
Related
https://github.com/markdown-confluence/markdown-confluence/issues/363