### PR TITLE
Update regular expression in callout.ts

### DIFF
--- a/packages/lib/src/MarkdownTransformer/callout.ts
+++ b/packages/lib/src/MarkdownTransformer/callout.ts
@@ -3,7 +3,7 @@ import type StateCore from "markdown-it/lib/rules_core/state_core";
 import Token from "markdown-it/lib/token";
 
 const panelRegex =
-	/\[!(?<calloutType>.*)](?<collapseType>[+-])*[ \t]*(?<title>.*)*/;
+	/\[!(?<calloutType>.*?)\](?<collapseType>[+-])?[ \t]*(?<title>.*)/;
 
 //panelType Options: "info", "note", "warning", "success", "error", "custom"
 const panelTypeToAttributesMap: Record<string, [string, string][]> = {


### PR DESCRIPTION
Refine the regular expression used for parsing panel markdown syntax in callout.ts. The updated regex improves the matching of callout types and handles optional collapse types more accurately. This change should enhance the accuracy of parsing and transforming markdown to Confluence-specific syntax.

Fixes #441 