### PR TITLE
Remove first heading from page when using as page title

### DIFF
--- a/packages/lib/src/ConniePageConfig.ts
+++ b/packages/lib/src/ConniePageConfig.ts
@@ -112,13 +112,20 @@ export const conniePerPageConfig: ConfluencePerPageConfig = {
 				settings.firstHeadingPageTitle &&
 				adfContent.content.at(0)?.type === "heading" &&
 				adfContent.content.at(0)?.content?.at(0)?.type === "text" &&
-				typeof adfContent.content.at(0)?.content?.at(0)?.text ===
-					"string"
+				typeof adfContent.content.at(0)?.content?.at(0)?.text === "string"
 			) {
-				return (
-					adfContent.content.at(0)?.content?.at(0)?.text ??
-					markdownFile.pageTitle
-				);
+				// Get the first heading text content
+				const firstHeadingText = adfContent.content.at(0)?.content?.at(0)?.text;
+
+				// if firstHeadingText is truthy
+				if (firstHeadingText) {
+					// Remove the first heading from the content
+					// as it will be used as the page title
+					// and we don't want it in the body because it will be duplicated
+					adfContent.content = adfContent.content.slice(1);
+					// set the first heading text as the page title (return early)
+					return firstHeadingText;
+				}
 			}
 			return markdownFile.pageTitle;
 		},


### PR DESCRIPTION
This commit modifies the processing of the page title in the `conniePerPageConfig` object. If the `firstHeadingPageTitle` setting is enabled and the first element of the page content is a heading, the text of this heading is now used as the page title. Additionally, to prevent duplication, the first heading is removed from the body of the page. This change only applies if the first heading's text content is not an empty string.

I'm not sure if it's appropriate to make this change here, but it seems that other page configs are modifying the adfContent, so I'm trying my luck. Fixes #440.