### PR TITLE
fix: update 'markdown-it-table' & '@typescript-eslint/parser' to fix build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13190,9 +13190,9 @@
          }
       },
       "node_modules/markdown-it-table": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/markdown-it-table/-/markdown-it-table-4.1.0.tgz",
-         "integrity": "sha512-LlAmpiOEbV7hrjZ4GDCSFJBbMscKKZjzaB8bSWIOjKHUIhTYvL5yYPH/y9ZJsvRHSWMNBZKM9Zzy1sFKVoXi2A==",
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/markdown-it-table/-/markdown-it-table-4.1.1.tgz",
+         "integrity": "sha512-dzFHRwCe97sXD071Gw/LSIwgAcO2vNsT0BcPCmnrKhNW/W57Bnknl8EaC+j4hM3bAqus1CiVPcTQAvLkUfHLhw==",
          "engines": {
             "node": ">12.6"
          }
@@ -18832,7 +18832,7 @@
             "gray-matter": "^4.0.3",
             "image-size": "^1.0.2",
             "lodash-es": "^4.17.21",
-            "markdown-it-table": "^4.1.0",
+            "markdown-it-table": "^4.1.1",
             "markdown-table": "^3.0.3",
             "prosemirror-markdown": "^1.11.0",
             "prosemirror-model": "1.19.3",
@@ -22697,7 +22697,7 @@
             "jest": "^29.6.1",
             "lodash-es": "^4.17.21",
             "markdown-it": "^13.0.1",
-            "markdown-it-table": "^4.1.0",
+            "markdown-it-table": "^4.1.1",
             "markdown-table": "^3.0.3",
             "prosemirror-markdown": "^1.11.0",
             "prosemirror-model": "1.19.3",
@@ -29841,9 +29841,9 @@
          }
       },
       "markdown-it-table": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/markdown-it-table/-/markdown-it-table-4.1.0.tgz",
-         "integrity": "sha512-LlAmpiOEbV7hrjZ4GDCSFJBbMscKKZjzaB8bSWIOjKHUIhTYvL5yYPH/y9ZJsvRHSWMNBZKM9Zzy1sFKVoXi2A=="
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/markdown-it-table/-/markdown-it-table-4.1.1.tgz",
+         "integrity": "sha512-dzFHRwCe97sXD071Gw/LSIwgAcO2vNsT0BcPCmnrKhNW/W57Bnknl8EaC+j4hM3bAqus1CiVPcTQAvLkUfHLhw=="
       },
       "markdown-table": {
          "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
          "devDependencies": {
             "@types/node": "^16.11.6",
             "@typescript-eslint/eslint-plugin": "^6.3.0",
-            "@typescript-eslint/parser": "^5.62.0",
+            "@typescript-eslint/parser": "^6.3.0",
             "builtin-modules": "3.3.0",
             "esbuild": "0.18.14",
             "esbuild-node-externals": "^1.8.0",
@@ -30,7 +30,7 @@
             "ts-jest": "^29.1.1",
             "ts-node": "^10.9.1",
             "tslib": "2.5.0",
-            "typescript": "5.1.6"
+            "typescript": "^5.1.6"
          }
       },
       "node_modules/@aashutoshrathi/word-wrap": {
@@ -4956,25 +4956,26 @@
          "license": "ISC"
       },
       "node_modules/@typescript-eslint/parser": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-         "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+         "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
          "dev": true,
          "dependencies": {
-            "@typescript-eslint/scope-manager": "5.62.0",
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/typescript-estree": "5.62.0",
+            "@typescript-eslint/scope-manager": "6.4.0",
+            "@typescript-eslint/types": "6.4.0",
+            "@typescript-eslint/typescript-estree": "6.4.0",
+            "@typescript-eslint/visitor-keys": "6.4.0",
             "debug": "^4.3.4"
          },
          "engines": {
-            "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            "node": "^16.0.0 || >=18.0.0"
          },
          "funding": {
             "type": "opencollective",
             "url": "https://opencollective.com/typescript-eslint"
          },
          "peerDependencies": {
-            "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            "eslint": "^7.0.0 || ^8.0.0"
          },
          "peerDependenciesMeta": {
             "typescript": {
@@ -4983,16 +4984,16 @@
          }
       },
       "node_modules/@typescript-eslint/scope-manager": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-         "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+         "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
          "dev": true,
          "dependencies": {
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/visitor-keys": "5.62.0"
+            "@typescript-eslint/types": "6.4.0",
+            "@typescript-eslint/visitor-keys": "6.4.0"
          },
          "engines": {
-            "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            "node": "^16.0.0 || >=18.0.0"
          },
          "funding": {
             "type": "opencollective",
@@ -5117,12 +5118,12 @@
          "dev": true
       },
       "node_modules/@typescript-eslint/types": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-         "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+         "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
          "dev": true,
          "engines": {
-            "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            "node": "^16.0.0 || >=18.0.0"
          },
          "funding": {
             "type": "opencollective",
@@ -5130,21 +5131,21 @@
          }
       },
       "node_modules/@typescript-eslint/typescript-estree": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-         "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+         "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
          "dev": true,
          "dependencies": {
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/visitor-keys": "5.62.0",
+            "@typescript-eslint/types": "6.4.0",
+            "@typescript-eslint/visitor-keys": "6.4.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
          },
          "engines": {
-            "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            "node": "^16.0.0 || >=18.0.0"
          },
          "funding": {
             "type": "opencollective",
@@ -5322,16 +5323,16 @@
          "dev": true
       },
       "node_modules/@typescript-eslint/visitor-keys": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-         "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+         "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
          "dev": true,
          "dependencies": {
-            "@typescript-eslint/types": "5.62.0",
-            "eslint-visitor-keys": "^3.3.0"
+            "@typescript-eslint/types": "6.4.0",
+            "eslint-visitor-keys": "^3.4.1"
          },
          "engines": {
-            "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            "node": "^16.0.0 || >=18.0.0"
          },
          "funding": {
             "type": "opencollective",
@@ -17366,25 +17367,6 @@
          "version": "2.5.0",
          "license": "0BSD"
       },
-      "node_modules/tsutils": {
-         "version": "3.21.0",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "tslib": "^1.8.1"
-         },
-         "engines": {
-            "node": ">= 6"
-         },
-         "peerDependencies": {
-            "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-         }
-      },
-      "node_modules/tsutils/node_modules/tslib": {
-         "version": "1.14.1",
-         "dev": true,
-         "license": "0BSD"
-      },
       "node_modules/tty-browserify": {
          "version": "0.0.0",
          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -23956,25 +23938,26 @@
          }
       },
       "@typescript-eslint/parser": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-         "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+         "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
          "dev": true,
          "requires": {
-            "@typescript-eslint/scope-manager": "5.62.0",
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/typescript-estree": "5.62.0",
+            "@typescript-eslint/scope-manager": "6.4.0",
+            "@typescript-eslint/types": "6.4.0",
+            "@typescript-eslint/typescript-estree": "6.4.0",
+            "@typescript-eslint/visitor-keys": "6.4.0",
             "debug": "^4.3.4"
          }
       },
       "@typescript-eslint/scope-manager": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-         "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+         "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
          "dev": true,
          "requires": {
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/visitor-keys": "5.62.0"
+            "@typescript-eslint/types": "6.4.0",
+            "@typescript-eslint/visitor-keys": "6.4.0"
          }
       },
       "@typescript-eslint/type-utils": {
@@ -24047,24 +24030,24 @@
          }
       },
       "@typescript-eslint/types": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-         "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+         "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
          "dev": true
       },
       "@typescript-eslint/typescript-estree": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-         "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+         "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
          "dev": true,
          "requires": {
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/visitor-keys": "5.62.0",
+            "@typescript-eslint/types": "6.4.0",
+            "@typescript-eslint/visitor-keys": "6.4.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
          },
          "dependencies": {
             "lru-cache": {
@@ -24176,13 +24159,13 @@
          }
       },
       "@typescript-eslint/visitor-keys": {
-         "version": "5.62.0",
-         "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-         "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+         "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
          "dev": true,
          "requires": {
-            "@typescript-eslint/types": "5.62.0",
-            "eslint-visitor-keys": "^3.3.0"
+            "@typescript-eslint/types": "6.4.0",
+            "eslint-visitor-keys": "^3.4.1"
          }
       },
       "@webassemblyjs/ast": {
@@ -32837,19 +32820,6 @@
       },
       "tslib": {
          "version": "2.5.0"
-      },
-      "tsutils": {
-         "version": "3.21.0",
-         "dev": true,
-         "requires": {
-            "tslib": "^1.8.1"
-         },
-         "dependencies": {
-            "tslib": {
-               "version": "1.14.1",
-               "dev": true
-            }
-         }
       },
       "tty-browserify": {
          "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
    "devDependencies": {
       "@types/node": "^16.11.6",
       "@typescript-eslint/eslint-plugin": "^6.3.0",
-      "@typescript-eslint/parser": "^5.62.0",
+      "@typescript-eslint/parser": "^6.3.0",
       "builtin-modules": "3.3.0",
       "esbuild": "0.18.14",
       "esbuild-node-externals": "^1.8.0",
+      "esbuild-plugin-copy": "^2.1.1",
       "eslint": "^8.46.0",
       "eslint-config-prettier": "^8.9.0",
       "husky": "^8.0.3",
@@ -26,8 +27,7 @@
       "ts-jest": "^29.1.1",
       "ts-node": "^10.9.1",
       "tslib": "2.5.0",
-      "typescript": "5.1.6",
-      "esbuild-plugin-copy": "^2.1.1"
+      "typescript": "^5.1.6"
    },
    "workspaces": [
       "packages/lib",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -53,7 +53,7 @@
         "gray-matter": "^4.0.3",
         "image-size": "^1.0.2",
         "lodash-es": "^4.17.21",
-        "markdown-it-table": "^4.1.0",
+        "markdown-it-table": "^4.1.1",
         "markdown-table": "^3.0.3",
         "prosemirror-markdown": "^1.11.0",
         "prosemirror-model": "1.19.3",


### PR DESCRIPTION
Latest master branch does not build as `markdown-it-table` is missing typings. Declaring the module fixes this.