### PR TITLE
Convert obsidian tasks to unicode checkboxes in Confluence

### DIFF
--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -197,6 +197,24 @@ const markdownTestCases: MarkdownFile[] = [
 			"connie-blog-post-date": "2022-01-01",
 		},
 	},
+	{
+		folderName: "tasks",
+		absoluteFilePath: "/path/to/tasks.md",
+		fileName: "tasks.md",
+		contents: `
+- Regular list item
+- [ ] Unchecked item
+- [x] Checked item
+- [*] Starred item
+- No checkbox [x] in the middle
+
+[x] non list item shouldn't get checkbox
+			`.trim(),
+		pageTitle: "Tasks",
+		frontmatter: {
+			"connie-blog-post-date": "2022-01-01",
+		},
+	},
 ];
 test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 	const settings: ConfluenceSettings = {

--- a/packages/lib/src/__snapshots__/MdToADF.test.ts.snap
+++ b/packages/lib/src/__snapshots__/MdToADF.test.ts.snap
@@ -1344,3 +1344,111 @@ exports[`parses tables.md 1`] = `
   "tags": [],
 }
 `;
+
+exports[`parses tasks.md 1`] = `
+{
+  "absoluteFilePath": "/path/to/tasks.md",
+  "blogPostDate": "2022-01-01",
+  "contentType": "blogpost",
+  "contents": {
+    "content": [
+      {
+        "content": [
+          {
+            "content": [
+              {
+                "content": [
+                  {
+                    "text": "Regular list item",
+                    "type": "text",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "listItem",
+          },
+          {
+            "content": [
+              {
+                "content": [
+                  {
+                    "text": "🔲 Unchecked item",
+                    "type": "text",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "listItem",
+          },
+          {
+            "content": [
+              {
+                "content": [
+                  {
+                    "text": "✅ Checked item",
+                    "type": "text",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "listItem",
+          },
+          {
+            "content": [
+              {
+                "content": [
+                  {
+                    "text": "⭐️ Starred item",
+                    "type": "text",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "listItem",
+          },
+          {
+            "content": [
+              {
+                "content": [
+                  {
+                    "text": "No checkbox [x] in the middle",
+                    "type": "text",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "listItem",
+          },
+        ],
+        "type": "bulletList",
+      },
+      {
+        "content": [
+          {
+            "text": "[x] non list item shouldn't get checkbox",
+            "type": "text",
+          },
+        ],
+        "type": "paragraph",
+      },
+    ],
+    "type": "doc",
+    "version": 1,
+  },
+  "dontChangeParentPageId": false,
+  "fileName": "tasks.md",
+  "folderName": "tasks",
+  "frontmatter": {
+    "connie-blog-post-date": "2022-01-01",
+  },
+  "pageId": undefined,
+  "pageTitle": "Tasks",
+  "publish": false,
+  "tags": [],
+}
+`;


### PR DESCRIPTION
This change converts Obsidian tasks to unicode checkboxes when publishing to Confluence.

Given the following Obsidian markdown:

Edit mode:
![image](https://github.com/markdown-confluence/markdown-confluence/assets/1480667/07f55b81-908a-4d24-bd9c-2c379d9ef82a)

Source mode:
![image](https://github.com/markdown-confluence/markdown-confluence/assets/1480667/2400ac6b-c39b-4f7f-9b21-19be70fc0c6b)

The following will be published to Confluence:

## Before
![image](https://github.com/markdown-confluence/markdown-confluence/assets/1480667/a7cca57a-4be8-4141-8022-2cfc30d8dfeb)


## After
![image](https://github.com/markdown-confluence/markdown-confluence/assets/1480667/b5c04187-3dbf-41bc-aa68-c62989d210e8)
