### PR TITLE
added support for multiple auth methods

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,7 +50,7 @@ docker run -it --rm -v "$(pwd):/content" -e ATLASSIAN_API_TOKEN ghcr.io/markdown
 
 ### GitHub Actions
 
-**Example setup**
+**Example setup, using a personal access token**
 
 `.github/workflows/publish.yml`:
 
@@ -62,10 +62,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Publish Markdown to Confluence
-        uses: markdown-confluence/publish@v1
+        uses: markdown-confluence/publish@v5
         with:
+		  confluenceAuthMethod: token
+		  confluenceBaseUrl: https://your_confluence_server_url
           atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Publish Markdown to Confluence
-        uses: markdown-confluence/publish@v5
+        uses: markdown-confluence/publish-action@v5
         with:
 		  confluenceAuthMethod: token
 		  confluenceBaseUrl: https://your_confluence_server_url

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -66,8 +66,8 @@ jobs:
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish-action@v5
         with:
-		  confluenceAuthMethod: token
-		  confluenceBaseUrl: https://your_confluence_server_url
+          confluenceAuthMethod: token
+          confluenceBaseUrl: https://your_confluence_server_url
           atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
 ```
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ async function main() {
 		case "basic":
 			authentication = {
 				basic: {
-					email: settings.atlassianUsername,
+					email: settings.atlassianUserName,
 					apiToken: settings.atlassianApiToken,
 				},
 			};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,8 +35,10 @@ async function main() {
 			break;
 		case "basic":
 			authentication = {
-				email: settings.atlassianUsername,
-				apiToken: settings.atlassianApiToken,
+				basic: {
+					email: settings.atlassianUsername,
+					apiToken: settings.atlassianApiToken,
+				},
 			};
 			break;
 		default:

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -1,5 +1,5 @@
 export type ConfluenceSettings = {
-	confluenceAuthMethod: "basic" | "oauth2" | "token";
+	confluenceAuthMethod: string;
 	confluenceBaseUrl: string;
 	confluenceParentId: string;
 	atlassianUserName: string;

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -1,4 +1,5 @@
 export type ConfluenceSettings = {
+	confluenceAuthMethod: "basic" | "oauth2" | "token";
 	confluenceBaseUrl: string;
 	confluenceParentId: string;
 	atlassianUserName: string;
@@ -9,6 +10,7 @@ export type ConfluenceSettings = {
 };
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
+	confluenceAuthMethod: "basic",
 	confluenceBaseUrl: "",
 	confluenceParentId: "",
 	atlassianUserName: "",

--- a/packages/lib/src/SettingsLoader/EnvironmentVariableSettingsLoader.ts
+++ b/packages/lib/src/SettingsLoader/EnvironmentVariableSettingsLoader.ts
@@ -18,6 +18,7 @@ export class EnvironmentVariableSettingsLoader extends SettingsLoader {
 			...this.getValue("atlassianApiToken", "ATLASSIAN_API_TOKEN"),
 			...this.getValue("folderToPublish", "FOLDER_TO_PUBLISH"),
 			...this.getValue("contentRoot", "CONFLUENCE_CONTENT_ROOT"),
+			...this.getValue("confluenceAuthMethod", "CONFLUENCE_AUTH_METHOD"),
 			firstHeadingPageTitle:
 				(process.env["CONFLUENCE_FIRST_HEADING_PAGE_TITLE"] ??
 					"false") === "true",

--- a/packages/lib/src/SettingsLoader/SettingsLoader.ts
+++ b/packages/lib/src/SettingsLoader/SettingsLoader.ts
@@ -20,7 +20,7 @@ export abstract class SettingsLoader {
 			throw new Error("Confluence parent ID is required");
 		}
 
-		if (!settings.atlassianUserName) {
+		if (settings.confluenceAuthMethod == "basic" && !settings.atlassianUserName) {
 			throw new Error("Atlassian user name is required");
 		}
 


### PR DESCRIPTION
This PR adds support for the different auth methods, rather than just `basic`

- `basic`
- `oauth2`
- `token`

In my case, we need to use a personal access token, rather than email/password. 