### PR TITLE
update electron/remote

### DIFF
--- a/packages/mermaid-electron-renderer/package.json
+++ b/packages/mermaid-electron-renderer/package.json
@@ -19,7 +19,7 @@
     "license": "Apache 2.0",
     "devDependencies": {},
     "dependencies": {
-        "@electron/remote": "^2.0.9",
+        "@electron/remote": "^2.1.2",
         "mermaid": "^10.2.3",
         "@markdown-confluence/lib": "5.5.2"
     },


### PR DESCRIPTION
fixes issue with `W_e.isDesktopCapturerEnabled()` call in Obsidian