### PR TITLE
Add support for soft breaks

### DIFF
--- a/packages/lib/src/ADFToMarkdown.ts
+++ b/packages/lib/src/ADFToMarkdown.ts
@@ -91,6 +91,9 @@ function renderADFContent(
 		case "text": {
 			return renderTextMarks(element);
 		}
+		case "softBreak": {
+			return " ";
+		}
 		case "hardBreak": {
 			return "\n";
 		}

--- a/packages/lib/src/MarkdownTransformer/index.ts
+++ b/packages/lib/src/MarkdownTransformer/index.ts
@@ -67,7 +67,7 @@ const mdToPmMapping = {
 		block: "heading",
 		attrs: (tok: any) => ({ level: +tok.tag.slice(1) }),
 	},
-	softbreak: { node: "hardBreak" },
+	softbreak: { node: "softBreak" },
 	hardbreak: { node: "hardBreak" },
 	code_block: { block: "codeBlock" },
 	list_item: { block: "listItem" },


### PR DESCRIPTION
This PR adds support for soft breaks to prevent rendering newlines that only exist because of line length best practices in Markdown files.