### PR TITLE
Jira links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19213,14 +19213,14 @@
       },
       "packages/cli": {
          "name": "@markdown-confluence/cli",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "bin": {
             "cli": "dist/index.js"
          },
          "devDependencies": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.2",
             "boxen": "7.1.1",
             "chalk": "5.3.0",
             "confluence.js": "^1.6.3"
@@ -19228,7 +19228,7 @@
       },
       "packages/lib": {
          "name": "@markdown-confluence/lib",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
             "@atlaskit/adf-schema": "^25.6.4",
@@ -19967,32 +19967,32 @@
       },
       "packages/mermaid-electron-renderer": {
          "name": "@markdown-confluence/mermaid-electron-renderer",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
             "@electron/remote": "^2.0.9",
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "^10.2.3"
          },
          "devDependencies": {}
       },
       "packages/mermaid-puppeteer-renderer": {
          "name": "@markdown-confluence/mermaid-puppeteer-renderer",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "10.4.0",
             "puppeteer": "21.3.4"
          }
       },
       "packages/obsidian": {
          "name": "obsidian-confluence",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-electron-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-electron-renderer": "5.5.2",
             "confluence.js": "^1.6.3",
             "mime-types": "^2.1.35",
             "react": "^16.14.0",
@@ -23163,8 +23163,8 @@
       "@markdown-confluence/cli": {
          "version": "file:packages/cli",
          "requires": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.2",
             "boxen": "7.1.1",
             "chalk": "5.3.0",
             "confluence.js": "^1.6.3"
@@ -23819,14 +23819,14 @@
          "version": "file:packages/mermaid-electron-renderer",
          "requires": {
             "@electron/remote": "^2.0.9",
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "^10.2.3"
          }
       },
       "@markdown-confluence/mermaid-puppeteer-renderer": {
          "version": "file:packages/mermaid-puppeteer-renderer",
          "requires": {
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "10.4.0",
             "puppeteer": "21.3.4"
          }
@@ -31436,8 +31436,8 @@
       "obsidian-confluence": {
          "version": "file:packages/obsidian",
          "requires": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-electron-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-electron-renderer": "5.5.2",
             "@types/mime-types": "^2.1.1",
             "@types/react-dom": "^18.0.11",
             "confluence.js": "^1.6.3",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import {
 	FileSystemAdaptor,
 	Publisher,
 	MermaidRendererPlugin,
+	JiraLinkPlugin,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { ConfluenceClient } from "confluence.js";
@@ -41,6 +42,7 @@ async function main() {
 
 	const publisher = new Publisher(adaptor, settingLoader, confluenceClient, [
 		new MermaidRendererPlugin(new PuppeteerMermaidRenderer()),
+		new JiraLinkPlugin(settings.jiraUrl),
 	]);
 
 	const publishFilter = "";

--- a/packages/lib/src/ADFProcessingPlugins/JiraLinkPlugin.ts
+++ b/packages/lib/src/ADFProcessingPlugins/JiraLinkPlugin.ts
@@ -1,0 +1,48 @@
+import { traverse } from "@atlaskit/adf-utils/traverse";
+import { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import { ADFProcessingPlugin, PublisherFunctions } from "./types";
+import { ADFEntity } from "@atlaskit/adf-utils/types";
+
+export interface JiraLink {
+	issueId: string;
+}
+
+export class JiraLinkPlugin implements ADFProcessingPlugin<string, string> {
+	constructor(private jiraUrl: string) {}
+
+	extract(_adf: JSONDocNode): string {
+		return "no-op";
+	}
+
+	async transform(
+		items: string,
+		_supportFunctions: PublisherFunctions,
+	): Promise<string> {
+		return items;
+	}
+
+	load(adf: JSONDocNode, _transformed: string): JSONDocNode {
+		let afterAdf = adf as ADFEntity;
+
+		afterAdf =
+			traverse(afterAdf, {
+				text: (node, _parent) => {
+					if (!node.text?.startsWith("JIRA:")) return;
+					if ((node.marks || [])[0]?.["type"] !== "code") return;
+					const text = node.text;
+					const issueId = text.substring(
+						text.startsWith("JIRA:-") ? 6 : 5,
+					);
+					node.type = "inlineCard";
+					node.attrs = {
+						url: `${this.jiraUrl}/browse/${issueId}`,
+					};
+					delete node.marks;
+					delete node.text;
+					return node;
+				},
+			}) || afterAdf;
+
+		return afterAdf as JSONDocNode;
+	}
+}

--- a/packages/lib/src/ADFProcessingPlugins/index.ts
+++ b/packages/lib/src/ADFProcessingPlugins/index.ts
@@ -2,5 +2,6 @@ import { ImageUploaderPlugin } from "./ImageUploaderPlugin";
 
 export * from "./types";
 export * from "./MermaidRendererPlugin";
+export * from "./JiraLinkPlugin";
 
 export const AlwaysADFProcessingPlugins = [ImageUploaderPlugin];

--- a/packages/lib/src/Publisher.test.ts
+++ b/packages/lib/src/Publisher.test.ts
@@ -22,6 +22,7 @@ import {
 	MermaidRenderer,
 	MermaidRendererPlugin,
 } from "./ADFProcessingPlugins/MermaidRendererPlugin";
+import { JiraLinkPlugin } from "./ADFProcessingPlugins";
 
 const settingsLoader = new AutoSettingsLoader();
 const settings = settingsLoader.load();
@@ -212,6 +213,17 @@ const markdownTestCases: MarkdownFile[] = [
 			//			"connie-dont-change-parent-page": "invalid",
 		},
 	},
+	{
+		folderName: "jira",
+		absoluteFilePath: "/path/to/jira/file.md",
+		fileName: "file.md",
+		contents: "This here `JIRA:-XYZ-123` is a jira link",
+		pageTitle: "Jira Link Test",
+		frontmatter: {
+			title: "Jira Link Test",
+			description: "A Markdown file with a jira link.",
+		},
+	},
 ];
 
 class TestMermaidRenderer implements MermaidRenderer {
@@ -294,7 +306,10 @@ test("Upload to Confluence", async () => {
 		filesystemAdaptor,
 		publisherSettingsLoader,
 		confluenceClient,
-		[new MermaidRendererPlugin(mermaidRenderer)],
+		[
+			new MermaidRendererPlugin(mermaidRenderer),
+			new JiraLinkPlugin("https://jira.example.com"),
+		],
 	);
 
 	const result = await publisher.publish();

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -6,6 +6,7 @@ export type ConfluenceSettings = {
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
+	jiraUrl: string;
 };
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
@@ -16,4 +17,5 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	folderToPublish: "Confluence Pages",
 	contentRoot: process.cwd(),
 	firstHeadingPageTitle: false,
+	jiraUrl: "",
 };

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -120,5 +120,18 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 					});
 				/* eslint-enable @typescript-eslint/naming-convention */
 			});
+
+		new Setting(containerEl)
+			.setName("Jira URL")
+			.setDesc("Base URL of the Jira instance, when linking Jira issues")
+			.addText((text) =>
+				text
+					.setPlaceholder("https://team-23232345645.atlassian.net/")
+					.setValue(this.plugin.settings.jiraUrl)
+					.onChange(async (value) => {
+						this.plugin.settings.jiraUrl = value;
+						await this.plugin.saveSettings();
+					}),
+			);
 	}
 }

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -6,6 +6,7 @@ import {
 	StaticSettingsLoader,
 	renderADFDoc,
 	MermaidRendererPlugin,
+	JiraLinkPlugin,
 	UploadAdfFileResult,
 } from "@markdown-confluence/lib";
 import { ElectronMermaidRenderer } from "@markdown-confluence/mermaid-electron-renderer";
@@ -97,7 +98,10 @@ export default class ConfluencePlugin extends Plugin {
 			this.adaptor,
 			settingsLoader,
 			confluenceClient,
-			[new MermaidRendererPlugin(mermaidRenderer)],
+			[
+				new MermaidRendererPlugin(mermaidRenderer),
+				new JiraLinkPlugin(this.settings.jiraUrl),
+			],
 		);
 	}
 


### PR DESCRIPTION
Adds a adf plugin to the publisher that adds support for jira links for the [Obsidian Jira Plugin](https://github.com/marc0l92/obsidian-jira-issue)

Currently, only inline jira code blocks are supported
```
Look at this issue `JIRA:XYZ-123` for details
```

I plan to expand the support later