### PR TITLE
Added confluenceUrlSuffix 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19213,14 +19213,14 @@
       },
       "packages/cli": {
          "name": "@markdown-confluence/cli",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "bin": {
             "cli": "dist/index.js"
          },
          "devDependencies": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.2",
             "boxen": "7.1.1",
             "chalk": "5.3.0",
             "confluence.js": "^1.6.3"
@@ -19228,7 +19228,7 @@
       },
       "packages/lib": {
          "name": "@markdown-confluence/lib",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
             "@atlaskit/adf-schema": "^25.6.4",
@@ -19967,32 +19967,32 @@
       },
       "packages/mermaid-electron-renderer": {
          "name": "@markdown-confluence/mermaid-electron-renderer",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
             "@electron/remote": "^2.0.9",
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "^10.2.3"
          },
          "devDependencies": {}
       },
       "packages/mermaid-puppeteer-renderer": {
          "name": "@markdown-confluence/mermaid-puppeteer-renderer",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "10.4.0",
             "puppeteer": "21.3.4"
          }
       },
       "packages/obsidian": {
          "name": "obsidian-confluence",
-         "version": "5.5.1",
+         "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-electron-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-electron-renderer": "5.5.2",
             "confluence.js": "^1.6.3",
             "mime-types": "^2.1.35",
             "react": "^16.14.0",
@@ -23163,8 +23163,8 @@
       "@markdown-confluence/cli": {
          "version": "file:packages/cli",
          "requires": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-puppeteer-renderer": "5.5.2",
             "boxen": "7.1.1",
             "chalk": "5.3.0",
             "confluence.js": "^1.6.3"
@@ -23819,14 +23819,14 @@
          "version": "file:packages/mermaid-electron-renderer",
          "requires": {
             "@electron/remote": "^2.0.9",
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "^10.2.3"
          }
       },
       "@markdown-confluence/mermaid-puppeteer-renderer": {
          "version": "file:packages/mermaid-puppeteer-renderer",
          "requires": {
-            "@markdown-confluence/lib": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
             "mermaid": "10.4.0",
             "puppeteer": "21.3.4"
          }
@@ -31436,8 +31436,8 @@
       "obsidian-confluence": {
          "version": "file:packages/obsidian",
          "requires": {
-            "@markdown-confluence/lib": "5.5.1",
-            "@markdown-confluence/mermaid-electron-renderer": "5.5.1",
+            "@markdown-confluence/lib": "5.5.2",
+            "@markdown-confluence/mermaid-electron-renderer": "5.5.2",
             "@types/mime-types": "^2.1.1",
             "@types/react-dom": "^18.0.11",
             "confluence.js": "^1.6.3",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,10 @@ async function main() {
 			},
 		},
 	});
+	// Forcefully overriding urlSuffix used by the client
+	// This is a hack and should be fixed in the confluence.js library
+	// This is needed because the confluence.js library doesn't allow us to set the urlSuffix in the constructor
+	confluenceClient["urlSuffix"] = settings.confluenceUrlSuffix;
 
 	const publisher = new Publisher(adaptor, settingLoader, confluenceClient, [
 		new MermaidRendererPlugin(new PuppeteerMermaidRenderer()),

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -6,6 +6,7 @@ export type ConfluenceSettings = {
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
+	confluenceUrlSuffix: string;
 };
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
@@ -16,4 +17,5 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	folderToPublish: "Confluence Pages",
 	contentRoot: process.cwd(),
 	firstHeadingPageTitle: false,
+	confluenceUrlSuffix: "/wiki/rest/",
 };


### PR DESCRIPTION
Added confluenceUrlSuffix to fix issues with some Confluence Data Center installations where the rest api is directly at /rest/