### PR TITLE
feat(cli): add 'to-adf' subcommand for standalone Markdown to ADF conversion

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,61 +9,149 @@ import {
 	FileSystemAdaptor,
 	Publisher,
 	MermaidRendererPlugin,
+	parseMarkdownToADF,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { ConfluenceClient } from "confluence.js";
+import * as fs from "fs";
+import * as path from "path";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
-// Define the main function
-async function main() {
-	const settingLoader = new AutoSettingsLoader();
-	const settings = settingLoader.load();
+const subcommand = process.argv[2];
 
-	const adaptor = new FileSystemAdaptor(settings); // Make sure this is identical as possible between Obsidian and CLI
-	const confluenceClient = new ConfluenceClient({
-		host: settings.confluenceBaseUrl,
-		authentication: {
-			basic: {
-				email: settings.atlassianUserName,
-				apiToken: settings.atlassianApiToken,
+if (subcommand === "to-adf") {
+	// Handle the to-adf subcommand
+	yargs(hideBin(process.argv))
+		.command(
+			"to-adf [input]",
+			"Convert a Markdown file (or stdin) to Atlassian Document Format (ADF) JSON",
+			(yargs) => {
+				return yargs
+					.positional("input", {
+						describe:
+							"Path to the Markdown file to convert. Reads from stdin if omitted.",
+						type: "string",
+					})
+					.option("output", {
+						alias: "o",
+						describe:
+							"Write ADF JSON to this file instead of stdout",
+						type: "string",
+					})
+					.option("base-url", {
+						alias: "b",
+						describe:
+							"Confluence base URL (used for resolving Confluence links)",
+						type: "string",
+						default: "https://confluence.atlassian.com",
+					});
 			},
-		},
-		middlewares: {
-			onError(e) {
-				if ("response" in e && "data" in e.response) {
-					e.message =
-						typeof e.response.data === "string"
-							? e.response.data
-							: JSON.stringify(e.response.data);
+			async (args) => {
+				let markdown: string;
+
+				if (args.input) {
+					const filePath = path.resolve(args.input as string);
+					if (!fs.existsSync(filePath)) {
+						console.error(
+							chalk.red(`Error: File not found: ${filePath}`),
+						);
+						process.exit(1);
+					}
+					markdown = fs.readFileSync(filePath, "utf-8");
+				} else {
+					// Read from stdin
+					markdown = fs.readFileSync("/dev/stdin", "utf-8");
+				}
+
+				const baseUrl = args["base-url"] as string;
+
+				try {
+					const adf = parseMarkdownToADF(markdown, baseUrl);
+					const adfJson = JSON.stringify(adf, null, 2);
+
+					if (args.output) {
+						const outPath = path.resolve(args.output as string);
+						fs.writeFileSync(outPath, adfJson, "utf-8");
+						console.error(
+							chalk.green(`ADF written to: ${outPath}`),
+						);
+					} else {
+						process.stdout.write(adfJson + "\n");
+					}
+				} catch (error: unknown) {
+					const message =
+						error instanceof Error ? error.message : String(error);
+					console.error(
+						chalk.red(
+							boxen(`Conversion error: ${message}`, {
+								padding: 1,
+							}),
+						),
+					);
+					process.exit(1);
 				}
 			},
-		},
-	});
-
-	const publisher = new Publisher(adaptor, settingLoader, confluenceClient, [
-		new MermaidRendererPlugin(new PuppeteerMermaidRenderer()),
-	]);
-
-	const publishFilter = "";
-	const results = await publisher.publish(publishFilter);
-	results.forEach((file) => {
-		if (file.successfulUploadResult) {
-			console.log(
-				chalk.green(
-					`SUCCESS: ${file.node.file.absoluteFilePath} Content: ${file.successfulUploadResult.contentResult}, Images: ${file.successfulUploadResult.imageResult}, Labels: ${file.successfulUploadResult.labelResult}, Page URL: ${file.node.file.pageUrl}`,
-				),
-			);
-			return;
-		}
-		console.error(
-			chalk.red(
-				`FAILED:  ${file.node.file.absoluteFilePath} publish failed. Error is: ${file.reason}`,
-			),
-		);
-	});
+		)
+		.help()
+		.parse();
+} else {
+	publishToConfluence();
 }
 
-// Call the main function
-main().catch((error) => {
-	console.error(chalk.red(boxen(`Error: ${error.message}`, { padding: 1 })));
-	process.exit(1);
-});
+async function publishToConfluence() {
+	try {
+		const settingLoader = new AutoSettingsLoader();
+		const settings = settingLoader.load();
+
+		const adaptor = new FileSystemAdaptor(settings);
+		const confluenceClient = new ConfluenceClient({
+			host: settings.confluenceBaseUrl,
+			authentication: {
+				basic: {
+					email: settings.atlassianUserName,
+					apiToken: settings.atlassianApiToken,
+				},
+			},
+			middlewares: {
+				onError(e) {
+					if ("response" in e && "data" in e.response) {
+						e.message =
+							typeof e.response.data === "string"
+								? e.response.data
+								: JSON.stringify(e.response.data);
+					}
+				},
+			},
+		});
+
+		const publisher = new Publisher(
+			adaptor,
+			settingLoader,
+			confluenceClient,
+			[new MermaidRendererPlugin(new PuppeteerMermaidRenderer())],
+		);
+
+		const publishFilter = "";
+		const results = await publisher.publish(publishFilter);
+		results.forEach((file) => {
+			if (file.successfulUploadResult) {
+				console.log(
+					chalk.green(
+						`SUCCESS: ${file.node.file.absoluteFilePath} Content: ${file.successfulUploadResult.contentResult}, Images: ${file.successfulUploadResult.imageResult}, Labels: ${file.successfulUploadResult.labelResult}, Page URL: ${file.node.file.pageUrl}`,
+					),
+				);
+				return;
+			}
+			console.error(
+				chalk.red(
+					`FAILED:  ${file.node.file.absoluteFilePath} publish failed. Error is: ${file.reason}`,
+				),
+			);
+		});
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(chalk.red(boxen(`Error: ${message}`, { padding: 1 })));
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
Adds a new 'to-adf' subcommand to the CLI that converts a Markdown file to Atlassian Document Format (ADF) JSON without requiring a Confluence connection.

Usage:
  npx @markdown-confluence/cli to-adf <file.md>         # stdout
  npx @markdown-confluence/cli to-adf <file.md> -o out.json  # file
  cat file.md | npx @markdown-confluence/cli to-adf     # stdin

Options:
  -o, --output    Write ADF JSON to this file instead of stdout
  -b, --base-url  Confluence base URL for resolving internal links

The existing publish-to-Confluence behavior is unchanged.