### PR TITLE
fix: resolve wikilinks with paths

### DIFF
--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@jest/globals";
+import { TextDefinition } from "@atlaskit/adf-schema";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { prepareAdfToUpload } from "./AdfProcessing";
 import { ConfluenceAdfFile, ConfluenceNode } from "./Publisher";
@@ -24,8 +25,9 @@ test("resolves wikilinks that include a path under the publish root", () => {
 
 	prepareAdfToUpload(pages, testSettings);
 
-	const link = pages[0]!.file.contents.content[0]!.content![0] as any;
-	expect(link.marks[0].attrs.href).toBe(
+	const link = pages[0]!.file.contents.content[0]!
+		.content![0] as TextDefinition;
+	expect(link.marks?.[0]?.attrs?.href).toBe(
 		"https://example.atlassian.net/wiki/spaces/SPACE/pages/123456",
 	);
 });

--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@jest/globals";
+import { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import { prepareAdfToUpload } from "./AdfProcessing";
+import { ConfluenceAdfFile, ConfluenceNode } from "./Publisher";
+import { ConfluenceSettings } from "./Settings";
+
+test("resolves wikilinks that include a path under the publish root", () => {
+	const pages = [
+		createNode({
+			fileName: "source.md",
+			absoluteFilePath: "Confluence Pages/source.md",
+			contents: docWithLink(
+				"Read this",
+				"wikilinks:confluence/note/test",
+			),
+		}),
+		createNode({
+			fileName: "test.md",
+			absoluteFilePath: "Confluence Pages/confluence/note/test.md",
+			pageId: "123456",
+			spaceKey: "SPACE",
+		}),
+	];
+
+	prepareAdfToUpload(pages, testSettings);
+
+	const link = pages[0]!.file.contents.content[0]!.content![0] as any;
+	expect(link.marks[0].attrs.href).toBe(
+		"https://example.atlassian.net/wiki/spaces/SPACE/pages/123456",
+	);
+});
+
+function docWithLink(text: string, href: string): JSONDocNode {
+	return {
+		version: 1,
+		type: "doc",
+		content: [
+			{
+				type: "paragraph",
+				content: [
+					{
+						type: "text",
+						text,
+						marks: [
+							{
+								type: "link",
+								attrs: { href },
+							},
+						],
+					},
+				],
+			},
+		],
+	} as JSONDocNode;
+}
+
+function createNode(file: Partial<ConfluenceAdfFile>): ConfluenceNode {
+	const confluenceFile: ConfluenceAdfFile = {
+		folderName: "",
+		absoluteFilePath: "Confluence Pages/default.md",
+		fileName: "default.md",
+		contents: docWithLink("", ""),
+		pageTitle: "Default",
+		frontmatter: {},
+		tags: [],
+		dontChangeParentPageId: false,
+		pageId: "654321",
+		spaceKey: "SPACE",
+		pageUrl: "",
+		contentType: "page",
+		blogPostDate: undefined,
+		...file,
+	};
+
+	return {
+		file: confluenceFile,
+		version: 1,
+		lastUpdatedBy: "tester",
+		existingPageData: {
+			adfContent: {
+				version: 1,
+				type: "doc",
+				content: [],
+			},
+			pageTitle: confluenceFile.pageTitle,
+			ancestors: [],
+			contentType: "page",
+		},
+		ancestors: [],
+	};
+}
+
+const testSettings: ConfluenceSettings = {
+	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceParentId: "1",
+	atlassianUserName: "test@example.com",
+	atlassianApiToken: "token",
+	folderToPublish: "Confluence Pages",
+	contentRoot: ".",
+	firstHeadingPageTitle: false,
+};

--- a/packages/lib/src/AdfProcessing.ts
+++ b/packages/lib/src/AdfProcessing.ts
@@ -37,7 +37,9 @@ export function prepareAdfToUpload(
 	const fileToPageIdMap: Record<string, ConfluenceAdfFile> = {};
 
 	confluencePagesToPublish.forEach((node) => {
-		fileToPageIdMap[node.file.fileName] = node.file;
+		for (const key of getWikilinkLookupKeys(node.file, settings)) {
+			fileToPageIdMap[key] = node.file;
+		}
 	});
 
 	confluencePagesToPublish.forEach((confluenceNode) => {
@@ -671,7 +673,12 @@ function processWikilinkToActualLink(
 				) {
 					const wikilinkUrl = new URL(node.marks[0].attrs["href"]);
 
-					const pathName = decodeURI(wikilinkUrl.pathname);
+					const pathName = normalizeWikilinkPath(
+						decodeURI(wikilinkUrl.pathname),
+					);
+					const pathNameParts = pathName.split("/");
+					const displayFileName =
+						pathNameParts[pathNameParts.length - 1] ?? pathName;
 					const pagename =
 						wikilinkUrl.pathname !== ""
 							? `${pathName}.md`
@@ -681,7 +688,11 @@ function processWikilinkToActualLink(
 					if (linkPage) {
 						const confluenceUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${linkPage.spaceKey}/pages/${linkPage.pageId}${wikilinkUrl.hash}`;
 						node.marks[0].attrs["href"] = confluenceUrl;
-						if (node.text === `${pathName}${wikilinkUrl.hash}`) {
+						if (
+							node.text === `${pathName}${wikilinkUrl.hash}` ||
+							node.text ===
+								`${displayFileName}${wikilinkUrl.hash}`
+						) {
 							node.type = "inlineCard";
 							node.attrs = {
 								url: node.marks[0].attrs["href"],
@@ -715,6 +726,33 @@ function processWikilinkToActualLink(
 			return;
 		},
 	}) as JSONDocNode;
+}
+
+function getWikilinkLookupKeys(
+	file: ConfluenceAdfFile,
+	settings: ConfluenceSettings,
+) {
+	const keys = new Set<string>([file.fileName]);
+	const normalizedPath = normalizeWikilinkPath(file.absoluteFilePath);
+	const folderToPublish = normalizeWikilinkPath(settings.folderToPublish);
+
+	if (normalizedPath) {
+		keys.add(normalizedPath);
+	}
+
+	if (
+		folderToPublish &&
+		folderToPublish !== "." &&
+		normalizedPath.startsWith(`${folderToPublish}/`)
+	) {
+		keys.add(normalizedPath.slice(folderToPublish.length + 1));
+	}
+
+	return keys;
+}
+
+function normalizeWikilinkPath(value: string) {
+	return value.replace(/\\/g, "/").replace(/^\/+/, "");
 }
 
 function removeEmptyProperties(adf: JSONDocNode) {


### PR DESCRIPTION
## Summary
- resolve wikilinks that include folder paths under the configured publish root
- keep filename-only wikilink behavior intact
- add a regression test for path-based wikilinks

## Validation
- npm test -w @markdown-confluence/lib
- npm run prettier-check -w @markdown-confluence/lib

Supersedes #652.