### PR TITLE
feat: support configurable Confluence REST suffix

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,7 +100,8 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
   "atlassianApiToken": "optional-token-from-config",
   "folderToPublish": "docs",
   "contentRoot": ".",
-  "firstHeadingPageTitle": false
+  "firstHeadingPageTitle": false,
+  "confluenceUrlSuffix": "/wiki/rest/"
 }
 ```
 
@@ -115,6 +116,7 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
 | `folderToPublish` | `FOLDER_TO_PUBLISH` | `--enableFolder`, `-f` | The folder, relative to `contentRoot`, whose Markdown files default to `connie-publish: true`. Use `.` to publish all Markdown files under `contentRoot`. |
 | `contentRoot` | `CONFLUENCE_CONTENT_ROOT` | `--contentRoot`, `--cr` | The root directory to scan for Markdown files and referenced content. |
 | `firstHeadingPageTitle` | `CONFLUENCE_FIRST_HEADING_PAGE_TITLE` | `--firstHeaderPageTitle`, `--fh` | When `true`, use the first heading as the page title when `connie-title` is not set. |
+| `confluenceUrlSuffix` | `CONFLUENCE_URL_SUFFIX` | `--urlSuffix` | The REST API suffix appended to `confluenceBaseUrl`. The default is `/wiki/rest/`; use `/rest/` for Confluence Data Center instances whose REST API is not below `/wiki`. |
 
 ### `folderToPublish` vs `contentRoot`
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import {
 	MermaidRendererPlugin,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
-import { ConfluenceClient } from "confluence.js";
+import { Config, ConfluenceClient } from "confluence.js";
 
 // Define the main function
 async function main() {
@@ -19,25 +19,28 @@ async function main() {
 	const settings = settingLoader.load();
 
 	const adaptor = new FileSystemAdaptor(settings); // Make sure this is identical as possible between Obsidian and CLI
-	const confluenceClient = new ConfluenceClient({
-		host: settings.confluenceBaseUrl,
-		authentication: {
-			basic: {
-				email: settings.atlassianUserName,
-				apiToken: settings.atlassianApiToken,
+	const confluenceClient = new MarkdownConfluenceClient(
+		{
+			host: settings.confluenceBaseUrl,
+			authentication: {
+				basic: {
+					email: settings.atlassianUserName,
+					apiToken: settings.atlassianApiToken,
+				},
+			},
+			middlewares: {
+				onError(e) {
+					if ("response" in e && "data" in e.response) {
+						e.message =
+							typeof e.response.data === "string"
+								? e.response.data
+								: JSON.stringify(e.response.data);
+					}
+				},
 			},
 		},
-		middlewares: {
-			onError(e) {
-				if ("response" in e && "data" in e.response) {
-					e.message =
-						typeof e.response.data === "string"
-							? e.response.data
-							: JSON.stringify(e.response.data);
-				}
-			},
-		},
-	});
+		settings.confluenceUrlSuffix,
+	);
 
 	const publisher = new Publisher(adaptor, settingLoader, confluenceClient, [
 		new MermaidRendererPlugin(new PuppeteerMermaidRenderer()),
@@ -67,3 +70,15 @@ main().catch((error) => {
 	console.error(chalk.red(boxen(`Error: ${error.message}`, { padding: 1 })));
 	process.exit(1);
 });
+
+class MarkdownConfluenceClient extends ConfluenceClient {
+	constructor(config: Config, urlSuffix: string) {
+		super(config);
+		this.urlSuffix = normalizeUrlSuffix(urlSuffix);
+	}
+}
+
+function normalizeUrlSuffix(urlSuffix: string) {
+	const prefixed = urlSuffix.startsWith("/") ? urlSuffix : `/${urlSuffix}`;
+	return prefixed.endsWith("/") ? prefixed : `${prefixed}/`;
+}

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -266,6 +266,7 @@ test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 		folderToPublish: ".",
 		contentRoot: "./",
 		firstHeadingPageTitle: false,
+		confluenceUrlSuffix: "/wiki/rest/",
 	};
 	const adfFile = convertMDtoADF(markdown, settings);
 	expect(adfFile).toMatchSnapshot();

--- a/packages/lib/src/PublisherErrors.test.ts
+++ b/packages/lib/src/PublisherErrors.test.ts
@@ -72,4 +72,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	confluenceUrlSuffix: "/wiki/rest/",
 };

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -6,6 +6,7 @@ export type ConfluenceSettings = {
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
+	confluenceUrlSuffix: string;
 };
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
@@ -16,4 +17,5 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	folderToPublish: "Confluence Pages",
 	contentRoot: process.cwd(),
 	firstHeadingPageTitle: false,
+	confluenceUrlSuffix: "/wiki/rest/",
 };

--- a/packages/lib/src/SettingsLoader/CommandLineArgumentSettingsLoader.ts
+++ b/packages/lib/src/SettingsLoader/CommandLineArgumentSettingsLoader.ts
@@ -57,6 +57,12 @@ export class CommandLineArgumentSettingsLoader extends SettingsLoader {
 				type: "boolean",
 				demandOption: false,
 			})
+			.option("urlSuffix", {
+				describe:
+					"Confluence REST URL suffix. Use /rest/ for Confluence Data Center instances whose REST API is not under /wiki/rest/.",
+				type: "string",
+				demandOption: false,
+			})
 			.parseSync();
 
 		return {
@@ -80,6 +86,9 @@ export class CommandLineArgumentSettingsLoader extends SettingsLoader {
 				: undefined),
 			...(options.firstHeaderPageTitle
 				? { firstHeadingPageTitle: options.firstHeaderPageTitle }
+				: undefined),
+			...(options.urlSuffix
+				? { confluenceUrlSuffix: options.urlSuffix }
 				: undefined),
 		};
 	}

--- a/packages/lib/src/SettingsLoader/EnvironmentVariableSettingsLoader.ts
+++ b/packages/lib/src/SettingsLoader/EnvironmentVariableSettingsLoader.ts
@@ -18,6 +18,7 @@ export class EnvironmentVariableSettingsLoader extends SettingsLoader {
 			...this.getValue("atlassianApiToken", "ATLASSIAN_API_TOKEN"),
 			...this.getValue("folderToPublish", "FOLDER_TO_PUBLISH"),
 			...this.getValue("contentRoot", "CONFLUENCE_CONTENT_ROOT"),
+			...this.getValue("confluenceUrlSuffix", "CONFLUENCE_URL_SUFFIX"),
 			firstHeadingPageTitle:
 				(process.env["CONFLUENCE_FIRST_HEADING_PAGE_TITLE"] ??
 					"false") === "true",

--- a/packages/lib/src/TreeConfluence.test.ts
+++ b/packages/lib/src/TreeConfluence.test.ts
@@ -116,4 +116,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	confluenceUrlSuffix: "/wiki/rest/",
 };

--- a/packages/lib/src/adaptors/filesystem.test.ts
+++ b/packages/lib/src/adaptors/filesystem.test.ts
@@ -50,4 +50,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	confluenceUrlSuffix: "/wiki/rest/",
 };


### PR DESCRIPTION
## Summary
- add `confluenceUrlSuffix` setting with `/wiki/rest/` as the default
- support JSON config, env var `CONFLUENCE_URL_SUFFIX`, and CLI `--urlSuffix`
- wire the CLI client through a small subclass so Data Center users can use `/rest/` before the first request is created
- document the new setting

## Validation
- npm run build
- npm test -w @markdown-confluence/lib
- npm run prettier-check -w @markdown-confluence/lib
- npm run prettier-check -w @markdown-confluence/cli

Supersedes #668.