### PR TITLE
feat: add CLI markdown to ADF conversion

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,14 @@ set ATLASSIAN_API_TOKEN="YOUR API TOKEN"
 npx @markdown-confluence/cli
 ```
 
+**Convert Markdown to ADF**
+
+```bash
+npx @markdown-confluence/cli to-adf ./docs/page.md
+npx @markdown-confluence/cli to-adf ./docs/page.md --output page.adf.json
+cat ./docs/page.md | npx @markdown-confluence/cli to-adf
+```
+
 ### Docker Container
 
 **Example setup**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,12 +9,20 @@ import {
 	FileSystemAdaptor,
 	Publisher,
 	MermaidRendererPlugin,
+	parseMarkdownToADF,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { ConfluenceClient } from "confluence.js";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
 
 // Define the main function
 async function main() {
+	if (process.argv[2] === "to-adf") {
+		await markdownToAdf();
+		return;
+	}
+
 	const settingLoader = new AutoSettingsLoader();
 	const settings = settingLoader.load();
 
@@ -67,3 +75,103 @@ main().catch((error) => {
 	console.error(chalk.red(boxen(`Error: ${error.message}`, { padding: 1 })));
 	process.exit(1);
 });
+
+async function markdownToAdf() {
+	const options = parseToAdfOptions(process.argv.slice(3));
+	const markdown = options.input
+		? readMarkdownFile(options.input)
+		: await readStdin();
+	const adf = parseMarkdownToADF(markdown, options.baseUrl);
+	const output = `${JSON.stringify(adf, null, 2)}\n`;
+
+	if (options.output) {
+		writeFileSync(resolve(options.output), output, "utf-8");
+		return;
+	}
+
+	process.stdout.write(output);
+}
+
+type ToAdfOptions = {
+	input?: string;
+	output?: string;
+	baseUrl: string;
+};
+
+function parseToAdfOptions(args: string[]): ToAdfOptions {
+	const options: ToAdfOptions = {
+		baseUrl: "https://confluence.atlassian.com",
+	};
+
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (!arg) {
+			continue;
+		}
+
+		if (arg === "-o" || arg === "--output") {
+			options.output = requireOptionValue(arg, args[++index]);
+			continue;
+		}
+
+		if (arg.startsWith("--output=")) {
+			options.output = arg.slice("--output=".length);
+			continue;
+		}
+
+		if (arg === "-b" || arg === "--base-url") {
+			options.baseUrl = requireOptionValue(arg, args[++index]);
+			continue;
+		}
+
+		if (arg.startsWith("--base-url=")) {
+			options.baseUrl = arg.slice("--base-url=".length);
+			continue;
+		}
+
+		if (arg.startsWith("-")) {
+			throw new Error(`Unknown to-adf option: ${arg}`);
+		}
+
+		if (options.input) {
+			throw new Error("Only one Markdown input file can be converted.");
+		}
+
+		options.input = arg;
+	}
+
+	return options;
+}
+
+function requireOptionValue(option: string, value: string | undefined) {
+	if (!value) {
+		throw new Error(`${option} requires a value.`);
+	}
+
+	return value;
+}
+
+function readMarkdownFile(input: string) {
+	const filePath = resolve(input);
+
+	if (!existsSync(filePath)) {
+		throw new Error(`File not found: ${filePath}`);
+	}
+
+	return readFileSync(filePath, "utf-8");
+}
+
+async function readStdin() {
+	if (process.stdin.isTTY) {
+		throw new Error("Input file is required when stdin is not piped.");
+	}
+
+	process.stdin.setEncoding("utf-8");
+	let input = "";
+
+	for await (const chunk of process.stdin) {
+		input += chunk;
+	}
+
+	return input;
+}


### PR DESCRIPTION
## Summary
- add a `to-adf` CLI subcommand for converting Markdown to ADF JSON without contacting Confluence
- support file input, piped stdin, `--output`, and `--base-url` for Confluence link cleanup
- document the new conversion examples

## Validation
- npm run build -w @markdown-confluence/cli
- npm run prettier-check -w @markdown-confluence/cli
- node packages/cli/dist/index.js to-adf /tmp/markdown-confluence-to-adf.md
- printf "# Stdin\n" | node packages/cli/dist/index.js to-adf

Supersedes #681.