### PR TITLE
fix: upload non-image attachments

### DIFF
--- a/packages/lib/src/Attachments.test.ts
+++ b/packages/lib/src/Attachments.test.ts
@@ -1,0 +1,52 @@
+import { expect, jest, test } from "@jest/globals";
+import { uploadFile } from "./Attachments";
+import {
+	BinaryFile,
+	LoaderAdaptor,
+	RequiredConfluenceClient,
+} from "./adaptors";
+
+test("uploads non-image attachments without requiring image dimensions", async () => {
+	const createOrUpdateAttachments = jest.fn(async () => ({
+		results: [
+			{
+				extensions: { fileId: "attachment-1" },
+				container: { id: "page-1" },
+			},
+		],
+	}));
+	const confluenceClient = {
+		contentAttachments: {
+			createOrUpdateAttachments,
+		},
+	} as unknown as RequiredConfluenceClient;
+	const adaptor = {
+		async readBinary(): Promise<BinaryFile> {
+			return {
+				contents: Buffer.from("not an image"),
+				filePath: "docs/movie.mp4",
+				filename: "movie.mp4",
+				mimeType: "video/mp4",
+			};
+		},
+	} as unknown as LoaderAdaptor;
+
+	const result = await uploadFile(
+		confluenceClient,
+		adaptor,
+		"page-1",
+		"docs/page.md",
+		"movie.mp4",
+		{},
+	);
+
+	expect(createOrUpdateAttachments).toHaveBeenCalledTimes(1);
+	expect(result).toMatchObject({
+		filename: "movie.mp4",
+		id: "attachment-1",
+		collection: "contentId-page-1",
+		width: 0,
+		height: 0,
+		status: "uploaded",
+	});
+});

--- a/packages/lib/src/Attachments.ts
+++ b/packages/lib/src/Attachments.ts
@@ -34,7 +34,7 @@ export async function uploadBuffer(
 ): Promise<UploadedImageData | null> {
 	const spark = new SparkMD5.ArrayBuffer();
 	const currentFileMd5 = spark.append(fileBuffer).end();
-	const imageSize = await sizeOf(fileBuffer);
+	const mediaSize = await getMediaSize(fileBuffer);
 
 	const fileInCurrentAttachments = currentAttachments[uploadFilename];
 	if (fileInCurrentAttachments?.filehash === currentFileMd5) {
@@ -42,8 +42,8 @@ export async function uploadBuffer(
 			filename: uploadFilename,
 			id: fileInCurrentAttachments.attachmentId,
 			collection: fileInCurrentAttachments.collectionName,
-			width: imageSize.width ?? 0,
-			height: imageSize.height ?? 0,
+			width: mediaSize.width,
+			height: mediaSize.height,
 			status: "existing",
 		};
 	}
@@ -75,8 +75,8 @@ export async function uploadBuffer(
 		filename: uploadFilename,
 		id: attachmentUploadResponse.extensions.fileId,
 		collection: `contentId-${attachmentUploadResponse.container.id}`,
-		width: imageSize.width ?? 0,
-		height: imageSize.height ?? 0,
+		width: mediaSize.width,
+		height: mediaSize.height,
 		status: "uploaded",
 	};
 }
@@ -101,7 +101,7 @@ export async function uploadFile(
 		const pathMd5 = SparkMD5.hash(testing.filePath);
 		const uploadFilename = `${pathMd5}-${testing.filename}`;
 		const imageBuffer = Buffer.from(testing.contents);
-		const imageSize = await sizeOf(imageBuffer);
+		const mediaSize = await getMediaSize(imageBuffer);
 
 		const fileInCurrentAttachments = currentAttachments[uploadFilename];
 		if (fileInCurrentAttachments?.filehash === currentFileMd5) {
@@ -109,8 +109,8 @@ export async function uploadFile(
 				filename: fileNameForUpload,
 				id: fileInCurrentAttachments.attachmentId,
 				collection: fileInCurrentAttachments.collectionName,
-				width: imageSize.width ?? 0,
-				height: imageSize.height ?? 0,
+				width: mediaSize.width,
+				height: mediaSize.height,
 				status: "existing",
 			};
 		}
@@ -141,11 +141,26 @@ export async function uploadFile(
 			filename: fileNameForUpload,
 			id: attachmentUploadResponse.extensions.fileId,
 			collection: `contentId-${attachmentUploadResponse.container.id}`,
-			width: imageSize.width ?? 0,
-			height: imageSize.height ?? 0,
+			width: mediaSize.width,
+			height: mediaSize.height,
 			status: "uploaded",
 		};
 	}
 
 	return null;
+}
+
+async function getMediaSize(fileBuffer: Buffer) {
+	try {
+		const dimensions = await sizeOf(fileBuffer);
+		return {
+			width: dimensions.width ?? 0,
+			height: dimensions.height ?? 0,
+		};
+	} catch {
+		return {
+			width: 0,
+			height: 0,
+		};
+	}
 }


### PR DESCRIPTION
## Summary
- keep attachment upload from failing when `image-size` cannot read dimensions
- use `0x0` for unknown media dimensions instead of inventing video dimensions
- add a regression test for non-image attachment uploads

## Validation
- npm test -w @markdown-confluence/lib -- Attachments.test.ts
- npm test -w @markdown-confluence/lib
- npm run prettier-check -w @markdown-confluence/lib

Supersedes #626.