### PR TITLE
deps: update electron remote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2560,7 +2560,9 @@
          }
       },
       "node_modules/@electron/remote": {
-         "version": "2.0.9",
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
+         "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
          "license": "MIT",
          "peerDependencies": {
             "electron": ">= 13.0.0"
@@ -20118,7 +20120,7 @@
          "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
-            "@electron/remote": "^2.0.9",
+            "@electron/remote": "^2.1.3",
             "@markdown-confluence/lib": "5.5.2",
             "mermaid": "^10.9.6"
          },
@@ -22137,7 +22139,9 @@
          }
       },
       "@electron/remote": {
-         "version": "2.0.9",
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
+         "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
          "requires": {}
       },
       "@emotion/babel-plugin": {
@@ -24022,7 +24026,7 @@
       "@markdown-confluence/mermaid-electron-renderer": {
          "version": "file:packages/mermaid-electron-renderer",
          "requires": {
-            "@electron/remote": "^2.0.9",
+            "@electron/remote": "^2.1.3",
             "@markdown-confluence/lib": "5.5.2",
             "mermaid": "10.9.6"
          }

--- a/packages/mermaid-electron-renderer/package.json
+++ b/packages/mermaid-electron-renderer/package.json
@@ -19,7 +19,7 @@
     "license": "Apache 2.0",
     "devDependencies": {},
     "dependencies": {
-        "@electron/remote": "^2.0.9",
+        "@electron/remote": "^2.1.3",
         "mermaid": "^10.9.6",
         "@markdown-confluence/lib": "5.5.2"
     },


### PR DESCRIPTION
## Summary
- update `@electron/remote` from `^2.0.9` to `^2.1.3` in the Mermaid Electron renderer
- refresh the lockfile entry for the updated package

## Validation
- npm ci --ignore-scripts
- npm run build -w @markdown-confluence/mermaid-electron-renderer
- npm run prettier-check -w @markdown-confluence/mermaid-electron-renderer

Supersedes #640.