### PR TITLE
fix: update Obsidian SDK compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -626,20 +626,6 @@
             }
          }
       },
-      "node_modules/@atlaskit/give-kudos/node_modules/typescript": {
-         "version": "4.9.5",
-         "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-         "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-         "optional": true,
-         "peer": true,
-         "bin": {
-            "tsc": "bin/tsc",
-            "tsserver": "bin/tsserver"
-         },
-         "engines": {
-            "node": ">=4.2.0"
-         }
-      },
       "node_modules/@atlaskit/heading": {
          "version": "1.3.8",
          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/heading/-/heading-1.3.8.tgz",
@@ -1396,20 +1382,6 @@
             }
          }
       },
-      "node_modules/@atlaskit/profilecard/node_modules/typescript": {
-         "version": "4.9.5",
-         "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-         "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-         "optional": true,
-         "peer": true,
-         "bin": {
-            "tsc": "bin/tsc",
-            "tsserver": "bin/tsserver"
-         },
-         "engines": {
-            "node": ">=4.2.0"
-         }
-      },
       "node_modules/@atlaskit/section-message": {
          "version": "6.4.12",
          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/section-message/-/section-message-6.4.12.tgz",
@@ -1574,20 +1546,6 @@
             "typescript": {
                "optional": true
             }
-         }
-      },
-      "node_modules/@atlaskit/smart-user-picker/node_modules/typescript": {
-         "version": "4.9.5",
-         "resolved": "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.9.5.tgz",
-         "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-         "optional": true,
-         "peer": true,
-         "bin": {
-            "tsc": "bin/tsc",
-            "tsserver": "bin/tsserver"
-         },
-         "engines": {
-            "node": ">=4.2.0"
          }
       },
       "node_modules/@atlaskit/smart-user-picker/node_modules/uuid": {
@@ -1965,20 +1923,6 @@
             "typescript": {
                "optional": true
             }
-         }
-      },
-      "node_modules/@atlassianlabs/jql-editor/node_modules/typescript": {
-         "version": "4.9.5",
-         "resolved": "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.9.5.tgz",
-         "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-         "optional": true,
-         "peer": true,
-         "bin": {
-            "tsc": "bin/tsc",
-            "tsserver": "bin/tsserver"
-         },
-         "engines": {
-            "node": ">=4.2.0"
          }
       },
       "node_modules/@atlassianlabs/jql-editor/node_modules/uuid": {
@@ -2505,19 +2449,27 @@
          "license": "MIT"
       },
       "node_modules/@codemirror/state": {
-         "version": "6.2.0",
-         "dev": true,
-         "license": "MIT",
-         "peer": true
-      },
-      "node_modules/@codemirror/view": {
-         "version": "6.9.5",
+         "version": "6.5.0",
+         "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+         "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
          "dev": true,
          "license": "MIT",
          "peer": true,
          "dependencies": {
-            "@codemirror/state": "^6.1.4",
-            "style-mod": "^4.0.0",
+            "@marijn/find-cluster-break": "^1.0.0"
+         }
+      },
+      "node_modules/@codemirror/view": {
+         "version": "6.38.6",
+         "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+         "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+         "dev": true,
+         "license": "MIT",
+         "peer": true,
+         "dependencies": {
+            "@codemirror/state": "^6.5.0",
+            "crelt": "^1.0.6",
+            "style-mod": "^4.1.0",
             "w3c-keyname": "^2.2.4"
          }
       },
@@ -2560,7 +2512,9 @@
          }
       },
       "node_modules/@electron/remote": {
-         "version": "2.0.9",
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
+         "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
          "license": "MIT",
          "peerDependencies": {
             "electron": ">= 13.0.0"
@@ -4260,6 +4214,14 @@
             "node": ">= 10"
          }
       },
+      "node_modules/@marijn/find-cluster-break": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+         "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+         "dev": true,
+         "license": "MIT",
+         "peer": true
+      },
       "node_modules/@markdown-confluence/cli": {
          "resolved": "packages/cli",
          "link": true
@@ -4653,7 +4615,9 @@
          }
       },
       "node_modules/@types/codemirror": {
-         "version": "0.0.108",
+         "version": "5.60.8",
+         "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+         "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -4687,7 +4651,9 @@
          }
       },
       "node_modules/@types/estree": {
-         "version": "1.0.0",
+         "version": "1.0.9",
+         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+         "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
          "dev": true,
          "license": "MIT"
       },
@@ -4941,7 +4907,9 @@
          "license": "MIT"
       },
       "node_modules/@types/tern": {
-         "version": "0.23.4",
+         "version": "0.23.9",
+         "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+         "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -7494,6 +7462,14 @@
          "version": "1.1.1",
          "license": "MIT"
       },
+      "node_modules/crelt": {
+         "version": "1.0.6",
+         "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+         "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+         "dev": true,
+         "license": "MIT",
+         "peer": true
+      },
       "node_modules/cross-fetch": {
          "version": "4.0.0",
          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cross-fetch/-/cross-fetch-4.0.0.tgz",
@@ -9676,7 +9652,6 @@
       },
       "node_modules/fsevents": {
          "version": "2.3.2",
-         "dev": true,
          "license": "MIT",
          "optional": true,
          "os": [
@@ -14726,6 +14701,21 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/obsidian": {
+         "version": "1.12.3",
+         "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+         "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/codemirror": "5.60.8",
+            "moment": "2.29.4"
+         },
+         "peerDependencies": {
+            "@codemirror/state": "6.5.0",
+            "@codemirror/view": "6.38.6"
+         }
+      },
       "node_modules/obsidian-confluence": {
          "resolved": "packages/obsidian",
          "link": true
@@ -17375,7 +17365,9 @@
          }
       },
       "node_modules/style-mod": {
-         "version": "4.0.3",
+         "version": "4.1.3",
+         "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+         "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
          "dev": true,
          "license": "MIT",
          "peer": true
@@ -20099,26 +20091,12 @@
             }
          }
       },
-      "packages/lib/node_modules/typescript": {
-         "version": "4.9.5",
-         "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-         "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-         "optional": true,
-         "peer": true,
-         "bin": {
-            "tsc": "bin/tsc",
-            "tsserver": "bin/tsserver"
-         },
-         "engines": {
-            "node": ">=4.2.0"
-         }
-      },
       "packages/mermaid-electron-renderer": {
          "name": "@markdown-confluence/mermaid-electron-renderer",
          "version": "5.5.2",
          "license": "Apache 2.0",
          "dependencies": {
-            "@electron/remote": "^2.0.9",
+            "@electron/remote": "^2.1.3",
             "@markdown-confluence/lib": "5.5.2",
             "mermaid": "^10.9.6"
          },
@@ -20130,7 +20108,7 @@
          "license": "Apache 2.0",
          "dependencies": {
             "@markdown-confluence/lib": "5.5.2",
-            "mermaid": "^10.9.6",
+            "mermaid": "10.9.6",
             "puppeteer": "21.3.4"
          }
       },
@@ -20149,20 +20127,7 @@
          "devDependencies": {
             "@types/mime-types": "^2.1.1",
             "@types/react-dom": "^18.0.11",
-            "obsidian": "1.1.1"
-         }
-      },
-      "packages/obsidian/node_modules/obsidian": {
-         "version": "1.1.1",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "@types/codemirror": "0.0.108",
-            "moment": "2.29.4"
-         },
-         "peerDependencies": {
-            "@codemirror/state": "^6.0.0",
-            "@codemirror/view": "^6.0.0"
+            "obsidian": "1.12.3"
          }
       }
    },
@@ -20674,13 +20639,6 @@
                   "intl-messageformat": "9.13.0",
                   "tslib": "^2.1.0"
                }
-            },
-            "typescript": {
-               "version": "4.9.5",
-               "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-               "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-               "optional": true,
-               "peer": true
             }
          }
       },
@@ -21277,13 +21235,6 @@
                   "intl-messageformat": "9.13.0",
                   "tslib": "^2.1.0"
                }
-            },
-            "typescript": {
-               "version": "4.9.5",
-               "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-               "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-               "optional": true,
-               "peer": true
             }
          }
       },
@@ -21415,13 +21366,6 @@
                   "intl-messageformat": "9.13.0",
                   "tslib": "^2.1.0"
                }
-            },
-            "typescript": {
-               "version": "4.9.5",
-               "resolved": "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.9.5.tgz",
-               "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-               "optional": true,
-               "peer": true
             },
             "uuid": {
                "version": "3.4.0",
@@ -21717,13 +21661,6 @@
                   "intl-messageformat": "9.13.0",
                   "tslib": "^2.1.0"
                }
-            },
-            "typescript": {
-               "version": "4.9.5",
-               "resolved": "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.9.5.tgz",
-               "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-               "optional": true,
-               "peer": true
             },
             "uuid": {
                "version": "3.4.0",
@@ -22093,17 +22030,25 @@
          "version": "6.0.2"
       },
       "@codemirror/state": {
-         "version": "6.2.0",
-         "dev": true,
-         "peer": true
-      },
-      "@codemirror/view": {
-         "version": "6.9.5",
+         "version": "6.5.0",
+         "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+         "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
          "dev": true,
          "peer": true,
          "requires": {
-            "@codemirror/state": "^6.1.4",
-            "style-mod": "^4.0.0",
+            "@marijn/find-cluster-break": "^1.0.0"
+         }
+      },
+      "@codemirror/view": {
+         "version": "6.38.6",
+         "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+         "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+         "dev": true,
+         "peer": true,
+         "requires": {
+            "@codemirror/state": "^6.5.0",
+            "crelt": "^1.0.6",
+            "style-mod": "^4.1.0",
             "w3c-keyname": "^2.2.4"
          }
       },
@@ -22137,7 +22082,9 @@
          }
       },
       "@electron/remote": {
-         "version": "2.0.9",
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
+         "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
          "requires": {}
       },
       "@emotion/babel-plugin": {
@@ -23353,6 +23300,13 @@
             "iconv-lite": "^0.6.3"
          }
       },
+      "@marijn/find-cluster-break": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+         "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+         "dev": true,
+         "peer": true
+      },
       "@markdown-confluence/cli": {
          "version": "file:packages/cli",
          "requires": {
@@ -24009,22 +23963,15 @@
                   "intl-messageformat": "9.13.0",
                   "tslib": "^2.1.0"
                }
-            },
-            "typescript": {
-               "version": "4.9.5",
-               "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-               "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-               "optional": true,
-               "peer": true
             }
          }
       },
       "@markdown-confluence/mermaid-electron-renderer": {
          "version": "file:packages/mermaid-electron-renderer",
          "requires": {
-            "@electron/remote": "^2.0.9",
+            "@electron/remote": "^2.1.3",
             "@markdown-confluence/lib": "5.5.2",
-            "mermaid": "10.9.6"
+            "mermaid": "^10.9.6"
          }
       },
       "@markdown-confluence/mermaid-puppeteer-renderer": {
@@ -24345,7 +24292,9 @@
          }
       },
       "@types/codemirror": {
-         "version": "0.0.108",
+         "version": "5.60.8",
+         "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+         "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
          "dev": true,
          "requires": {
             "@types/tern": "*"
@@ -24378,7 +24327,9 @@
          }
       },
       "@types/estree": {
-         "version": "1.0.0",
+         "version": "1.0.9",
+         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+         "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
          "dev": true
       },
       "@types/graceful-fs": {
@@ -24609,7 +24560,9 @@
          "dev": true
       },
       "@types/tern": {
-         "version": "0.23.4",
+         "version": "0.23.9",
+         "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+         "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
          "dev": true,
          "requires": {
             "@types/estree": "*"
@@ -26530,6 +26483,13 @@
       "create-require": {
          "version": "1.1.1"
       },
+      "crelt": {
+         "version": "1.0.6",
+         "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+         "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+         "dev": true,
+         "peer": true
+      },
       "cross-fetch": {
          "version": "4.0.0",
          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cross-fetch/-/cross-fetch-4.0.0.tgz",
@@ -28135,7 +28095,6 @@
       },
       "fsevents": {
          "version": "2.3.2",
-         "dev": true,
          "optional": true
       },
       "function-bind": {
@@ -31711,6 +31670,16 @@
             "isobject": "^3.0.1"
          }
       },
+      "obsidian": {
+         "version": "1.12.3",
+         "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+         "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+         "dev": true,
+         "requires": {
+            "@types/codemirror": "5.60.8",
+            "moment": "2.29.4"
+         }
+      },
       "obsidian-confluence": {
          "version": "file:packages/obsidian",
          "requires": {
@@ -31720,19 +31689,9 @@
             "@types/react-dom": "^18.0.11",
             "confluence.js": "^1.6.3",
             "mime-types": "^2.1.35",
-            "obsidian": "1.1.1",
+            "obsidian": "1.12.3",
             "react": "^16.14.0",
             "react-dom": "^16.14.0"
-         },
-         "dependencies": {
-            "obsidian": {
-               "version": "1.1.1",
-               "dev": true,
-               "requires": {
-                  "@types/codemirror": "0.0.108",
-                  "moment": "2.29.4"
-               }
-            }
          }
       },
       "once": {
@@ -33713,7 +33672,9 @@
          "dev": true
       },
       "style-mod": {
-         "version": "4.0.3",
+         "version": "4.1.3",
+         "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+         "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
          "dev": true,
          "peer": true
       },

--- a/packages/mermaid-electron-renderer/package.json
+++ b/packages/mermaid-electron-renderer/package.json
@@ -19,7 +19,7 @@
     "license": "Apache 2.0",
     "devDependencies": {},
     "dependencies": {
-        "@electron/remote": "^2.0.9",
+        "@electron/remote": "^2.1.3",
         "mermaid": "^10.9.6",
         "@markdown-confluence/lib": "5.5.2"
     },

--- a/packages/obsidian/package.json
+++ b/packages/obsidian/package.json
@@ -17,7 +17,7 @@
     "devDependencies": {
         "@types/mime-types": "^2.1.1",
         "@types/react-dom": "^18.0.11",
-        "obsidian": "1.1.1"
+        "obsidian": "1.12.3"
     },
     "dependencies": {
         "confluence.js": "^1.6.3",
@@ -31,4 +31,3 @@
         "prosemirror-model": "1.14.3"
     }
 }
-       

--- a/packages/obsidian/src/adaptors/obsidian.ts
+++ b/packages/obsidian/src/adaptors/obsidian.ts
@@ -85,7 +85,7 @@ export default class ObsidianAdaptor implements LoaderAdaptor {
 
 		return {
 			pageTitle: file.basename,
-			folderName: file.parent.name,
+			folderName: file.parent?.name ?? "",
 			absoluteFilePath: file.path,
 			fileName: file.name,
 			contents: await this.vault.cachedRead(file),

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -51,7 +51,7 @@ export default class ConfluencePlugin extends Plugin {
 	adaptor!: ObsidianAdaptor;
 
 	activeLeafPath(workspace: Workspace) {
-		return workspace.getActiveViewOfType(MarkdownView)?.file.path;
+		return workspace.getActiveViewOfType(MarkdownView)?.file?.path;
 	}
 
 	async init() {


### PR DESCRIPTION
## Summary
- update the Obsidian SDK from `1.1.1` to the latest published `1.12.3`
- update `@electron/remote` to `^2.1.3` for current Obsidian runtime compatibility
- fix the nullability issues surfaced by the current Obsidian SDK types

## Validation
- npm ci --ignore-scripts
- npm run build -w obsidian-confluence
- npm run build -w @markdown-confluence/mermaid-electron-renderer
- npm run lint -w obsidian-confluence
- npm run prettier-check -w obsidian-confluence
- npm run prettier-check -w @markdown-confluence/mermaid-electron-renderer

Closes #677.
Supersedes #528 and #640.