### PR TITLE
chore: run builds on Node 24

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -31,9 +31,9 @@ jobs:
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
     - name: Set up Node.js
-      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: "16.x"
+        node-version: "24.x"
 
     - name: Install dependencies
       run: npm ci
@@ -93,9 +93,9 @@ jobs:
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
     - name: Set up Node.js
-      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: "16.x"
+        node-version: "24.x"
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,14 +39,14 @@ jobs:
       
       - name: Use Node.js
         if: ${{ steps.release-please.outputs.release_created }}
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "16.x"
+          node-version: "24.x"
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Latest NPM
+      - name: Use NPM 11
         if: ${{ steps.release-please.outputs.release_created }}
-        run: npm install -g npm@9.6.5
+        run: npm install -g npm@11
 
       - name: Checkout source repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
             "packages/obsidian"
          ],
          "devDependencies": {
-            "@types/node": "^16.11.6",
+            "@types/node": "^24.12.4",
             "@typescript-eslint/eslint-plugin": "^6.3.0",
             "@typescript-eslint/parser": "^6.3.0",
             "builtin-modules": "3.3.0",
@@ -4794,8 +4794,13 @@
          "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
       },
       "node_modules/@types/node": {
-         "version": "16.18.8",
-         "license": "MIT"
+         "version": "24.12.4",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+         "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+         "license": "MIT",
+         "dependencies": {
+            "undici-types": "~7.16.0"
+         }
       },
       "node_modules/@types/normalize-package-data": {
          "version": "2.4.1",
@@ -8387,6 +8392,13 @@
          "version": "1.4.284",
          "dev": true,
          "license": "ISC"
+      },
+      "node_modules/electron/node_modules/@types/node": {
+         "version": "16.18.126",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+         "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+         "license": "MIT",
+         "peer": true
       },
       "node_modules/elkjs": {
          "version": "0.9.3",
@@ -17960,6 +17972,12 @@
             "through": "^2.3.8"
          }
       },
+      "node_modules/undici-types": {
+         "version": "7.16.0",
+         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+         "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+         "license": "MIT"
+      },
       "node_modules/union-value": {
          "version": "1.0.1",
          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/union-value/-/union-value-1.0.1.tgz",
@@ -24460,7 +24478,12 @@
          "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
       },
       "@types/node": {
-         "version": "16.18.8"
+         "version": "24.12.4",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+         "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+         "requires": {
+            "undici-types": "~7.16.0"
+         }
       },
       "@types/normalize-package-data": {
          "version": "2.4.1",
@@ -27165,6 +27188,14 @@
             "@electron/get": "^2.0.0",
             "@types/node": "^16.11.26",
             "extract-zip": "^2.0.1"
+         },
+         "dependencies": {
+            "@types/node": {
+               "version": "16.18.126",
+               "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+               "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+               "peer": true
+            }
          }
       },
       "electron-to-chromium": {
@@ -34093,6 +34124,11 @@
             "buffer": "^5.2.1",
             "through": "^2.3.8"
          }
+      },
+      "undici-types": {
+         "version": "7.16.0",
+         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+         "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
       },
       "union-value": {
          "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "test": "npm test -ws --if-present"
    },
    "devDependencies": {
-      "@types/node": "^16.11.6",
+      "@types/node": "^24.12.4",
       "@typescript-eslint/eslint-plugin": "^6.3.0",
       "@typescript-eslint/parser": "^6.3.0",
       "builtin-modules": "3.3.0",

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/puppeteer/puppeteer:21.6.1@sha256:d41d0271c774019a9bf6a1bbec8071d067558815f047bc6f15c84ebab12f0391
+FROM ghcr.io/puppeteer/puppeteer:24.43.1@sha256:75e3404b1df87e39eec2af9fa95e4e0fdbc5c73fc924aafa1429c89a2a3e8654
 
 COPY ./dist /app
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
       "inlineSources":true,
       "jsx":"react",
       "module":"CommonJS",
-      "target":"ES2021",
+      "target":"ES2022",
       "allowJs":true,
       "moduleResolution":"node",
       "importHelpers":true,
@@ -40,7 +40,7 @@
          "ES5",
          "ES6",
          "ES7",
-         "ES2021"
+         "ES2022"
       ],
       "paths":{
          "@markdown-confluence/*":[


### PR DESCRIPTION
## Summary
- update PR and release workflows to setup-node v4 running Node 24
- update Node type definitions and TypeScript target/lib for Node 24-compatible builds
- update the CLI Docker base image to a Puppeteer image with Node 24

Stacked on #701.

## Validation
- npx -p node@24 -p npm@11.14.1 npm ci --ignore-scripts
- npx -p node@24 -p npm@11.14.1 npm run test -ws --if-present
- npx -p node@24 -p npm@11.14.1 npm run build -ws --if-present
- npx -p node@24 -p npm@11.14.1 npm run lint -ws --if-present
- npx -p node@24 -p npm@11.14.1 npm run prettier-check -ws --if-present
- node -e "const fs=require('fs'); const yaml=require('yaml'); for (const file of ['.github/workflows/pr-check.yml','.github/workflows/release-please.yml']) yaml.parse(fs.readFileSync(file,'utf8')); console.log('workflow yaml ok')"

## Notes
- Local Docker build was not run because Docker Desktop/daemon is not available in this environment: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`.