### PR TITLE
ci: publish npm packages with trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,6 +62,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
 
+      - name: Use Node.js for trusted publishing
+        if: ${{ steps.release-please.outputs.release_created }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24.x"
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Use NPM with trusted publishing support
+        if: ${{ steps.release-please.outputs.release_created }}
+        run: npm install -g npm@^11.5.1
+
       - name: Publish to NPM
         if: ${{ steps.release-please.outputs.release_created }}
         run: |
@@ -69,8 +81,6 @@ jobs:
           npm publish -w @markdown-confluence/mermaid-electron-renderer
           npm publish -w @markdown-confluence/mermaid-puppeteer-renderer
           npm publish -w @markdown-confluence/cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Log in to the Container registry
         if: ${{ steps.release-please.outputs.release_created }}


### PR DESCRIPTION
## Summary
- switch the npm publish phase to Node 24 and npm 11.5+ so npm trusted publishing/OIDC is supported
- keep the existing Node 16 build/release-asset path unchanged
- remove the long-lived NODE_AUTH_TOKEN from npm publishing

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "release-please.yml parsed"'\n- npm trust github <package> --file release-please.yml --repo markdown-confluence/markdown-confluence --dry-run --json for each published npm package\n\n## npm package setup after merge\nRun these while logged in as an npm owner/publisher for the packages:\n\n```sh\nnpm trust github @markdown-confluence/lib --repo markdown-confluence/markdown-confluence --file release-please.yml -y\nnpm trust github @markdown-confluence/mermaid-electron-renderer --repo markdown-confluence/markdown-confluence --file release-please.yml -y\nnpm trust github @markdown-confluence/mermaid-puppeteer-renderer --repo markdown-confluence/markdown-confluence --file release-please.yml -y\nnpm trust github @markdown-confluence/cli --repo markdown-confluence/markdown-confluence --file release-please.yml -y\n```