### PR TITLE
Document and align repo tooling decisions

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Vite+
       uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
       with:
-        node-version: "24"
+        node-version: "24.15.0"
         cache: true
         run-install: false
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Vite+
       uses: voidzero-dev/setup-vp@v1
       with:
-        node-version: "24"
+        node-version: "24.15.0"
         cache: true
         run-install: false
 
@@ -97,7 +97,7 @@ jobs:
     - name: Set up Vite+
       uses: voidzero-dev/setup-vp@v1
       with:
-        node-version: "24"
+        node-version: "24.15.0"
         cache: true
         run-install: false
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
         if: ${{ steps.release-please.outputs.release_created }}
         uses: voidzero-dev/setup-vp@v1
         with:
-          node-version: "24"
+          node-version: "24.15.0"
           cache: true
           run-install: false
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Vite+
         uses: voidzero-dev/setup-vp@v1
         with:
-          node-version: "24"
+          node-version: "24.15.0"
           cache: true
           run-install: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines
+
+## Tooling Decisions
+
+- Use Node.js `24.15.0` for local parity with CI.
+- Use `pnpm` for package management. Do not add `package-lock.json` or Yarn lockfiles; `pnpm-lock.yaml` is the authoritative lockfile.
+- Use Vite+ (`vp`) for formatting, linting, tests, checks, builds, and workspace task execution.
+- GitHub Actions should use `voidzero-dev/setup-vp` with Node.js `24.15.0`.
+- In CI and release scripts, invoke the same Vite+ commands that the GitHub workflows run, for example:
+    - `vp install --frozen-lockfile`
+    - `vp run check`
+    - `vp run fmt:check`
+    - `vp test run`
+    - `vp run build`
+    - `vp run -r build:docker`
+- Avoid adding direct ESLint, Prettier, or Jest commands for repo workflows. When touching legacy tooling paths, migrate them to `vp`.
+- Local `pnpm run ...` is fine for interactive work, but committed GitHub Actions should follow the checked-in Vite+ workflow pattern above.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -55,6 +55,7 @@
 		"glob": "^13.0.6",
 		"image-size": "^2.0.2",
 		"lodash-es": "^4.18.1",
+		"markdown-it": "^14.1.1",
 		"markdown-it-table": "^4.1.1",
 		"markdown-table": "^3.0.4",
 		"mime-types": "^3.0.2",
@@ -67,7 +68,6 @@
 		"@types/lodash-es": "^4.17.12",
 		"@types/markdown-it": "^14.1.2",
 		"@types/mime-types": "^3.0.1",
-		"@types/spark-md5": "^3.0.5",
-		"markdown-it": "^14.1.1"
+		"@types/spark-md5": "^3.0.5"
 	}
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -53,7 +53,6 @@
 		"effect": "4.0.0-beta.66",
 		"formdata-node": "^6.0.3",
 		"glob": "^13.0.6",
-		"gray-matter": "^4.0.3",
 		"image-size": "^2.0.2",
 		"lodash-es": "^4.18.1",
 		"markdown-it-table": "^4.1.1",
@@ -62,14 +61,13 @@
 		"sort-any": "^4.0.7",
 		"spark-md5": "^3.0.2",
 		"uuid": "^14.0.0",
-		"yargs": "18.0.0"
+		"yaml": "^2.9.0"
 	},
 	"devDependencies": {
 		"@types/lodash-es": "^4.17.12",
 		"@types/markdown-it": "^14.1.2",
 		"@types/mime-types": "^3.0.1",
 		"@types/spark-md5": "^3.0.5",
-		"@types/yargs": "^17.0.35",
 		"markdown-it": "^14.1.1"
 	}
 }

--- a/packages/lib/src/MarkdownFrontmatter.test.ts
+++ b/packages/lib/src/MarkdownFrontmatter.test.ts
@@ -28,6 +28,25 @@ test("returns empty data when a file has no frontmatter", () => {
 	expect(parsed).toEqual({ data: {}, content: "# Hello\n" });
 });
 
+test("returns the full content when an opening delimiter is not closed", () => {
+	const content = `---
+title: Hello
+# Hello
+`;
+
+	expect(parseMarkdownFrontmatter(content)).toEqual({ data: {}, content });
+});
+
+test("returns empty data when frontmatter YAML is malformed", () => {
+	const parsed = parseMarkdownFrontmatter(`---
+title: [Hello
+---
+# Hello
+`);
+
+	expect(parsed).toEqual({ data: {}, content: "# Hello\n" });
+});
+
 test("stringifies merged frontmatter data", () => {
 	const parsed = parseMarkdownFrontmatter(`---
 title: Hello

--- a/packages/lib/src/MarkdownFrontmatter.test.ts
+++ b/packages/lib/src/MarkdownFrontmatter.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@effect/vitest";
+import { parseMarkdownFrontmatter, stringifyMarkdownFrontmatter } from "./MarkdownFrontmatter";
+
+test("parses leading YAML frontmatter", () => {
+	const parsed = parseMarkdownFrontmatter(`---
+title: Hello
+tags:
+  - docs
+  - confluence
+published: true
+---
+# Hello
+`);
+
+	expect(parsed).toEqual({
+		data: {
+			title: "Hello",
+			tags: ["docs", "confluence"],
+			published: true,
+		},
+		content: "# Hello\n",
+	});
+});
+
+test("returns empty data when a file has no frontmatter", () => {
+	const parsed = parseMarkdownFrontmatter("# Hello\n");
+
+	expect(parsed).toEqual({ data: {}, content: "# Hello\n" });
+});
+
+test("stringifies merged frontmatter data", () => {
+	const parsed = parseMarkdownFrontmatter(`---
+title: Hello
+draft: true
+---
+# Hello
+`);
+
+	expect(
+		stringifyMarkdownFrontmatter(parsed, {
+			draft: false,
+			pageId: "123",
+		}),
+	).toBe(`---
+title: Hello
+draft: false
+pageId: "123"
+---
+# Hello
+`);
+});
+
+test("omits empty frontmatter when no data is present", () => {
+	expect(stringifyMarkdownFrontmatter({ data: {}, content: "# Hello" }, {})).toBe("# Hello\n");
+});

--- a/packages/lib/src/MarkdownFrontmatter.ts
+++ b/packages/lib/src/MarkdownFrontmatter.ts
@@ -16,13 +16,12 @@ export function parseMarkdownFrontmatter(fileContent: string): MarkdownFrontmatt
 	const frontmatterStart = openingDelimiter[0].length;
 	const remainingContent = fileContent.slice(frontmatterStart);
 	const closingDelimiter = delimiterPattern.exec(remainingContent);
+	if (!closingDelimiter) {
+		return { data: {}, content: fileContent };
+	}
 
-	const frontmatterContent = closingDelimiter
-		? remainingContent.slice(0, closingDelimiter.index)
-		: remainingContent;
-	const content = closingDelimiter
-		? remainingContent.slice(closingDelimiter.index + closingDelimiter[0].length)
-		: "";
+	const frontmatterContent = remainingContent.slice(0, closingDelimiter.index);
+	const content = remainingContent.slice(closingDelimiter.index + closingDelimiter[0].length);
 
 	return {
 		data: parseFrontmatterData(frontmatterContent),
@@ -52,10 +51,18 @@ function parseFrontmatterData(frontmatterContent: string): Record<string, unknow
 		return {};
 	}
 
-	const parsedData: unknown = parseYaml(frontmatterContent);
+	const parsedData = parseFrontmatterYaml(frontmatterContent);
 	if (parsedData && typeof parsedData === "object" && !Array.isArray(parsedData)) {
 		return parsedData as Record<string, unknown>;
 	}
 
 	return {};
+}
+
+function parseFrontmatterYaml(frontmatterContent: string): unknown {
+	try {
+		return parseYaml(frontmatterContent);
+	} catch {
+		return {};
+	}
 }

--- a/packages/lib/src/MarkdownFrontmatter.ts
+++ b/packages/lib/src/MarkdownFrontmatter.ts
@@ -1,0 +1,61 @@
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+export type MarkdownFrontmatter = {
+	data: Record<string, unknown>;
+	content: string;
+};
+
+const delimiterPattern = /(?:^|\r?\n)---[ \t]*(?:\r?\n|$)/;
+
+export function parseMarkdownFrontmatter(fileContent: string): MarkdownFrontmatter {
+	const openingDelimiter = /^---[ \t]*(?:\r?\n|$)/.exec(fileContent);
+	if (!openingDelimiter) {
+		return { data: {}, content: fileContent };
+	}
+
+	const frontmatterStart = openingDelimiter[0].length;
+	const remainingContent = fileContent.slice(frontmatterStart);
+	const closingDelimiter = delimiterPattern.exec(remainingContent);
+
+	const frontmatterContent = closingDelimiter
+		? remainingContent.slice(0, closingDelimiter.index)
+		: remainingContent;
+	const content = closingDelimiter
+		? remainingContent.slice(closingDelimiter.index + closingDelimiter[0].length)
+		: "";
+
+	return {
+		data: parseFrontmatterData(frontmatterContent),
+		content,
+	};
+}
+
+export function stringifyMarkdownFrontmatter(
+	fileContent: MarkdownFrontmatter,
+	data: Record<string, unknown>,
+): string {
+	const updatedData = { ...fileContent.data, ...data };
+	const frontmatter = stringifyYaml(updatedData).trim();
+	const content = fileContent.content.endsWith("\n")
+		? fileContent.content
+		: `${fileContent.content}\n`;
+
+	if (!frontmatter || frontmatter === "{}") {
+		return content;
+	}
+
+	return `---\n${frontmatter}\n---\n${content}`;
+}
+
+function parseFrontmatterData(frontmatterContent: string): Record<string, unknown> {
+	if (frontmatterContent.replace(/^\s*#[^\n]+/gm, "").trim() === "") {
+		return {};
+	}
+
+	const parsedData: unknown = parseYaml(frontmatterContent);
+	if (parsedData && typeof parsedData === "object" && !Array.isArray(parsedData)) {
+		return parsedData as Record<string, unknown>;
+	}
+
+	return {};
+}

--- a/packages/lib/src/MarkdownWorkspace.ts
+++ b/packages/lib/src/MarkdownWorkspace.ts
@@ -1,7 +1,6 @@
 import { FileSystem } from "effect/FileSystem";
 import { Path } from "effect/Path";
 import { Console, Context, Effect, Layer } from "effect";
-import matter from "gray-matter";
 import { lookup } from "mime-types";
 import {
 	ConfluencePerPageAllValues,
@@ -9,6 +8,7 @@ import {
 	conniePerPageConfig,
 } from "./ConniePageConfig";
 import { runEffect } from "./effects";
+import { parseMarkdownFrontmatter, stringifyMarkdownFrontmatter } from "./MarkdownFrontmatter";
 import { ConfluenceSettings, ConfluenceSettingsService } from "./Settings";
 
 interface MarkdownContent {
@@ -85,10 +85,7 @@ export function makeMarkdownWorkspaceEffect(
 		const getFileContent = (absoluteFilePath: string): Effect.Effect<MarkdownContent, Error> =>
 			Effect.gen(function* () {
 				const fileContent = yield* fs.readFileString(absoluteFilePath, "utf-8");
-				const parsed = yield* Effect.try({
-					try: () => matter(fileContent),
-					catch: toError,
-				});
+				const parsed = parseMarkdownFrontmatter(fileContent);
 
 				return {
 					data: parsed.data,
@@ -144,7 +141,7 @@ export function makeMarkdownWorkspaceEffect(
 					}
 				}
 
-				const updatedData = matter.stringify(fileContent, fm);
+				const updatedData = stringifyMarkdownFrontmatter(fileContent, fm);
 				yield* fs.writeFileString(actualAbsoluteFilePath, updatedData);
 			}).pipe(Effect.mapError(toError));
 

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -122,6 +122,54 @@ test("keeps explicit false values from config providers", async () => {
 	expect(settings.contentRoot).toBe(expectedContentRoot);
 });
 
+test("parses boolean CLI values passed as separate arguments", async () => {
+	const { settings, expectedContentRoot } = await runEffect(
+		Effect.gen(function* () {
+			const path = yield* Path;
+			const contentRoot = "docs";
+			const runtimeEnvironment = makeRuntimeEnvironment({
+				argv: [
+					"node",
+					"markdown-confluence",
+					"--baseUrl",
+					"https://cli.example.atlassian.net",
+					"--parentId",
+					"cli-parent",
+					"--userName",
+					"cli-user@example.com",
+					"--apiToken",
+					"cli-token",
+					"--enableFolder",
+					"docs",
+					"--contentRoot",
+					contentRoot,
+					"--fh",
+					"false",
+				],
+				cwd: ".",
+				env: {},
+			});
+			const settings = yield* loadConfluenceSettingsEffect().pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						NodeFileSystem.layer,
+						NodePath.layer,
+						Layer.succeed(RuntimeEnvironmentService, runtimeEnvironment),
+					),
+				),
+			);
+
+			return {
+				settings,
+				expectedContentRoot: `${contentRoot}${path.sep}`,
+			};
+		}),
+	);
+
+	expect(settings.firstHeadingPageTitle).toBe(false);
+	expect(settings.contentRoot).toBe(expectedContentRoot);
+});
+
 function makeRuntimeEnvironment({
 	argv,
 	cwd,

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -1,7 +1,6 @@
 import { FileSystem } from "effect/FileSystem";
 import { Path } from "effect/Path";
 import { Config, ConfigProvider, Effect, Layer } from "effect";
-import yargs from "yargs";
 import {
 	MarkdownConfluencePlatform,
 	runEffect,
@@ -11,6 +10,14 @@ import {
 import { ConfluenceSettings, ConfluenceSettingsService, DEFAULT_SETTINGS } from "./Settings";
 
 const CONFLUENCE_SETTINGS_KEYS = Object.keys(DEFAULT_SETTINGS) as (keyof ConfluenceSettings)[];
+
+type ArgumentDefinition = {
+	name: string;
+	aliases?: string[];
+	type: "boolean" | "string";
+};
+
+type ArgumentValue = boolean | string | undefined;
 
 export const confluenceSettingsConfig = Config.all({
 	confluenceBaseUrl: Config.string("confluenceBaseUrl"),
@@ -133,15 +140,12 @@ function getConfigPath(
 	cwd: string,
 	path: Path,
 ): string {
-	return yargs([...argv])
-		.option("config", {
-			alias: "c",
-			describe: "Path to the config file",
-			type: "string",
-			default: envConfigPath ?? path.join(cwd, ".markdown-confluence.json"),
-			demandOption: false,
-		})
-		.parseSync().config;
+	const options = parseArgumentValues(argv, [{ name: "config", aliases: ["c"], type: "string" }]);
+	const config = options["config"];
+
+	return typeof config === "string"
+		? config
+		: (envConfigPath ?? path.join(cwd, ".markdown-confluence.json"));
 }
 
 function makeConfigFileProvider(
@@ -194,64 +198,83 @@ function makeEnvironmentProvider(
 }
 
 function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.ConfigProvider {
-	const options = yargs([...argv])
-		.usage("Usage: $0 [options]")
-		.option("baseUrl", {
-			alias: "b",
-			describe: "Confluence base URL",
-			type: "string",
-			demandOption: false,
-		})
-		.option("parentId", {
-			alias: "p",
-			describe: "Confluence parent ID",
-			type: "string",
-			demandOption: false,
-		})
-		.option("userName", {
-			alias: "u",
-			describe: "Atlassian user name",
-			type: "string",
-			demandOption: false,
-		})
-		.option("apiToken", {
-			describe: "Atlassian API token",
-			type: "string",
-			demandOption: false,
-		})
-		.option("enableFolder", {
-			alias: "f",
-			describe: "Folder enable to publish",
-			type: "string",
-			demandOption: false,
-		})
-		.option("contentRoot", {
-			alias: "cr",
-			describe:
-				"Root to search for files to publish. All files must be part of this directory.",
-			type: "string",
-			demandOption: false,
-		})
-		.option("firstHeaderPageTitle", {
-			alias: "fh",
-			describe:
-				"Replace page title with first header element when 'connie-title' isn't specified.",
-			type: "boolean",
-			demandOption: false,
-		})
-		.parseSync();
+	const options = parseArgumentValues(argv, [
+		{ name: "baseUrl", aliases: ["b"], type: "string" },
+		{ name: "parentId", aliases: ["p"], type: "string" },
+		{ name: "userName", aliases: ["u"], type: "string" },
+		{ name: "apiToken", type: "string" },
+		{ name: "enableFolder", aliases: ["f"], type: "string" },
+		{ name: "contentRoot", aliases: ["cr"], type: "string" },
+		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
+	]);
 
 	return ConfigProvider.fromUnknown(
 		compactRecord({
-			confluenceBaseUrl: options.baseUrl,
-			confluenceParentId: options.parentId,
-			atlassianUserName: options.userName,
-			atlassianApiToken: options.apiToken,
-			folderToPublish: options.enableFolder,
-			contentRoot: options.contentRoot,
-			firstHeadingPageTitle: options.firstHeaderPageTitle ? true : undefined,
+			confluenceBaseUrl: options["baseUrl"],
+			confluenceParentId: options["parentId"],
+			atlassianUserName: options["userName"],
+			atlassianApiToken: options["apiToken"],
+			folderToPublish: options["enableFolder"],
+			contentRoot: options["contentRoot"],
+			firstHeadingPageTitle: options["firstHeaderPageTitle"],
 		}),
 	);
+}
+
+function parseArgumentValues(
+	argv: readonly string[],
+	definitions: ArgumentDefinition[],
+): Record<string, ArgumentValue> {
+	const definitionsByFlag = new Map<string, ArgumentDefinition>();
+
+	for (const definition of definitions) {
+		definitionsByFlag.set(`--${definition.name}`, definition);
+		for (const alias of definition.aliases ?? []) {
+			definitionsByFlag.set(`--${alias}`, definition);
+			definitionsByFlag.set(`-${alias}`, definition);
+		}
+	}
+
+	const parsed: Record<string, ArgumentValue> = {};
+	for (let index = 2; index < argv.length; index += 1) {
+		const rawArgument = argv[index];
+		if (!rawArgument || rawArgument === "--") {
+			break;
+		}
+
+		const equalsIndex = rawArgument.indexOf("=");
+		const flag = equalsIndex >= 0 ? rawArgument.slice(0, equalsIndex) : rawArgument;
+		const inlineValue = equalsIndex >= 0 ? rawArgument.slice(equalsIndex + 1) : undefined;
+		const definition = definitionsByFlag.get(flag);
+		if (!definition) {
+			continue;
+		}
+
+		if (definition.type === "boolean") {
+			parsed[definition.name] = parseBooleanArgument(inlineValue);
+			continue;
+		}
+
+		const value = inlineValue ?? argv[index + 1];
+		if (value === undefined || value.startsWith("-")) {
+			continue;
+		}
+
+		parsed[definition.name] = value;
+		if (inlineValue === undefined) {
+			index += 1;
+		}
+	}
+
+	return parsed;
+}
+
+function parseBooleanArgument(value: string | undefined): boolean {
+	if (value === undefined) {
+		return true;
+	}
+
+	return !["0", "false", "no", "off"].includes(value.toLowerCase());
 }
 
 function pickConfluenceSettings(config: Record<string, unknown>): Partial<ConfluenceSettings> {
@@ -275,7 +298,7 @@ function compactRecord<T extends Record<string, unknown>>(record: T): Record<str
 	const compacted: Record<string, string> = {};
 
 	for (const [key, value] of Object.entries(record)) {
-		if (value) {
+		if (value !== undefined && value !== "") {
 			compacted[key] = String(value);
 		}
 	}

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -251,7 +251,16 @@ function parseArgumentValues(
 		}
 
 		if (definition.type === "boolean") {
-			parsed[definition.name] = parseBooleanArgument(inlineValue);
+			const nextValue = inlineValue === undefined ? argv[index + 1] : undefined;
+			const usesSeparateValue =
+				inlineValue === undefined && nextValue !== undefined && !nextValue.startsWith("-");
+
+			parsed[definition.name] = parseBooleanArgument(
+				inlineValue ?? (usesSeparateValue ? nextValue : undefined),
+			);
+			if (usesSeparateValue) {
+				index += 1;
+			}
 			continue;
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
       markdown-it-table:
         specifier: ^4.1.1
         version: 4.1.1
@@ -146,9 +149,6 @@ importers:
       '@types/spark-md5':
         specifier: ^3.0.5
         version: 3.0.5
-      markdown-it:
-        specifier: ^14.1.1
-        version: 14.1.1
 
   packages/mermaid-electron-renderer:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       image-size:
         specifier: ^2.0.2
         version: 2.0.2
@@ -133,9 +130,9 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
-      yargs:
-        specifier: 18.0.0
-        version: 18.0.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/lodash-es':
         specifier: ^4.17.12
@@ -149,9 +146,6 @@ importers:
       '@types/spark-md5':
         specifier: ^3.0.5
         version: 3.0.5
-      '@types/yargs':
-        specifier: ^17.0.35
-        version: 17.0.35
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -1297,12 +1291,6 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.35':
-    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
-
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
@@ -1489,9 +1477,6 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1639,10 +1624,6 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -2010,11 +1991,6 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -2032,10 +2008,6 @@ packages:
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
-
-  extend-shallow@2.0.1:
-    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
-    engines: {node: '>=0.10.0'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -2159,10 +2131,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
-    engines: {node: '>=6.0'}
-
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -2244,10 +2212,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-extendable@0.1.1:
-    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
-    engines: {node: '>=0.10.0'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -2272,10 +2236,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -2309,10 +2269,6 @@ packages:
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
-
-  kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
@@ -2823,10 +2779,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  section-matter@1.0.0:
-    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
-    engines: {node: '>=4'}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2899,9 +2851,6 @@ packages:
   spark-md5@3.0.2:
     resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -2930,10 +2879,6 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
-
-  strip-bom-string@1.0.0:
-    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
-    engines: {node: '>=0.10.0'}
 
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
@@ -3190,17 +3135,9 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -4281,12 +4218,6 @@ snapshots:
     dependencies:
       '@types/node': 25.8.0
 
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.35':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
-
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 25.8.0
@@ -4407,10 +4338,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -4551,12 +4478,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
 
   cluster-key-slot@1.1.2: {}
 
@@ -4936,8 +4857,6 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  esprima@4.0.1: {}
-
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
@@ -4998,10 +4917,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  extend-shallow@2.0.1:
-    dependencies:
-      is-extendable: 0.1.1
 
   extract-zip@2.0.1:
     dependencies:
@@ -5123,13 +5038,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.2
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
-
   hachure-fill@0.5.2: {}
 
   has-symbols@1.1.0: {}
@@ -5208,8 +5116,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-extendable@0.1.1: {}
-
   is-fullwidth-code-point@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -5223,11 +5129,6 @@ snapshots:
   js-md4@0.3.2: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -5250,8 +5151,6 @@ snapshots:
       commander: 8.3.0
 
   khroma@2.1.0: {}
-
-  kind-of@6.0.3: {}
 
   kubernetes-types@1.30.0: {}
 
@@ -5798,11 +5697,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  section-matter@1.0.0:
-    dependencies:
-      extend-shallow: 2.0.1
-      kind-of: 6.0.3
-
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -5888,8 +5782,6 @@ snapshots:
 
   spark-md5@3.0.2: {}
 
-  sprintf-js@1.0.3: {}
-
   standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
@@ -5924,8 +5816,6 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
-
-  strip-bom-string@1.0.0: {}
 
   strip-final-newline@4.0.0: {}
 
@@ -6154,8 +6044,6 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
-  yargs-parser@22.0.0: {}
-
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -6165,15 +6053,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add AGENTS.md with the repo tooling decisions: Node 24.15.0, pnpm, and Vite+ workflows
- Pin active GitHub Actions Vite+ setup steps to Node 24.15.0
- Replace gray-matter with a local YAML frontmatter module and remove direct yargs usage from lib settings parsing

## Validation
- PUPPETEER_SKIP_DOWNLOAD=true vp env exec --node 24 -- vp install --frozen-lockfile
- vp env exec --node 24 -- vp run check
- vp env exec --node 24 -- vp run fmt:check
- vp env exec --node 24 -- vp test run
- vp env exec --node 24 -- vp run build
- Workflow YAML parse check

## Note
- vp env exec --node 24 -- vp run -r build:docker was attempted locally, but Docker daemon is not running in this environment.