### PR TITLE
fix: add vitest runner dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@stryker-mutator/core": "9.6.1",
 		"@stryker-mutator/typescript-checker": "9.6.1",
 		"@types/node": "^25.9.0",
+		"@vitest/runner": "4.1.5",
 		"effect": "4.0.0-beta.66",
 		"husky": "^9.1.7",
 		"oxlint": "1.63.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@types/node':
         specifier: ^25.9.0
         version: 25.9.0
+      '@vitest/runner':
+        specifier: 4.1.5
+        version: 4.1.5
       effect:
         specifier: 4.0.0-beta.66
         version: 4.0.0-beta.66
@@ -1312,6 +1315,15 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@voidzero-dev/vite-plus-core@0.1.21':
     resolution: {integrity: sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA==}
@@ -2626,6 +2638,9 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -2945,6 +2960,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -4285,13 +4304,28 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 25.9.0
     optional: true
 
   '@upsetjs/venn.js@2.0.0':
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.9.0)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
@@ -5544,6 +5578,8 @@ snapshots:
 
   path-to-regexp@0.1.13: {}
 
+  pathe@2.0.3: {}
+
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
@@ -5948,6 +5984,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
 


### PR DESCRIPTION
Add @vitest/runner to the root devDependencies so @effect/vitest can resolve its internal runner import during build and test runs.

Validated with:
-  RUN  /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner


 Test Files  11 passed | 1 skipped (12)
      Tests  42 passed | 1 skipped (43)
   Start at  18:44:26
   Duration  3.16s (transform 1.59s, setup 0ms, import 17.99s, tests 418ms, environment 1ms)
- ~/packages/lib$ vp exec tsc --noEmit ⊘ cache disabled

~/packages/lib$ vp build ⊘ cache disabled
vite v8.0.11 building client environment for production...
[2Ktransforming...✓ 29 modules transformed.
rendering chunks...
computing gzip size...
dist/index.js  66.73 kB │ gzip: 19.50 kB │ map: 221.63 kB

✓ built in 43ms

~/packages/lib$ vp exec tsc --emitDeclarationOnly ⊘ cache disabled
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFToMarkdown.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFToMarkdown.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/isEqual.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/isEqual.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/AdfEqual.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/AdfEqual.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/effects/index.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/effects/index.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConfluenceClient.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConfluenceClient.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/Settings.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/Settings.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/media.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/media.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/callout.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/callout.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/wikilinks.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/wikilinks.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/index.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownTransformer/index.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/CodeBlockLanguageMap.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/CodeBlockLanguageMap.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConfluenceUrlParser.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConfluenceUrlParser.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MdToADF.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MdToADF.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConniePageConfig.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConniePageConfig.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownFrontmatter.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownFrontmatter.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownWorkspace.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/MarkdownWorkspace.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/Attachments.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/Attachments.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/types.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/types.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/ImageUploaderPlugin.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/ImageUploaderPlugin.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/MermaidRendererPlugin.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/MermaidRendererPlugin.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/index.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ADFProcessingPlugins/index.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConfluenceErrors.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/ConfluenceErrors.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/TreeConfluence.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/TreeConfluence.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/FolderFile.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/FolderFile.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/TreeLocal.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/TreeLocal.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/Publisher.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/Publisher.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/AdfProcessing.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/AdfProcessing.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/SettingsConfig.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/SettingsConfig.d.ts.map
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/index.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/lib/dist/index.d.ts.map

~/packages/mermaid-puppeteer-renderer$ vp exec tsc --noEmit ⊘ cache disabled
~/packages/mermaid-electron-renderer$ vp exec tsc --noEmit ⊘ cache disabled

~/packages/mermaid-electron-renderer$ vp build ⊘ cache disabled

~/packages/mermaid-puppeteer-renderer$ vp build ⊘ cache disabled
vite v8.0.11 building client environment for production...
[2Ktransforming...✓ 2 modules transformed.
rendering chunks...
computing gzip size...
dist/index.js  2.64 kB │ gzip: 1.31 kB │ map: 6.00 kB

✓ built in 23ms

~/packages/mermaid-electron-renderer$ vp exec tsc --emitDeclarationOnly ⊘ cache disabled
vite v8.0.11 building client environment for production...
[2Ktransforming...✓ 2 modules transformed.
rendering chunks...
computing gzip size...
dist/index.js  1.77 kB │ gzip: 0.86 kB │ map: 4.11 kB

✓ built in 20ms

~/packages/mermaid-puppeteer-renderer$ vp exec tsc --emitDeclarationOnly ⊘ cache disabled
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/mermaid-electron-renderer/dist/index.d.ts
TSFILE: /Users/andrewmcclenaghan/dev/markdown-confluence/markdown-confluence-fix-vitest-runner/packages/mermaid-electron-renderer/dist/index.d.ts.map

~/packages/obsidian$ vp exec tsc --noEmit ⊘ cache disabled

~/packages/cli$ vp exec tsc --noEmit ⊘ cache disabled

~/packages/obsidian$ vp build ⊘ cache disabled
vite v8.0.11 building client environment for production...
[2Ktransforming...✓ 3423 modules transformed.

~/packages/cli$ vp build ⊘ cache disabled
rendering chunks...
vite v8.0.11 building client environment for production...
[2Ktransforming...computing gzip size...
dist/main.js  5,045.39 kB │ gzip: 1,370.89 kB

✓ built in 1.48s

✓ 2451 modules transformed.
rendering chunks...
computing gzip size...
dist/index.js  7,711.98 kB │ gzip: 1,824.78 kB │ map: 24,296.86 kB

✓ built in 2.61s

---
vp run: 0/13 cache hit (0%). (Run `vp run --last-details` for full details)