### PR TITLE
feat: allow publish result notices in Obsidian

### DIFF
--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -96,6 +96,18 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Show Publish Results Dialog")
+			.setDesc("Show a dialog after publishing finishes")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.showPublishResultsModal)
+					.onChange(async (value) => {
+						this.plugin.settings.showPublishResultsModal = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
 			.setName("Mermaid Diagram Theme")
 			.setDesc("Pick the theme to apply to mermaid diagrams")
 			.addDropdown((dropdown) => {

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -24,6 +24,7 @@ import { ObsidianPlatformLive } from "./effects/ObsidianPlatform";
 import type { Mermaid } from "mermaid";
 
 export interface ObsidianPluginSettings extends ConfluenceUploadSettings.ConfluenceSettings {
+	showPublishResultsModal: boolean;
 	mermaidTheme:
 		| "match-obsidian"
 		| "light-obsidian"
@@ -219,27 +220,9 @@ export default class ConfluencePlugin extends Plugin {
 			this.isSyncing = true;
 			try {
 				const stats = await this.doPublish();
-				new CompletedModal(this.app, {
-					uploadResults: stats,
-				}).open();
+				this.showPublishResults(stats);
 			} catch (error) {
-				if (error instanceof Error) {
-					new CompletedModal(this.app, {
-						uploadResults: {
-							errorMessage: error.message,
-							failedFiles: [],
-							filesUploadResult: [],
-						},
-					}).open();
-				} else {
-					new CompletedModal(this.app, {
-						uploadResults: {
-							errorMessage: JSON.stringify(error),
-							failedFiles: [],
-							filesUploadResult: [],
-						},
-					}).open();
-				}
+				this.showPublishError(error);
 			} finally {
 				this.isSyncing = false;
 			}
@@ -284,28 +267,10 @@ export default class ConfluencePlugin extends Plugin {
 						this.isSyncing = true;
 						this.doPublish(this.activeLeafPath(this.workspace))
 							.then((stats) => {
-								new CompletedModal(this.app, {
-									uploadResults: stats,
-								}).open();
+								this.showPublishResults(stats);
 							})
 							.catch((error) => {
-								if (error instanceof Error) {
-									new CompletedModal(this.app, {
-										uploadResults: {
-											errorMessage: error.message,
-											failedFiles: [],
-											filesUploadResult: [],
-										},
-									}).open();
-								} else {
-									new CompletedModal(this.app, {
-										uploadResults: {
-											errorMessage: JSON.stringify(error),
-											failedFiles: [],
-											filesUploadResult: [],
-										},
-									}).open();
-								}
+								this.showPublishError(error);
 							})
 							.finally(() => {
 								this.isSyncing = false;
@@ -326,28 +291,10 @@ export default class ConfluencePlugin extends Plugin {
 						this.isSyncing = true;
 						this.doPublish()
 							.then((stats) => {
-								new CompletedModal(this.app, {
-									uploadResults: stats,
-								}).open();
+								this.showPublishResults(stats);
 							})
 							.catch((error) => {
-								if (error instanceof Error) {
-									new CompletedModal(this.app, {
-										uploadResults: {
-											errorMessage: error.message,
-											failedFiles: [],
-											filesUploadResult: [],
-										},
-									}).open();
-								} else {
-									new CompletedModal(this.app, {
-										uploadResults: {
-											errorMessage: JSON.stringify(error),
-											failedFiles: [],
-											filesUploadResult: [],
-										},
-									}).open();
-								}
+								this.showPublishError(error);
 							})
 							.finally(() => {
 								this.isSyncing = false;
@@ -472,7 +419,7 @@ export default class ConfluencePlugin extends Plugin {
 		this.settings = Object.assign(
 			{},
 			ConfluenceUploadSettings.DEFAULT_SETTINGS,
-			{ mermaidTheme: "match-obsidian" },
+			{ mermaidTheme: "match-obsidian", showPublishResultsModal: true },
 			await this.loadData(),
 		);
 	}
@@ -494,6 +441,25 @@ export default class ConfluencePlugin extends Plugin {
 			),
 		);
 	}
+
+	private showPublishError(error: unknown) {
+		this.showPublishResults({
+			errorMessage: toError(error).message,
+			failedFiles: [],
+			filesUploadResult: [],
+		});
+	}
+
+	private showPublishResults(uploadResults: UploadResults) {
+		if (this.settings.showPublishResultsModal) {
+			new CompletedModal(this.app, {
+				uploadResults,
+			}).open();
+			return;
+		}
+
+		new Notice(getPublishResultsMessage(uploadResults), 10000);
+	}
 }
 
 function toError(error: unknown): Error {
@@ -502,4 +468,16 @@ function toError(error: unknown): Error {
 	}
 
 	return new Error(typeof error === "string" ? error : JSON.stringify(error));
+}
+
+function getPublishResultsMessage(uploadResults: UploadResults): string {
+	if (uploadResults.errorMessage) {
+		return `Confluence publish failed: ${uploadResults.errorMessage}`;
+	}
+
+	if (uploadResults.failedFiles.length > 0) {
+		return `Confluence publish finished: ${uploadResults.filesUploadResult.length} succeeded, ${uploadResults.failedFiles.length} failed.`;
+	}
+
+	return `Confluence publish finished: ${uploadResults.filesUploadResult.length} file(s) processed.`;
 }


### PR DESCRIPTION
## Summary
- add an Obsidian setting to keep the publish results dialog or use a notice after publish
- route ribbon, current-file, and publish-all completion through the same result display helpers
- keep the existing modal behavior as the default for existing users

## Validation
- vp check --fix --no-error-on-unmatched-pattern packages/obsidian/src/main.ts packages/obsidian/src/ConfluenceSettingTab.ts
- npm run build

Closes #628