### PR TITLE
fix: handle callout wikilink images

### DIFF
--- a/packages/lib/src/MarkdownTransformer/media.ts
+++ b/packages/lib/src/MarkdownTransformer/media.ts
@@ -3,6 +3,7 @@ export type Token = {
 	type: string;
 	content: string;
 	level: number;
+	nesting: number;
 	tag: string;
 	attrs?: string[][];
 	children?: unknown[];
@@ -22,7 +23,14 @@ export interface MdState {
 function createRule() {
 	const regx = /!\[[^\]]*\]\([^)]+\)|!\[[^\]]*\]\[[^\]]*]|!\[\[.*\..*]]/g;
 	const referenceImageRegex = /^!\[(?<alt>[^\]]*)]\[(?<label>[^\]]*)]$/;
-	const validParentTokens = ["th_open", "td_open", "list_item_open"];
+	const validParentTokens = [
+		"blockquote_open",
+		"expand_open",
+		"panel_open",
+		"th_open",
+		"td_open",
+		"list_item_open",
+	];
 
 	/**
 	 * This function looks for strings that matches ![description](url) inside Inline-tokens.
@@ -151,21 +159,16 @@ function createRule() {
 					let previousToken = arr[cursor];
 					let subTree: Token[] = [];
 
-					while (
-						previousToken &&
-						previousToken.level > 0 &&
-						validParentTokens.indexOf(previousToken.type) === -1
-					) {
+					while (previousToken && previousToken.nesting === 1) {
+						if (validParentTokens.indexOf(previousToken.type) !== -1) {
+							break;
+						}
+
 						openingTokens.unshift(previousToken);
 						cursor--;
 						previousToken = arr[cursor];
 					}
-
-					if (previousToken && validParentTokens.indexOf(previousToken.type) === -1) {
-						openingTokens.unshift(previousToken);
-					} else {
-						cursor++;
-					}
+					cursor++;
 
 					const closingTokens = openingTokens
 						.map(

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -258,3 +258,37 @@ test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 	const adfFile = convertMDtoADF(markdown, settings);
 	expect(adfFile).toMatchSnapshot();
 });
+
+test("parses callout with adjacent wikilink image", () => {
+	const markdown: MarkdownFile = {
+		folderName: "callouts",
+		absoluteFilePath: "/path/to/callouts.md",
+		fileName: "callouts.md",
+		contents: [
+			"> [!info] Title",
+			"> Request the following three groups, so three separate requests:",
+			"> \t`group1`",
+			"> \t`group2`",
+			"> \t`group3`",
+			"> ",
+			"> [Request Ticket](https://somelink.internal/123)",
+			"> ![[Pasted image 20231006155212.png|400]]",
+		].join("\n"),
+		pageTitle: "Callouts",
+		frontmatter: {},
+	};
+	const settings: ConfluenceSettings = {
+		confluenceBaseUrl: "https://example.com",
+		confluenceParentId: "asdf",
+		atlassianUserName: "asdf@asdf.com",
+		atlassianApiToken: "asdfasdf",
+		folderToPublish: ".",
+		contentRoot: "./",
+		firstHeadingPageTitle: false,
+	};
+
+	const adfFile = convertMDtoADF(markdown, settings);
+
+	expect(adfFile.contents.content?.[0]?.type).toBe("panel");
+	expect(JSON.stringify(adfFile.contents)).toContain("file://Pasted image 20231006155212.png");
+});


### PR DESCRIPTION
## Summary
- prevent the media splitter from collecting previous sibling tokens inside callouts
- keep callout containers intact when splitting wikilink images out of inline content
- add a regression test for the issue #576 callout image repro

## Validation
- vp test run packages/lib/src/MdToADF.test.ts --testNamePattern "parses callout with adjacent wikilink image"
- vp test run packages/lib/src/MdToADF.test.ts
- npm run check
- npm test
- npm run build
- git diff --check

Closes #576