### PR TITLE
feat: expand ADF conversion coverage

### DIFF
--- a/packages/lib/src/ADFToMarkdown.test.ts
+++ b/packages/lib/src/ADFToMarkdown.test.ts
@@ -80,10 +80,6 @@ const ADFToMDTest = {
 						timestamp: "1683244800000",
 					},
 				},
-				{
-					text: " ",
-					type: "text",
-				},
 			],
 		},
 		{

--- a/packages/lib/src/ADFToMarkdown.ts
+++ b/packages/lib/src/ADFToMarkdown.ts
@@ -107,6 +107,9 @@ function renderADFContent(
 		case "orderedList": {
 			return renderChildrenResult;
 		}
+		case "decisionList": {
+			return renderChildrenResult;
+		}
 		case "listItem": {
 			let prefix = "- ";
 			switch (parent.type) {
@@ -165,6 +168,13 @@ function renderADFContent(
 				element.attrs && element.attrs["state"] ? element.attrs["state"] : "TODO";
 			const taskStateMarkdown = taskState === "TODO" ? " " : "x";
 			return `- [${taskStateMarkdown}] ${renderChildrenResult}\n`;
+		}
+		case "decisionItem": {
+			return `- ${renderChildrenResult}\n`;
+		}
+		case "date": {
+			const timestamp = element.attrs && element.attrs["timestamp"];
+			return renderDate(timestamp);
 		}
 		case "emoji": {
 			const emojiId = element.attrs && element.attrs["id"] ? element.attrs["id"] : undefined;
@@ -232,6 +242,16 @@ function renderTable(element: ADFEntity) {
 
 function renderCodeBlock(language: string, code: string) {
 	return `\`\`\`${language} \n${code}\n\`\`\``;
+}
+
+function renderDate(timestamp: unknown) {
+	const timestampNumber =
+		typeof timestamp === "string" || typeof timestamp === "number" ? Number(timestamp) : NaN;
+	if (!Number.isFinite(timestampNumber)) {
+		return "";
+	}
+
+	return new Date(timestampNumber).toISOString().slice(0, 10);
 }
 
 function renderChildren(element: ADFEntity) {

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -259,6 +259,63 @@ test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 	expect(adfFile).toMatchSnapshot();
 });
 
+test("converts markdown task list items to ADF task nodes", () => {
+	const markdown: MarkdownFile = {
+		folderName: "tasks",
+		absoluteFilePath: "/path/to/tasks.md",
+		fileName: "tasks.md",
+		contents: "- [ ] Draft the page\n- [x] Publish it",
+		pageTitle: "Tasks",
+		frontmatter: {},
+	};
+	const settings: ConfluenceSettings = {
+		confluenceBaseUrl: "https://example.com",
+		confluenceParentId: "asdf",
+		atlassianUserName: "asdf@asdf.com",
+		atlassianApiToken: "asdfasdf",
+		folderToPublish: ".",
+		contentRoot: "./",
+		firstHeadingPageTitle: false,
+	};
+
+	const adfFile = convertMDtoADF(markdown, settings);
+
+	expect(adfFile.contents.content?.[0]).toEqual({
+		type: "taskList",
+		attrs: {
+			localId: "task-list-1",
+		},
+		content: [
+			{
+				type: "taskItem",
+				attrs: {
+					localId: "task-1",
+					state: "TODO",
+				},
+				content: [
+					{
+						type: "text",
+						text: "Draft the page",
+					},
+				],
+			},
+			{
+				type: "taskItem",
+				attrs: {
+					localId: "task-2",
+					state: "DONE",
+				},
+				content: [
+					{
+						type: "text",
+						text: "Publish it",
+					},
+				],
+			},
+		],
+	});
+});
+
 test("parses callout with adjacent wikilink image", () => {
 	const markdown: MarkdownFile = {
 		folderName: "callouts",

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -15,6 +15,20 @@ const frontmatterRegex = /^\s*?---\n([\s\S]*?)\n---\s*/g;
 const transformer = new MarkdownTransformer();
 const serializer = new JSONTransformer();
 
+type AdfNode = {
+	type: string;
+	attrs?: Record<string, unknown>;
+	content?: AdfNode[];
+	text?: string;
+	marks?: unknown[];
+	[key: string]: unknown;
+};
+
+type TaskListCounters = {
+	taskItem: number;
+	taskList: number;
+};
+
 export function stripMarkdownHtmlComments(markdown: string): string {
 	const lines = markdown.split("\n");
 	const strippedLines: string[] = [];
@@ -108,7 +122,8 @@ export function parseMarkdownToADF(markdown: string, confluenceBaseUrl: string) 
 }
 
 function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
-	const olivia = traverse(adf, {
+	const adfWithTaskLists = transformMarkdownTaskLists(adf as AdfNode) as JSONDocNode;
+	const olivia = traverse(adfWithTaskLists, {
 		text: (node, _parent) => {
 			if (_parent.parent?.node?.type == "listItem" && node.text) {
 				node.text = node.text
@@ -218,6 +233,138 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 	}
 
 	return olivia as JSONDocNode;
+}
+
+function transformMarkdownTaskLists(
+	node: AdfNode,
+	counters: TaskListCounters = { taskItem: 1, taskList: 1 },
+): AdfNode {
+	const content = node.content;
+	if (!content) {
+		return node;
+	}
+
+	const transformedContent = content.flatMap((child) => {
+		const transformedChild = transformMarkdownTaskLists(child, counters);
+		if (transformedChild.type === "bulletList") {
+			return splitBulletListTaskItems(transformedChild, counters);
+		}
+		return [transformedChild];
+	});
+
+	return {
+		...node,
+		content: transformedContent,
+	};
+}
+
+function splitBulletListTaskItems(bulletList: AdfNode, counters: TaskListCounters): AdfNode[] {
+	const result: AdfNode[] = [];
+	let bulletItems: AdfNode[] = [];
+	let taskItems: AdfNode[] = [];
+
+	const flushBulletItems = () => {
+		if (bulletItems.length === 0) {
+			return;
+		}
+		result.push({
+			...bulletList,
+			content: bulletItems,
+		});
+		bulletItems = [];
+	};
+
+	const flushTaskItems = () => {
+		if (taskItems.length === 0) {
+			return;
+		}
+		result.push({
+			type: "taskList",
+			attrs: {
+				localId: `task-list-${counters.taskList}`,
+			},
+			content: taskItems,
+		});
+		counters.taskList += 1;
+		taskItems = [];
+	};
+
+	for (const listItem of bulletList.content ?? []) {
+		const taskItem = convertListItemToTaskItem(listItem, counters);
+		if (taskItem) {
+			flushBulletItems();
+			taskItems.push(taskItem);
+			continue;
+		}
+
+		flushTaskItems();
+		bulletItems.push(listItem);
+	}
+
+	flushTaskItems();
+	flushBulletItems();
+
+	return result;
+}
+
+function convertListItemToTaskItem(
+	listItem: AdfNode,
+	counters: TaskListCounters,
+): AdfNode | undefined {
+	if (listItem.type !== "listItem" || listItem.content?.length !== 1) {
+		return undefined;
+	}
+
+	const paragraph = listItem.content[0];
+	if (!paragraph || paragraph.type !== "paragraph") {
+		return undefined;
+	}
+
+	const paragraphContent = paragraph.content ?? [];
+	const firstChild = paragraphContent[0];
+	if (!firstChild || firstChild.type !== "text" || typeof firstChild.text !== "string") {
+		return undefined;
+	}
+
+	const taskMarker = parseTaskMarker(firstChild.text);
+	if (!taskMarker) {
+		return undefined;
+	}
+
+	const firstTaskContent = taskMarker.text
+		? [
+				{
+					...firstChild,
+					text: taskMarker.text,
+				},
+			]
+		: [];
+
+	const taskItem = {
+		type: "taskItem",
+		attrs: {
+			localId: `task-${counters.taskItem}`,
+			state: taskMarker.state,
+		},
+		content: [...firstTaskContent, ...paragraphContent.slice(1)],
+	};
+	counters.taskItem += 1;
+
+	return taskItem;
+}
+
+function parseTaskMarker(
+	textContent: string,
+): { state: "TODO" | "DONE"; text: string } | undefined {
+	const markerMatch = textContent.match(/^\[( |x|X)\]\s?(.*)$/u);
+	if (!markerMatch) {
+		return undefined;
+	}
+
+	return {
+		state: markerMatch[1] === " " ? "TODO" : "DONE",
+		text: markerMatch[2] ?? "",
+	};
 }
 
 export function convertMDtoADF(file: MarkdownFile, settings: ConfluenceSettings): LocalAdfFile {

--- a/packages/lib/src/__snapshots__/ADFToMarkdown.test.ts.snap
+++ b/packages/lib/src/__snapshots__/ADFToMarkdown.test.ts.snap
@@ -5,12 +5,11 @@ exports[`ADF To Markdown Test 1`] = `
 
 [https://andymac4182.atlassian.net/wiki/spaces/T2/pages/8290305](https://andymac4182.atlassian.net/wiki/spaces/T2/pages/8290305) 
 
-\`\`\`adf 
-{"type":"decisionList","attrs":{"localId":"39becc7a-48c3-4e2d-a6bc-35648d6689a2"},"content":[{"type":"decisionItem","attrs":{"state":"DECIDED","localId":"95268b83-2fc0-4801-9b4f-e5c42cc530e6"},"content":[{"text":"Decision to track","type":"text"}]},{"type":"decisionItem","attrs":{"state":"DECIDED","localId":"564ab974-e6fe-48d2-a144-507f5ec30906"},"content":[{"text":"Testing Decision 2","type":"text"}]}]}
-\`\`\`
-\`\`\`adf 
-{"type":"paragraph","content":[{"type":"date","attrs":{"timestamp":"1683244800000"}},{"text":" ","type":"text"}]}
-\`\`\`
+- Decision to track
+- Testing Decision 2
+
+2023-05-05
+
 | **Testing** | **Testing 2** | **Testing 3** |
 | ----------- | ------------- | ------------- |
 | Row 1       | Row 1.2       | Row 1.3       |

--- a/packages/lib/src/__snapshots__/MdToADF.test.ts.snap
+++ b/packages/lib/src/__snapshots__/MdToADF.test.ts.snap
@@ -1505,34 +1505,45 @@ exports[`parses 'tasks.md' 1`] = `
             ],
             "type": "listItem",
           },
+        ],
+        "type": "bulletList",
+      },
+      {
+        "attrs": {
+          "localId": "task-list-1",
+        },
+        "content": [
           {
+            "attrs": {
+              "localId": "task-1",
+              "state": "TODO",
+            },
             "content": [
               {
-                "content": [
-                  {
-                    "text": "🔲 Unchecked item",
-                    "type": "text",
-                  },
-                ],
-                "type": "paragraph",
+                "text": "Unchecked item",
+                "type": "text",
               },
             ],
-            "type": "listItem",
+            "type": "taskItem",
           },
           {
+            "attrs": {
+              "localId": "task-2",
+              "state": "DONE",
+            },
             "content": [
               {
-                "content": [
-                  {
-                    "text": "✅ Checked item",
-                    "type": "text",
-                  },
-                ],
-                "type": "paragraph",
+                "text": "Checked item",
+                "type": "text",
               },
             ],
-            "type": "listItem",
+            "type": "taskItem",
           },
+        ],
+        "type": "taskList",
+      },
+      {
+        "content": [
           {
             "content": [
               {


### PR DESCRIPTION
## Summary
- convert Markdown task-list bullets into ADF `taskList` / `taskItem` nodes, including mixed-list splitting
- render ADF decision lists and dates back to readable Markdown instead of raw ADF fallback blocks
- add deterministic converter coverage and update snapshots

Refs #260.
Refs #264.

## Validation
- `vp install --frozen-lockfile`
- `vp run fmt:check`
- `vp run check`
- `vp test run`
- `vp run --filter @markdown-confluence/lib build`