### PR TITLE
fix: upload Mermaid attachments reliably

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -51,6 +51,7 @@
 		"@effect/platform-node": "4.0.0-beta.70",
 		"confluence.js": "^2.1.0",
 		"effect": "4.0.0-beta.70",
+		"form-data": "^4.0.4",
 		"formdata-node": "^6.0.3",
 		"glob": "^13.0.6",
 		"image-size": "^2.0.2",

--- a/packages/lib/src/Attachments.test.ts
+++ b/packages/lib/src/Attachments.test.ts
@@ -40,7 +40,14 @@ test("fully decodes file URL components before reading binary files", async () =
 	);
 
 	expect(result?.status).toBe("uploaded");
-	expect(getUploadedAttachment(uploadRequests).contentType).toBe("image/png");
+	const uploadRequestBody = getUploadRequestBody(uploadRequests);
+	expect(uploadRequestBody).toContain('name="file"; filename="');
+	expect(uploadRequestBody).toContain('file#name.png"');
+	expect(uploadRequestBody).toContain("Content-Type: image/png");
+	expect(uploadRequestBody).toContain('name="minorEdit"\r\n\r\nfalse');
+	expect(uploadRequestBody).toContain('name="comment"\r\n\r\n');
+	expect(uploadRequestBody).not.toContain('name="minorEdit"; filename=');
+	expect(uploadRequestBody).not.toContain('name="comment"; filename=');
 });
 
 test("derives upload buffer content type from the filename", async () => {
@@ -57,7 +64,7 @@ test("derives upload buffer content type from the filename", async () => {
 	);
 
 	expect(result?.status).toBe("uploaded");
-	expect(getUploadedAttachment(uploadRequests).contentType).toBe("text/plain");
+	expect(getUploadRequestBody(uploadRequests)).toContain("Content-Type: text/plain");
 });
 
 class TestMarkdownWorkspace implements MarkdownWorkspace {
@@ -83,42 +90,35 @@ class TestMarkdownWorkspace implements MarkdownWorkspace {
 
 function makeConfluenceClient(uploadRequests: unknown[]): RequiredConfluenceClient {
 	return {
-		contentAttachments: {
-			createOrUpdateAttachments: async (attachmentDetails: unknown) => {
-				uploadRequests.push(attachmentDetails);
-				return {
-					results: [
-						{
-							extensions: {
-								fileId: "file-id",
-							},
-							container: {
-								id: "page-id",
-							},
+		sendRequest: async (request: unknown) => {
+			uploadRequests.push(request);
+			return {
+				results: [
+					{
+						extensions: {
+							fileId: "file-id",
 						},
-					],
-				};
-			},
+						container: {
+							id: "page-id",
+						},
+					},
+				],
+			};
 		},
 	} as unknown as RequiredConfluenceClient;
 }
 
-function getUploadedAttachment(uploadRequests: unknown[]): { contentType: string } {
+function getUploadRequestBody(uploadRequests: unknown[]): string {
 	const request = uploadRequests[0] as
 		| {
-				attachments: Array<{
-					contentType: string;
-				}>;
+				data: {
+					getBuffer(): Buffer;
+				};
 		  }
 		| undefined;
 	if (!request) {
 		throw new Error("Missing upload request");
 	}
 
-	const attachment = request.attachments[0];
-	if (!attachment) {
-		throw new Error("Missing upload attachment");
-	}
-
-	return attachment;
+	return request.data.getBuffer().toString();
 }

--- a/packages/lib/src/Attachments.ts
+++ b/packages/lib/src/Attachments.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import FormData from "form-data";
 import SparkMD5 from "spark-md5";
 import { lookup } from "mime-types";
 import { runEffect } from "./effects";
@@ -25,6 +26,17 @@ export type CurrentAttachments = Record<
 		collectionName: string;
 	}
 >;
+
+interface AttachmentUploadResponse {
+	results: {
+		extensions: {
+			fileId: string;
+		};
+		container: {
+			id: string;
+		};
+	}[];
+}
 
 function toArrayBuffer(contents: Uint8Array): ArrayBuffer {
 	return Uint8Array.from(contents).buffer;
@@ -81,22 +93,15 @@ export function uploadBufferEffect(
 			};
 		}
 
-		const attachmentDetails = {
-			id: pageId,
-			attachments: [
-				{
-					file: fileBuffer,
-					filename: uploadFilename,
-					minorEdit: false,
-					comment: currentFileMd5,
-					contentType: resolveContentType(uploadFilename, contentType),
-				},
-			],
-		};
-
 		const attachmentResponse = yield* Effect.tryPromise({
 			try: () =>
-				confluenceClient.contentAttachments.createOrUpdateAttachments(attachmentDetails),
+				uploadAttachment(confluenceClient, {
+					pageId,
+					fileBuffer,
+					uploadFilename,
+					contentType: resolveContentType(uploadFilename, contentType),
+					comment: currentFileMd5,
+				}),
 			catch: identity,
 		});
 
@@ -174,24 +179,15 @@ export function uploadFileEffect(
 				};
 			}
 
-			const attachmentDetails = {
-				id: pageId,
-				attachments: [
-					{
-						file: imageBuffer,
-						filename: uploadFilename,
-						minorEdit: false,
-						comment: currentFileMd5,
-						contentType: testing.mimeType,
-					},
-				],
-			};
-
 			const attachmentResponse = yield* Effect.tryPromise({
 				try: () =>
-					confluenceClient.contentAttachments.createOrUpdateAttachments(
-						attachmentDetails,
-					),
+					uploadAttachment(confluenceClient, {
+						pageId,
+						fileBuffer: imageBuffer,
+						uploadFilename,
+						contentType: testing.mimeType,
+						comment: currentFileMd5,
+					}),
 				catch: identity,
 			});
 
@@ -232,6 +228,36 @@ function getImageSize(buffer: Buffer): { width?: number; height?: number } {
 
 function resolveContentType(uploadFilename: string, contentType: string | undefined): string {
 	return contentType ?? (lookup(uploadFilename) || "application/octet-stream");
+}
+
+function uploadAttachment(
+	confluenceClient: RequiredConfluenceClient,
+	attachment: {
+		pageId: string;
+		fileBuffer: Buffer;
+		uploadFilename: string;
+		contentType: string;
+		comment: string;
+	},
+): Promise<AttachmentUploadResponse> {
+	const formData = new FormData();
+	formData.append("file", attachment.fileBuffer, {
+		filename: attachment.uploadFilename,
+		contentType: attachment.contentType,
+	});
+	formData.append("minorEdit", "false");
+	formData.append("comment", attachment.comment);
+
+	return confluenceClient.sendRequest<AttachmentUploadResponse>({
+		url: `/api/content/${attachment.pageId}/child/attachment`,
+		method: "PUT",
+		headers: {
+			"X-Atlassian-Token": "no-check",
+			...formData.getHeaders(),
+		},
+		params: {},
+		data: formData,
+	});
 }
 
 function identity(error: unknown): unknown {

--- a/packages/lib/src/ConfluenceClient.ts
+++ b/packages/lib/src/ConfluenceClient.ts
@@ -1,6 +1,6 @@
-import { Api } from "confluence.js";
+import { Api, Client } from "confluence.js";
 
-export interface RequiredConfluenceClient {
+export interface RequiredConfluenceClient extends Client {
 	content: Api.Content;
 	space: Api.Space;
 	contentAttachments: Api.ContentAttachments;

--- a/packages/lib/src/Publisher.test.ts
+++ b/packages/lib/src/Publisher.test.ts
@@ -5,14 +5,20 @@ import { ConfluenceClient } from "confluence.js";
 import { Effect } from "effect";
 import { orderMarks } from "./AdfEqual";
 import { ConfluencePerPageAllValues } from "./ConniePageConfig";
-import { Publisher } from "./Publisher";
+import { RequiredConfluenceClient } from "./ConfluenceClient";
+import { ConfluenceAdfFile, Publisher, UploadAdfFileResult } from "./Publisher";
 import { loadConfluenceSettings } from "./SettingsConfig";
 import {
 	ChartData,
 	MermaidRenderer,
 	MermaidRendererPlugin,
 } from "./ADFProcessingPlugins/MermaidRendererPlugin";
-import { RuntimeEnvironmentLive, RuntimeEnvironmentService, runEffect } from "./effects";
+import {
+	MarkdownConfluencePlatform,
+	RuntimeEnvironmentLive,
+	RuntimeEnvironmentService,
+	runEffect,
+} from "./effects";
 import {
 	BinaryFile,
 	FilesToUpload,
@@ -29,6 +35,11 @@ const confluenceIntegrationTestsEnabled = Effect.runSync(
 	}).pipe(Effect.provide(RuntimeEnvironmentLive)),
 );
 const confluenceIntegrationTest = confluenceIntegrationTestsEnabled ? test : test.skip;
+
+const pngBytes = Buffer.from(
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+	"base64",
+);
 
 const markdownTestCases: MarkdownFile[] = [
 	{
@@ -212,8 +223,17 @@ const markdownTestCases: MarkdownFile[] = [
 ];
 
 class TestMermaidRenderer implements MermaidRenderer {
-	async captureMermaidCharts(_charts: ChartData[]): Promise<Map<string, Buffer>> {
+	constructor(private readonly imageBuffer?: Buffer) {}
+
+	async captureMermaidCharts(charts: ChartData[]): Promise<Map<string, Buffer>> {
 		const capturedCharts = new Map<string, Buffer>();
+		if (!this.imageBuffer) {
+			return capturedCharts;
+		}
+
+		for (const chart of charts) {
+			capturedCharts.set(chart.name, this.imageBuffer);
+		}
 		return capturedCharts;
 	}
 }
@@ -248,6 +268,137 @@ class InMemoryMarkdownWorkspace implements MarkdownWorkspace {
 	): Effect.Effect<false | BinaryFile, Error> {
 		return Effect.fail(new Error("Method not implemented."));
 	}
+}
+
+test("refreshes page version after rendering and uploading Mermaid attachments", async () => {
+	const contentUpdates: unknown[] = [];
+	const uploadRequests: unknown[] = [];
+	const confluenceClient = {
+		content: {
+			getContentById: async () => ({
+				version: {
+					number: 7,
+				},
+			}),
+			updateContent: async (details: unknown) => {
+				contentUpdates.push(details);
+				return {};
+			},
+		},
+		contentAttachments: {
+			getAttachments: async () => ({ results: [] }),
+		},
+		contentLabels: {
+			getLabelsForContent: async () => ({ results: [] }),
+		},
+		sendRequest: async (request: unknown) => {
+			uploadRequests.push(request);
+			return {
+				results: [
+					{
+						extensions: {
+							fileId: "file-id",
+						},
+						container: {
+							id: "page-id",
+						},
+					},
+				],
+			};
+		},
+	} as unknown as RequiredConfluenceClient;
+
+	const publisher = new Publisher(
+		{
+			confluenceBaseUrl: "https://example.atlassian.net",
+		} as never,
+		confluenceClient,
+		[new MermaidRendererPlugin(new TestMermaidRenderer(pngBytes))],
+	);
+	(publisher as unknown as { myAccountId: string }).myAccountId = "me";
+
+	const updatePageContentEffect = (
+		publisher as unknown as {
+			updatePageContentEffect(
+				ancestors: string[],
+				pageVersionNumber: number,
+				existingPageData: {
+					adfContent: unknown;
+					pageTitle: string;
+					ancestors: { id: string }[];
+					contentType: string;
+				},
+				adfFile: ConfluenceAdfFile,
+				lastUpdatedBy: string,
+			): Effect.Effect<
+				UploadAdfFileResult,
+				unknown,
+				MarkdownConfluencePlatform | MarkdownWorkspaceService
+			>;
+		}
+	).updatePageContentEffect.bind(publisher);
+
+	const result = await runEffect(
+		updatePageContentEffect(
+			[],
+			3,
+			{
+				adfContent: {
+					type: "doc",
+					version: 1,
+					content: [],
+				},
+				pageTitle: "Mermaid Page",
+				ancestors: [],
+				contentType: "page",
+			},
+			{
+				folderName: "",
+				absoluteFilePath: "/page.md",
+				fileName: "page.md",
+				contents: {
+					type: "doc",
+					version: 1,
+					content: [
+						{
+							type: "codeBlock",
+							attrs: {
+								language: "mermaid",
+							},
+							content: [
+								{
+									type: "text",
+									text: "flowchart LR\nA-->B",
+								},
+							],
+						},
+					],
+				},
+				pageTitle: "Mermaid Page",
+				frontmatter: {},
+				tags: [],
+				dontChangeParentPageId: false,
+				pageId: "page-id",
+				spaceKey: "SPACE",
+				pageUrl: "https://example.atlassian.net/wiki/spaces/SPACE/pages/page-id/",
+				contentType: "page",
+				blogPostDate: undefined,
+			},
+			"me",
+		).pipe(Effect.provideService(MarkdownWorkspaceService, new InMemoryMarkdownWorkspace([]))),
+	);
+
+	expect(result.imageResult).toBe("updated");
+	expect(uploadRequests.length).toBe(1);
+	expect(getContentUpdate(contentUpdates).version.number).toBe(8);
+});
+
+function getContentUpdate(contentUpdates: unknown[]): { version: { number: number } } {
+	const update = contentUpdates[0] as { version: { number: number } } | undefined;
+	if (!update) {
+		throw new Error("Missing content update");
+	}
+	return update;
 }
 
 confluenceIntegrationTest(

--- a/packages/lib/src/Publisher.ts
+++ b/packages/lib/src/Publisher.ts
@@ -327,10 +327,17 @@ export class Publisher {
 				!isEqual(existingPageDetails, newPageDetails)
 			) {
 				result.contentResult = "updated";
+				const currentPageVersionNumber = processedAttachment
+					? yield* getCurrentPageVersionNumberEffect(
+							confluenceClient,
+							adfFile.pageId,
+							pageVersionNumber,
+						)
+					: pageVersionNumber;
 				const updateContentDetails = {
 					...newPageDetails,
 					id: adfFile.pageId,
-					version: { number: pageVersionNumber + 1 },
+					version: { number: currentPageVersionNumber + 1 },
 					body: {
 						// eslint-disable-next-line @typescript-eslint/naming-convention
 						atlas_doc_format: {
@@ -425,6 +432,25 @@ function trackProcessedAttachments(
 				.uploadBufferEffect(uploadFilename, fileBuffer, contentType)
 				.pipe(Effect.tap((uploaded) => Effect.sync(() => onProcessedAttachment(uploaded)))),
 	};
+}
+
+function getCurrentPageVersionNumberEffect(
+	confluenceClient: RequiredConfluenceClient,
+	pageId: string,
+	fallbackVersionNumber: number,
+): Effect.Effect<number, unknown, never> {
+	return Effect.gen(function* () {
+		const currentPage = yield* Effect.tryPromise({
+			try: () =>
+				confluenceClient.content.getContentById({
+					id: pageId,
+					expand: ["version"],
+				}),
+			catch: identity,
+		});
+
+		return currentPage.version?.number ?? fallbackVersionNumber;
+	});
 }
 
 function identity(error: unknown): unknown {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
+      form-data:
+        specifier: ^4.0.4
+        version: 4.0.5
       formdata-node:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- send Confluence attachment uploads with a local multipart request so minorEdit/comment are text fields, not extra file parts
- keep attachment hash comments for unchanged-upload detection
- refresh the page version after rendered Mermaid/image attachment uploads before updating ADF content

Closes #648

## Test plan

- [x] vp install --frozen-lockfile
- [x] vp test run packages/lib/src/Attachments.test.ts packages/lib/src/Publisher.test.ts
- [x] vp run check
- [x] vp run build
- [x] vp test run