### PR TITLE
fix: improve markdown content fidelity

### DIFF
--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -28,6 +28,48 @@ test("resolves wikilinks that include a path under the publish root", () => {
 	);
 });
 
+test("resolves relative markdown links from the current file directory", () => {
+	const pages = [
+		createNode({
+			fileName: "README.md",
+			absoluteFilePath: "Confluence Pages/docs/guidebook/README.md",
+			contents: docWithLink("Context", "wikilinks:context/README"),
+		}),
+		createNode({
+			fileName: "README.md",
+			absoluteFilePath: "Confluence Pages/docs/guidebook/context/README.md",
+			pageId: "222222",
+			spaceKey: "SPACE",
+		}),
+	];
+
+	prepareAdfToUpload(pages, testSettings);
+
+	const link = pages[0]!.file.contents.content[0]!.content![0] as TextDefinition;
+	expect(link.marks?.[0]?.attrs?.href).toBe(
+		"https://example.atlassian.net/wiki/spaces/SPACE/pages/222222",
+	);
+});
+
+test("resolves same-page heading wikilinks to the current page", () => {
+	const pages = [
+		createNode({
+			fileName: "source.md",
+			absoluteFilePath: "Confluence Pages/source.md",
+			pageId: "111111",
+			spaceKey: "SPACE",
+			contents: docWithLink("Overview", "wikilinks:#Overview"),
+		}),
+	];
+
+	prepareAdfToUpload(pages, testSettings);
+
+	const link = pages[0]!.file.contents.content[0]!.content![0] as TextDefinition;
+	expect(link.marks?.[0]?.attrs?.href).toBe(
+		"https://example.atlassian.net/wiki/spaces/SPACE/pages/111111#Overview",
+	);
+});
+
 function docWithLink(text: string, href: string): JSONDocNode {
 	return {
 		version: 1,

--- a/packages/lib/src/AdfProcessing.ts
+++ b/packages/lib/src/AdfProcessing.ts
@@ -51,7 +51,7 @@ export function prepareAdfToUpload(
 		}
 
 		result = processWikilinkToActualLink(
-			confluenceNode.file.fileName,
+			confluenceNode.file,
 			result,
 			fileToPageIdMap,
 			settings,
@@ -556,7 +556,7 @@ function extractInlineComments(adf: JSONDocNode) {
 }
 
 function processWikilinkToActualLink(
-	currentFileName: string,
+	currentFile: ConfluenceAdfFile,
 	adf: JSONDocNode,
 	fileToPageIdMap: Record<string, ConfluenceAdfFile>,
 	settings: ConfluenceSettings,
@@ -578,9 +578,10 @@ function processWikilinkToActualLink(
 					const pathName = normalizeWikilinkPath(decodeURI(wikilinkUrl.pathname));
 					const pathNameParts = pathName.split("/");
 					const displayFileName = pathNameParts[pathNameParts.length - 1] ?? pathName;
-					const pagename =
-						wikilinkUrl.pathname !== "" ? `${pathName}.md` : currentFileName;
-					const linkPage = fileToPageIdMap[pagename];
+					const linkPage =
+						wikilinkUrl.pathname !== ""
+							? findLinkedPage(pathName, currentFile, fileToPageIdMap, settings)
+							: currentFile;
 
 					if (linkPage) {
 						const confluenceUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${linkPage.spaceKey}/pages/${linkPage.pageId}${wikilinkUrl.hash}`;
@@ -644,8 +645,84 @@ function getWikilinkLookupKeys(file: ConfluenceAdfFile, settings: ConfluenceSett
 	return keys;
 }
 
+function findLinkedPage(
+	pathName: string,
+	currentFile: ConfluenceAdfFile,
+	fileToPageIdMap: Record<string, ConfluenceAdfFile>,
+	settings: ConfluenceSettings,
+) {
+	for (const candidate of getWikilinkPathCandidates(pathName, currentFile, settings)) {
+		const page = fileToPageIdMap[candidate];
+		if (page) {
+			return page;
+		}
+	}
+
+	return undefined;
+}
+
+function getWikilinkPathCandidates(
+	pathName: string,
+	currentFile: ConfluenceAdfFile,
+	settings: ConfluenceSettings,
+) {
+	const pathCandidates = [
+		withMarkdownExtension(pathName),
+		normalizePathSegments(pathName),
+		joinPaths(dirname(currentFile.absoluteFilePath), withMarkdownExtension(pathName)),
+		joinPaths(dirname(currentFile.absoluteFilePath), pathName),
+	];
+	const folderToPublish = normalizePathSegments(settings.folderToPublish);
+
+	if (folderToPublish && folderToPublish !== ".") {
+		pathCandidates.push(
+			...pathCandidates
+				.filter((candidate) => candidate.startsWith(`${folderToPublish}/`))
+				.map((candidate) => candidate.slice(folderToPublish.length + 1)),
+		);
+	}
+
+	return [...new Set(pathCandidates.filter(Boolean))];
+}
+
+function withMarkdownExtension(pathName: string) {
+	return /\.(md|markdown)$/i.test(pathName) ? normalizePathSegments(pathName) : `${pathName}.md`;
+}
+
+function dirname(pathName: string) {
+	const normalizedPath = normalizePathSegments(pathName);
+	const parts = normalizedPath.split("/");
+	parts.pop();
+	return parts.join("/");
+}
+
+function joinPaths(...paths: string[]) {
+	return normalizePathSegments(paths.filter(Boolean).join("/"));
+}
+
 function normalizeWikilinkPath(value: string) {
-	return value.replace(/\\/g, "/").replace(/^\/+/, "");
+	return normalizePathSegments(value);
+}
+
+function normalizePathSegments(value: string) {
+	const segments: string[] = [];
+
+	for (const segment of value.replace(/\\/g, "/").replace(/^\/+/, "").split("/")) {
+		if (segment === "" || segment === ".") {
+			continue;
+		}
+		if (segment === "..") {
+			if (segments.length > 0 && segments.at(-1) !== "..") {
+				segments.pop();
+			} else {
+				segments.push(segment);
+			}
+			continue;
+		}
+		segments.push(segment);
+	}
+
+	return segments.join("/");
 }
 
 function removeEmptyProperties(adf: JSONDocNode) {

--- a/packages/lib/src/MarkdownTransformer/highlight.ts
+++ b/packages/lib/src/MarkdownTransformer/highlight.ts
@@ -1,0 +1,41 @@
+import MarkdownIt from "markdown-it";
+import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
+
+function highlight(state: StateInline, silent: boolean): boolean {
+	if (state.src.slice(state.pos, state.pos + 2) !== "==") {
+		return false;
+	}
+
+	const contentStart = state.pos + 2;
+	const contentEnd = state.src.indexOf("==", contentStart);
+
+	if (contentEnd === -1 || contentEnd === contentStart) {
+		return false;
+	}
+
+	if (silent) {
+		return true;
+	}
+
+	const max = state.posMax;
+	const oldPos = state.pos;
+
+	state.push("strong_open", "strong", 1);
+	state.pos = contentStart;
+	state.posMax = contentEnd;
+	state.md.inline.tokenize(state);
+	state.push("strong_close", "strong", -1);
+
+	state.pos = contentEnd + 2;
+	state.posMax = max;
+
+	if (state.pos <= oldPos) {
+		return false;
+	}
+
+	return true;
+}
+
+export default function highlightPlugin(md: MarkdownIt): void {
+	md.inline.ruler.before("emphasis", "highlight", highlight);
+}

--- a/packages/lib/src/MarkdownTransformer/index.ts
+++ b/packages/lib/src/MarkdownTransformer/index.ts
@@ -8,6 +8,7 @@ import { Schema, Node as PMNode } from "@atlaskit/editor-prosemirror/model";
 import { markdownItMedia } from "./media";
 import myTokenizer from "./callout";
 import wikilinksPlugin from "./wikilinks";
+import highlightPlugin from "./highlight";
 
 interface Transformer<T> {
 	encode(node: PMNode): T;
@@ -160,6 +161,7 @@ export class MarkdownTransformer implements Transformer<Markdown> {
 		}
 
 		tokenizer.use(wikilinksPlugin);
+		tokenizer.use(highlightPlugin);
 
 		(["nodes", "marks"] as (keyof SchemaMapping)[]).forEach((key) => {
 			for (const idx in pmSchemaToMdMapping[key]) {

--- a/packages/lib/src/MarkdownTransformer/media.ts
+++ b/packages/lib/src/MarkdownTransformer/media.ts
@@ -21,7 +21,9 @@ export interface MdState {
 }
 
 function createRule() {
-	const regx = /!\[[^\]]*\]\([^)]+\)|!\[[^\]]*\]\[[^\]]*]|!\[\[.*\..*]]/g;
+	const imagePattern = String.raw`!\[[^\]]*\]\([^)]+\)|!\[[^\]]*\]\[[^\]]*]|!\[\[[^\]\n]*\.[^\]\n]*\]\]`;
+	const imageRegex = new RegExp(imagePattern);
+	const imageMatchRegex = new RegExp(imagePattern, "g");
 	const referenceImageRegex = /^!\[(?<alt>[^\]]*)]\[(?<label>[^\]]*)]$/;
 	const validParentTokens = [
 		"blockquote_open",
@@ -151,72 +153,64 @@ function createRule() {
 		};
 
 		let processedTokens: string[] = [];
-		const newTokens = State.tokens.reduce(
-			(tokens: Token[], token: Token, i: number, arr: Token[]) => {
-				if (token.type === "inline" && regx.test(token.content)) {
-					const openingTokens: Token[] = [];
-					let cursor = i - 1;
-					let previousToken = arr[cursor];
-					let subTree: Token[] = [];
+		const newTokens = State.tokens.reduce((tokens: Token[], token: Token) => {
+			if (token.type === "inline" && imageRegex.test(token.content)) {
+				const openingTokens: Token[] = [];
+				const precedingTokens = [...tokens];
+				let previousToken = precedingTokens.at(-1);
+				let subTree: Token[] = [];
 
-					while (previousToken && previousToken.nesting === 1) {
-						if (validParentTokens.indexOf(previousToken.type) !== -1) {
-							break;
-						}
-
-						openingTokens.unshift(previousToken);
-						cursor--;
-						previousToken = arr[cursor];
-					}
-					cursor++;
-
-					const closingTokens = openingTokens
-						.map(
-							(token) =>
-								new State.Token(
-									token.type.replace("_open", "_close"),
-									token.tag,
-									-1,
-								),
-						)
-						.reverse();
-
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					const matches = token.content.match(regx)!;
-					let inlineContentStack = token.content;
-					matches.forEach((match) => {
-						const start = inlineContentStack.indexOf(match);
-						const contentBefore = inlineContentStack.substr(0, start);
-						inlineContentStack = inlineContentStack.substr(start + match.length);
-
-						subTree = [
-							...subTree,
-							...createInlineTokens(contentBefore, openingTokens, closingTokens),
-							...createMediaTokens(match),
-						];
-					});
-
-					if (inlineContentStack.length) {
-						subTree = [
-							...subTree,
-							...createInlineTokens(inlineContentStack, openingTokens, closingTokens),
-						];
+				while (previousToken && previousToken.nesting === 1) {
+					if (validParentTokens.indexOf(previousToken.type) !== -1) {
+						break;
 					}
 
-					processedTokens = [...processedTokens, ...closingTokens.map((c) => c.type)];
-
-					tokens = [...tokens.slice(0, cursor), ...subTree];
-				} else if (processedTokens.indexOf(token.type) !== -1) {
-					// Ignore token if it's already processed
-					processedTokens.splice(processedTokens.indexOf(token.type), 1);
-				} else {
-					tokens.push(token);
+					openingTokens.unshift(previousToken);
+					precedingTokens.pop();
+					previousToken = precedingTokens.at(-1);
 				}
 
-				return tokens;
-			},
-			[],
-		);
+				const closingTokens = openingTokens
+					.map(
+						(token) =>
+							new State.Token(token.type.replace("_open", "_close"), token.tag, -1),
+					)
+					.reverse();
+
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				const matches = token.content.match(imageMatchRegex)!;
+				let inlineContentStack = token.content;
+				matches.forEach((match) => {
+					const start = inlineContentStack.indexOf(match);
+					const contentBefore = inlineContentStack.substr(0, start);
+					inlineContentStack = inlineContentStack.substr(start + match.length);
+
+					subTree = [
+						...subTree,
+						...createInlineTokens(contentBefore, openingTokens, closingTokens),
+						...createMediaTokens(match),
+					];
+				});
+
+				if (inlineContentStack.length) {
+					subTree = [
+						...subTree,
+						...createInlineTokens(inlineContentStack, openingTokens, closingTokens),
+					];
+				}
+
+				processedTokens = [...processedTokens, ...closingTokens.map((c) => c.type)];
+
+				tokens = [...precedingTokens, ...subTree];
+			} else if (processedTokens.indexOf(token.type) !== -1) {
+				// Ignore token if it's already processed
+				processedTokens.splice(processedTokens.indexOf(token.type), 1);
+			} else {
+				tokens.push(token);
+			}
+
+			return tokens;
+		}, []);
 
 		State.tokens = newTokens;
 		return true;

--- a/packages/lib/src/MarkdownTransformer/wikilinks.ts
+++ b/packages/lib/src/MarkdownTransformer/wikilinks.ts
@@ -35,7 +35,7 @@ export function wikilinks(state: StateInline): boolean {
 		headerStart > 0 ? headerStart : wikiLinkEnd,
 		aliasStart > 0 ? aliasStart - 1 : wikiLinkEnd,
 	);
-	const linkToPage = state.src.slice(pageNameStart, pageNameEnd);
+	const linkToPage = state.src.slice(pageNameStart, pageNameEnd).trim();
 
 	if (alias) {
 		state.pos = aliasStart;
@@ -141,7 +141,9 @@ function findLinkToHeader(
 	// restore old state
 	state.pos = oldPos;
 
-	const cleanHashFragment = hashFragment?.replace(/ /g, "-");
+	const cleanHashFragment = hashFragment
+		? `#${hashFragment.slice(1).trim().replace(/\s+/g, "-")}`
+		: undefined;
 	return { hashFragment: cleanHashFragment, headerStart, headerEnd };
 }
 

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -292,3 +292,104 @@ test("parses callout with adjacent wikilink image", () => {
 	expect(adfFile.contents.content?.[0]?.type).toBe("panel");
 	expect(JSON.stringify(adfFile.contents)).toContain("file://Pasted image 20231006155212.png");
 });
+
+test("parses multiple image paragraphs without dropping later images", () => {
+	const adfFile = convertMDtoADF(
+		createMarkdownFile(
+			[
+				"Intro",
+				"![First image](first.png)",
+				"",
+				"Middle",
+				"![Second image](second.png)",
+				"",
+				"Done",
+			].join("\n"),
+		),
+		testSettings,
+	);
+
+	const contents = JSON.stringify(adfFile.contents);
+	expect(contents).toContain("file://first.png");
+	expect(contents).toContain("file://second.png");
+	expect(contents).toContain("Done");
+});
+
+test("parses wikilink images adjacent to lists and headings", () => {
+	const adfFile = convertMDtoADF(
+		createMarkdownFile(
+			[
+				"- something",
+				"![[list-image.png]]",
+				"",
+				"### Header3",
+				"![[heading-image.png]]",
+			].join("\n"),
+		),
+		testSettings,
+	);
+
+	const contents = JSON.stringify(adfFile.contents);
+	expect(contents).toContain("file://list-image.png");
+	expect(contents).toContain("file://heading-image.png");
+});
+
+test("converts markdown highlights to bold text", () => {
+	const adfFile = convertMDtoADF(
+		createMarkdownFile("This is ==highlighted== text"),
+		testSettings,
+	);
+	const paragraph = adfFile.contents.content?.[0];
+	const highlightedText = paragraph?.content?.find((node) => node.text === "highlighted");
+
+	expect(highlightedText?.marks?.[0]?.type).toBe("strong");
+});
+
+test("normalizes local heading and relative markdown links", () => {
+	const adfFile = convertMDtoADF(
+		createMarkdownFile(
+			[
+				"[[#Overview |Overview of Feature]]",
+				"[[#How to Use|How to Use Feature]]",
+				"[Context](context/README.md#How%20to%20Use)",
+				"",
+				"# Overview",
+				"## How to use",
+			].join("\n"),
+		),
+		testSettings,
+	);
+	const links = JSON.stringify(adfFile.contents);
+
+	expect(links).toContain("wikilinks:#Overview");
+	expect(links).toContain("wikilinks:#How-to-use");
+	expect(links).toContain("wikilinks:context/README#How-to-use");
+	expect(links).not.toContain('"href":"#"');
+});
+
+test("keeps indented wikilink-like image text parseable", () => {
+	const adfFile = convertMDtoADF(createMarkdownFile("\t[[!image.png]]"), testSettings);
+
+	expect(adfFile.contents.content?.[0]?.type).toBe("codeBlock");
+});
+
+function createMarkdownFile(contents: string): MarkdownFile {
+	return {
+		folderName: "edge-cases",
+		absoluteFilePath: "/path/to/edge-cases.md",
+		fileName: "edge-cases.md",
+		contents,
+		pageTitle: "Edge Cases",
+		frontmatter: {},
+	};
+}
+
+const testSettings: ConfluenceSettings = {
+	confluenceBaseUrl: "https://example.com",
+	confluenceParentId: "asdf",
+	atlassianUserName: "asdf@asdf.com",
+	atlassianApiToken: "asdfasdf",
+	folderToPublish: ".",
+	contentRoot: "./",
+	firstHeadingPageTitle: false,
+};

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -108,6 +108,7 @@ export function parseMarkdownToADF(markdown: string, confluenceBaseUrl: string) 
 }
 
 function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
+	const headingFragments = collectHeadingFragments(adf);
 	const olivia = traverse(adf, {
 		text: (node, _parent) => {
 			if (_parent.parent?.node?.type == "listItem" && node.text) {
@@ -129,11 +130,20 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 				return node;
 			}
 
-			if (
-				node.marks[0].attrs["href"] === "" ||
-				(!isSafeUrl(node.marks[0].attrs["href"]) &&
-					!(node.marks[0].attrs["href"] as string).startsWith("wikilinks:") &&
-					!(node.marks[0].attrs["href"] as string).startsWith("mention:"))
+			const href = node.marks[0].attrs["href"];
+			if (typeof href !== "string") {
+				return node;
+			}
+
+			const markdownWikilinkHref = markdownLinkToWikilinkHref(href, headingFragments);
+			if (markdownWikilinkHref) {
+				node.marks[0].attrs["href"] = markdownWikilinkHref;
+			} else if (href.startsWith("wikilinks:#")) {
+				node.marks[0].attrs["href"] =
+					`wikilinks:${normalizeHashFragment(href.slice("wikilinks:".length), headingFragments)}`;
+			} else if (
+				href === "" ||
+				(!isSafeUrl(href) && !href.startsWith("wikilinks:") && !href.startsWith("mention:"))
 			) {
 				node.marks[0].attrs["href"] = "#";
 			}
@@ -178,7 +188,7 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 		},
 		codeBlock: (node, _parent) => {
 			if (!node || !node.attrs) {
-				return;
+				return node;
 			}
 
 			if (Object.keys(node.attrs).length === 0) {
@@ -218,6 +228,133 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 	}
 
 	return olivia as JSONDocNode;
+}
+
+function markdownLinkToWikilinkHref(
+	href: string,
+	headingFragments: Map<string, string>,
+): string | undefined {
+	if (href.startsWith("#")) {
+		return `wikilinks:${normalizeHashFragment(href, headingFragments)}`;
+	}
+
+	if (/^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith("//")) {
+		return undefined;
+	}
+
+	const hashIndex = href.indexOf("#");
+	const rawPath = hashIndex === -1 ? href : href.slice(0, hashIndex);
+	const rawHash = hashIndex === -1 ? "" : href.slice(hashIndex);
+	const pathWithoutQuery = rawPath.split("?")[0] ?? "";
+
+	if (!pathWithoutQuery) {
+		return rawHash
+			? `wikilinks:${normalizeHashFragment(rawHash, headingFragments)}`
+			: undefined;
+	}
+
+	const markdownPath = markdownPathToWikilinkPath(pathWithoutQuery);
+	if (!markdownPath) {
+		return undefined;
+	}
+
+	return `wikilinks:${markdownPath}${normalizeHashFragment(rawHash, headingFragments)}`;
+}
+
+function markdownPathToWikilinkPath(path: string): string | undefined {
+	const normalizedPath = normalizeMarkdownPath(path);
+
+	if (normalizedPath.endsWith("/")) {
+		return `${normalizedPath}README`;
+	}
+
+	if (/\.(md|markdown)$/i.test(normalizedPath)) {
+		return normalizedPath.replace(/\.(md|markdown)$/i, "");
+	}
+
+	return undefined;
+}
+
+function normalizeMarkdownPath(path: string): string {
+	const decodedPath = safeDecodeURI(path).replace(/\\/g, "/");
+	const segments: string[] = [];
+
+	for (const segment of decodedPath.split("/")) {
+		if (segment === "" || segment === ".") {
+			continue;
+		}
+		if (segment === "..") {
+			if (segments.length > 0 && segments.at(-1) !== "..") {
+				segments.pop();
+			} else {
+				segments.push(segment);
+			}
+			continue;
+		}
+		segments.push(segment);
+	}
+
+	return segments.join("/") + (decodedPath.endsWith("/") ? "/" : "");
+}
+
+function normalizeHashFragment(hash: string, headingFragments: Map<string, string>): string {
+	if (!hash) {
+		return "";
+	}
+
+	const hashText = safeDecodeURIComponent(hash.slice(1)).trim();
+	const headingFragment = headingFragments.get(normalizeHeadingLookupKey(hashText));
+	return headingFragment ?? `#${hashText.replace(/\s+/g, "-")}`;
+}
+
+function collectHeadingFragments(adf: JSONDocNode) {
+	const headingFragments = new Map<string, string>();
+
+	traverse(adf, {
+		heading: (node) => {
+			const headingText = collectText(node).trim();
+			if (headingText) {
+				headingFragments.set(
+					normalizeHeadingLookupKey(headingText),
+					`#${headingText.replace(/\s+/g, "-")}`,
+				);
+			}
+			return node;
+		},
+	});
+
+	return headingFragments;
+}
+
+function collectText(node: {
+	text?: string;
+	content?: Array<{ text?: string } | undefined>;
+}): string {
+	return (node.content ?? []).map((child) => child?.text ?? "").join("");
+}
+
+function normalizeHeadingLookupKey(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[^\w\s-]/g, "")
+		.replace(/\s+/g, "-");
+}
+
+function safeDecodeURI(value: string): string {
+	try {
+		return decodeURI(value);
+	} catch {
+		return value;
+	}
+}
+
+function safeDecodeURIComponent(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
 }
 
 export function convertMDtoADF(file: MarkdownFile, settings: ConfluenceSettings): LocalAdfFile {


### PR DESCRIPTION
## Summary

- Fix media token rewriting so multiple paragraphs with adjacent image references keep every image and following content instead of dropping earlier media nodes.
- Normalize same-page heading wikilinks and GitHub-style relative `.md` links into the existing Confluence page-link resolution flow, including README-style paths and current-file-relative targets.
- Parse `==highlight==` Markdown as bold text for Confluence output and keep indented wikilink-like image text parseable.

Closes #647.
Closes #424.
Closes #414.
Closes #387.
Closes #338.
Refs #623 because the issue lacks a concrete list sample, but this adds a deterministic list-adjacent image regression for the truncation class described across the related reports.

## Validation

- `vp env exec --node 24.15.0 vp install --frozen-lockfile`
- `vp env exec --node 24.15.0 vp test run`
- `vp env exec --node 24.15.0 vp run check`
- `vp env exec --node 24.15.0 vp run fmt:check`
- `vp env exec --node 24.15.0 vp run build`
