### PR TITLE
fix: validate Confluence settings

### DIFF
--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -10,6 +10,16 @@ export type ConfluenceSettings = {
 	firstHeadingPageTitle: boolean;
 };
 
+export type ConfluenceSettingsValidationIssue = {
+	field: keyof ConfluenceSettings;
+	message: string;
+};
+
+export type ConfluenceSettingsValidationResult = {
+	valid: boolean;
+	issues: ConfluenceSettingsValidationIssue[];
+};
+
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	confluenceBaseUrl: "",
 	confluenceParentId: "",
@@ -24,3 +34,82 @@ export class ConfluenceSettingsService extends Context.Service<
 	ConfluenceSettingsService,
 	ConfluenceSettings
 >()("@markdown-confluence/ConfluenceSettings") {}
+
+export function validateConfluenceSettings(
+	settings: ConfluenceSettings,
+): ConfluenceSettingsValidationResult {
+	const issues: ConfluenceSettingsValidationIssue[] = [];
+
+	addRequiredSettingIssue(issues, settings.confluenceBaseUrl, {
+		field: "confluenceBaseUrl",
+		message: "Confluence base URL is required",
+	});
+	addRequiredSettingIssue(issues, settings.confluenceParentId, {
+		field: "confluenceParentId",
+		message: "Confluence parent ID is required",
+	});
+	addRequiredSettingIssue(issues, settings.atlassianUserName, {
+		field: "atlassianUserName",
+		message: "Atlassian user name is required",
+	});
+	addRequiredSettingIssue(issues, settings.atlassianApiToken, {
+		field: "atlassianApiToken",
+		message: "Atlassian API token is required",
+	});
+	addRequiredSettingIssue(issues, settings.folderToPublish, {
+		field: "folderToPublish",
+		message: "Folder to publish is required",
+	});
+	addRequiredSettingIssue(issues, settings.contentRoot, {
+		field: "contentRoot",
+		message: "Content root is required",
+	});
+
+	const confluenceBaseUrl = settings.confluenceBaseUrl.trim();
+	if (confluenceBaseUrl) {
+		const parsedUrl = parseUrl(confluenceBaseUrl);
+		if (!parsedUrl) {
+			issues.push({
+				field: "confluenceBaseUrl",
+				message: "Confluence base URL must be a valid URL",
+			});
+		} else if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+			issues.push({
+				field: "confluenceBaseUrl",
+				message: "Confluence base URL must start with http:// or https://",
+			});
+		}
+
+		if (confluenceBaseUrl.endsWith("/")) {
+			issues.push({
+				field: "confluenceBaseUrl",
+				message: "Confluence base URL must not end with a slash",
+			});
+		}
+	}
+
+	return {
+		valid: issues.length === 0,
+		issues,
+	};
+}
+
+function addRequiredSettingIssue(
+	issues: ConfluenceSettingsValidationIssue[],
+	value: string,
+	issue: ConfluenceSettingsValidationIssue,
+) {
+	if (value.trim()) {
+		return;
+	}
+
+	issues.push(issue);
+}
+
+function parseUrl(value: string): URL | undefined {
+	try {
+		return new URL(value);
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -4,6 +4,7 @@ import { NodeFileSystem, NodePath } from "@effect/platform-node";
 import { afterEach, expect, test } from "@effect/vitest";
 import { ConfigProvider, Effect, Layer } from "effect";
 import { loadConfluenceSettingsEffect, parseConfluenceSettingsEffect } from "./SettingsConfig";
+import { type ConfluenceSettings, validateConfluenceSettings } from "./Settings";
 import { RuntimeEnvironment, RuntimeEnvironmentService, runEffect } from "./effects";
 
 let tmpRoot: string | undefined;
@@ -170,6 +171,41 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 	expect(settings.contentRoot).toBe(expectedContentRoot);
 });
 
+test("reports shared settings validation issues", () => {
+	const validationResult = validateConfluenceSettings({
+		...validSettings,
+		confluenceBaseUrl: "https://example.atlassian.net/",
+		atlassianApiToken: " ",
+	});
+
+	expect(validationResult).toEqual({
+		valid: false,
+		issues: [
+			{
+				field: "atlassianApiToken",
+				message: "Atlassian API token is required",
+			},
+			{
+				field: "confluenceBaseUrl",
+				message: "Confluence base URL must not end with a slash",
+			},
+		],
+	});
+});
+
+test("rejects invalid settings from config providers", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					...validSettings,
+					confluenceBaseUrl: "https://example.atlassian.net/",
+				}),
+			),
+		),
+	).rejects.toThrow("Confluence base URL must not end with a slash");
+});
+
 function makeRuntimeEnvironment({
 	argv,
 	cwd,
@@ -188,3 +224,13 @@ function makeRuntimeEnvironment({
 		exit: (code) => Effect.die(new Error(`Unexpected exit ${code}`)) as Effect.Effect<never>,
 	};
 }
+
+const validSettings: ConfluenceSettings = {
+	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceParentId: "file-parent",
+	atlassianUserName: "file-user@example.com",
+	atlassianApiToken: "file-token",
+	folderToPublish: "file-folder",
+	contentRoot: "docs",
+	firstHeadingPageTitle: false,
+};

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -7,7 +7,12 @@ import {
 	RuntimeEnvironment,
 	RuntimeEnvironmentService,
 } from "./effects";
-import { ConfluenceSettings, ConfluenceSettingsService, DEFAULT_SETTINGS } from "./Settings";
+import {
+	ConfluenceSettings,
+	ConfluenceSettingsService,
+	DEFAULT_SETTINGS,
+	validateConfluenceSettings,
+} from "./Settings";
 
 const CONFLUENCE_SETTINGS_KEYS = Object.keys(DEFAULT_SETTINGS) as (keyof ConfluenceSettings)[];
 
@@ -100,29 +105,12 @@ function validateConfluenceSettingsEffect(
 ): Effect.Effect<ConfluenceSettings, Error, Path> {
 	return Effect.gen(function* () {
 		const path = yield* Path;
+		const validationResult = validateConfluenceSettings(settings);
 
-		if (!settings.confluenceBaseUrl) {
-			return yield* Effect.fail(new Error("Confluence base URL is required"));
-		}
-
-		if (!settings.confluenceParentId) {
-			return yield* Effect.fail(new Error("Confluence parent ID is required"));
-		}
-
-		if (!settings.atlassianUserName) {
-			return yield* Effect.fail(new Error("Atlassian user name is required"));
-		}
-
-		if (!settings.atlassianApiToken) {
-			return yield* Effect.fail(new Error("Atlassian API token is required"));
-		}
-
-		if (!settings.folderToPublish) {
-			return yield* Effect.fail(new Error("Folder to publish is required"));
-		}
-
-		if (!settings.contentRoot) {
-			return yield* Effect.fail(new Error("Content root is required"));
+		if (!validationResult.valid) {
+			return yield* Effect.fail(
+				new Error(validationResult.issues.map((issue) => issue.message).join("\n")),
+			);
 		}
 
 		return {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -44,6 +44,11 @@ import {
 	type UploadAdfFileResult,
 } from "./Publisher";
 import {
+	validateConfluenceSettings,
+	type ConfluenceSettingsValidationIssue,
+	type ConfluenceSettingsValidationResult,
+} from "./Settings";
+import {
 	ConfluenceSettingsLive,
 	confluenceSettingsConfig,
 	loadConfluenceSettings,
@@ -81,11 +86,14 @@ export {
 	renderADFDoc,
 	runEffect,
 	stripMarkdownHtmlComments,
+	validateConfluenceSettings,
 	type ADFProcessingPlugin,
 	type BinaryFile,
 	type ChartData,
 	type ConfluenceAdfFile,
 	type ConfluenceNode,
+	type ConfluenceSettingsValidationIssue,
+	type ConfluenceSettingsValidationResult,
 	type ConfluenceTreeNode,
 	type FilesToUpload,
 	type LocalAdfFile,

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -1,4 +1,5 @@
 import { App, Setting, PluginSettingTab } from "obsidian";
+import { validateConfluenceSettings } from "@markdown-confluence/lib";
 import ConfluencePlugin from "./main";
 
 export class ConfluenceSettingTab extends PluginSettingTab {
@@ -18,6 +19,30 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 			text: "Settings for connecting to Atlassian Confluence",
 		});
 
+		const validationContainer = containerEl.createDiv({
+			cls: "markdown-confluence-settings-validation",
+		});
+		const renderValidationResult = () => {
+			validationContainer.empty();
+			const validationResult = validateConfluenceSettings(this.plugin.settings);
+			if (validationResult.valid) {
+				return;
+			}
+
+			validationContainer.createEl("p", {
+				text: "Settings need attention before publishing:",
+			});
+			const validationList = validationContainer.createEl("ul");
+			for (const issue of validationResult.issues) {
+				validationList.createEl("li", { text: issue.message });
+			}
+		};
+		const saveSettingsAndRenderValidation = async () => {
+			await this.plugin.saveSettings();
+			renderValidationResult();
+		};
+		renderValidationResult();
+
 		new Setting(containerEl)
 			.setName("Confluence Domain")
 			.setDesc('Confluence Domain eg "https://mysite.atlassian.net"')
@@ -27,7 +52,7 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.confluenceBaseUrl)
 					.onChange(async (value) => {
 						this.plugin.settings.confluenceBaseUrl = value;
-						await this.plugin.saveSettings();
+						await saveSettingsAndRenderValidation();
 					}),
 			);
 
@@ -40,7 +65,7 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.atlassianUserName)
 					.onChange(async (value) => {
 						this.plugin.settings.atlassianUserName = value;
-						await this.plugin.saveSettings();
+						await saveSettingsAndRenderValidation();
 					}),
 			);
 
@@ -53,7 +78,7 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.atlassianApiToken)
 					.onChange(async (value) => {
 						this.plugin.settings.atlassianApiToken = value;
-						await this.plugin.saveSettings();
+						await saveSettingsAndRenderValidation();
 					}),
 			);
 
@@ -66,7 +91,7 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.confluenceParentId)
 					.onChange(async (value) => {
 						this.plugin.settings.confluenceParentId = value;
-						await this.plugin.saveSettings();
+						await saveSettingsAndRenderValidation();
 					}),
 			);
 
@@ -79,7 +104,7 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.folderToPublish)
 					.onChange(async (value) => {
 						this.plugin.settings.folderToPublish = value;
-						await this.plugin.saveSettings();
+						await saveSettingsAndRenderValidation();
 					}),
 			);
 


### PR DESCRIPTION
## Summary
- add shared lib validation for required Confluence settings and base URL shape
- reject trailing slash Confluence base URLs during config loading
- show live validation messages in the Obsidian settings tab using the shared validator

Closes #235.

## Validation
- `vp install --frozen-lockfile`
- `vp test run packages/lib/src/SettingsConfig.test.ts`
- `vp run --filter @markdown-confluence/lib build`
- `vp run --filter @markdown-confluence/mermaid-electron-renderer build`
- `vp run --filter obsidian-confluence build`
- `vp run fmt:check`
- `vp run check`
- `vp test run`
- `vp run build`