### PR TITLE
feat: expose Confluence client auth and API config

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -98,6 +98,11 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
   "confluenceParentId": "123456",
   "atlassianUserName": "your-email@example.com",
   "atlassianApiToken": "optional-token-from-config",
+  "confluenceAuthType": "basic",
+  "confluenceApiPrefix": "/wiki/rest",
+  "confluenceRequestHeaders": {
+    "X-Custom-Header": "optional-value"
+  },
   "folderToPublish": "docs",
   "contentRoot": ".",
   "firstHeadingPageTitle": false
@@ -112,6 +117,9 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
 | `confluenceParentId` | `CONFLUENCE_PARENT_ID` | `--parentId`, `-p` | The numeric ID of an existing Confluence parent page. The parent page determines the target space. |
 | `atlassianUserName` | `ATLASSIAN_USERNAME` | `--userName`, `-u` | The Atlassian user name or email address used for publishing. |
 | `atlassianApiToken` | `ATLASSIAN_API_TOKEN` | `--apiToken` | The Atlassian API token. Prefer an environment variable or GitHub secret instead of committing this value to JSON. |
+| `confluenceAuthType` | `CONFLUENCE_AUTH_TYPE` | `--authType` | Authentication mode. Use `basic` for Confluence Cloud API tokens or `bearer` for PAT-style bearer tokens. |
+| `confluenceApiPrefix` | `CONFLUENCE_API_PREFIX` | `--apiPrefix` | API route prefix. Defaults to `/wiki/rest`; use values like `/rest` only when your Confluence API is exposed there. |
+| `confluenceRequestHeaders` | `CONFLUENCE_REQUEST_HEADERS` | `--requestHeaders` | Extra request headers. JSON config accepts an object; env and CLI accept `Header=Value,Another=Value`. |
 | `folderToPublish` | `FOLDER_TO_PUBLISH` | `--enableFolder`, `-f` | The folder, relative to `contentRoot`, whose Markdown files default to `connie-publish: true`. Use `.` to publish all Markdown files under `contentRoot`. |
 | `contentRoot` | `CONFLUENCE_CONTENT_ROOT` | `--contentRoot`, `--cr` | The root directory to scan for Markdown files and referenced content. |
 | `firstHeadingPageTitle` | `CONFLUENCE_FIRST_HEADING_PAGE_TITLE` | `--firstHeaderPageTitle`, `--fh` | When `true`, use the first heading as the page title when `connie-title` is not set. |

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
 	Publisher,
 	MermaidRendererPlugin,
 	RuntimeEnvironmentService,
+	createConfluenceClientConfig,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { ConfluenceClient } from "confluence.js";
@@ -22,25 +23,20 @@ const program = Effect.gen(function* () {
 
 	const settings = yield* ConfluenceUploadSettings.ConfluenceSettingsService as any;
 
-	const confluenceClient = new ConfluenceClient({
-		host: settings.confluenceBaseUrl,
-		authentication: {
-			basic: {
-				email: settings.atlassianUserName,
-				apiToken: settings.atlassianApiToken,
+	const confluenceClient = new ConfluenceClient(
+		createConfluenceClientConfig(settings, {
+			middlewares: {
+				onError(e) {
+					if ("response" in e && "data" in e.response) {
+						e.message =
+							typeof e.response.data === "string"
+								? e.response.data
+								: JSON.stringify(e.response.data);
+					}
+				},
 			},
-		},
-		middlewares: {
-			onError(e) {
-				if ("response" in e && "data" in e.response) {
-					e.message =
-						typeof e.response.data === "string"
-							? e.response.data
-							: JSON.stringify(e.response.data);
-				}
-			},
-		},
-	});
+		}),
+	);
 
 	const publisher = new Publisher(settings, confluenceClient, [
 		new MermaidRendererPlugin(new PuppeteerMermaidRenderer()),

--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -3,7 +3,7 @@ import { TextDefinition } from "@atlaskit/adf-schema";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { prepareAdfToUpload } from "./AdfProcessing";
 import { ConfluenceAdfFile, ConfluenceNode } from "./Publisher";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 
 test("resolves wikilinks that include a path under the publish root", () => {
 	const pages = [
@@ -89,6 +89,7 @@ function createNode(file: Partial<ConfluenceAdfFile>): ConfluenceNode {
 }
 
 const testSettings: ConfluenceSettings = {
+	...DEFAULT_SETTINGS,
 	confluenceBaseUrl: "https://example.atlassian.net",
 	confluenceParentId: "1",
 	atlassianUserName: "test@example.com",

--- a/packages/lib/src/ConfluenceClientConfig.test.ts
+++ b/packages/lib/src/ConfluenceClientConfig.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@effect/vitest";
+import {
+	createConfluenceClientConfig,
+	normalizeConfluenceApiPrefix,
+} from "./ConfluenceClientConfig";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
+
+test("creates default basic auth Confluence client config", () => {
+	const config = createConfluenceClientConfig(makeSettings());
+
+	expect(config).toEqual({
+		host: "https://example.atlassian.net",
+		apiPrefix: "/wiki/rest",
+		authentication: {
+			basic: {
+				email: "user@example.com",
+				apiToken: "token",
+			},
+		},
+		baseRequestConfig: undefined,
+	});
+});
+
+test("creates bearer auth config with custom API prefix and request headers", () => {
+	const config = createConfluenceClientConfig(
+		makeSettings({
+			atlassianUserName: "",
+			atlassianApiToken: "personal-access-token",
+			confluenceAuthType: "bearer",
+			confluenceApiPrefix: "rest/",
+			confluenceRequestHeaders: {
+				"X-Custom-Header": "tenant",
+			},
+		}),
+		{
+			middlewares: {
+				onError: () => undefined,
+			},
+		},
+	);
+
+	expect(config).toMatchObject({
+		host: "https://example.atlassian.net",
+		apiPrefix: "/rest",
+		authentication: {
+			oauth2: {
+				accessToken: "personal-access-token",
+			},
+		},
+		baseRequestConfig: {
+			headers: {
+				"X-Custom-Header": "tenant",
+			},
+		},
+		middlewares: {
+			onError: expect.any(Function),
+		},
+	});
+});
+
+test("normalizes Confluence API prefixes", () => {
+	expect(normalizeConfluenceApiPrefix("")).toBe("/wiki/rest");
+	expect(normalizeConfluenceApiPrefix("rest")).toBe("/rest");
+	expect(normalizeConfluenceApiPrefix("/rest/")).toBe("/rest");
+	expect(normalizeConfluenceApiPrefix("/")).toBe("");
+});
+
+function makeSettings(settings: Partial<ConfluenceSettings> = {}): ConfluenceSettings {
+	return {
+		...DEFAULT_SETTINGS,
+		confluenceBaseUrl: "https://example.atlassian.net",
+		confluenceParentId: "123456",
+		atlassianUserName: "user@example.com",
+		atlassianApiToken: "token",
+		...settings,
+	};
+}

--- a/packages/lib/src/ConfluenceClientConfig.ts
+++ b/packages/lib/src/ConfluenceClientConfig.ts
@@ -1,0 +1,50 @@
+import type { Config } from "confluence.js";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
+
+export const DEFAULT_CONFLUENCE_API_PREFIX = DEFAULT_SETTINGS.confluenceApiPrefix;
+
+export function createConfluenceClientConfig(
+	settings: ConfluenceSettings,
+	config: Pick<Config, "middlewares"> = {},
+): Config {
+	return {
+		host: settings.confluenceBaseUrl,
+		apiPrefix: normalizeConfluenceApiPrefix(settings.confluenceApiPrefix),
+		authentication:
+			settings.confluenceAuthType === "bearer"
+				? {
+						oauth2: {
+							accessToken: settings.atlassianApiToken,
+						},
+					}
+				: {
+						basic: {
+							email: settings.atlassianUserName,
+							apiToken: settings.atlassianApiToken,
+						},
+					},
+		baseRequestConfig: hasRequestHeaders(settings.confluenceRequestHeaders)
+			? {
+					headers: settings.confluenceRequestHeaders,
+				}
+			: undefined,
+		...config,
+	};
+}
+
+export function normalizeConfluenceApiPrefix(apiPrefix: string): string {
+	const trimmedApiPrefix = apiPrefix.trim();
+	if (!trimmedApiPrefix) {
+		return DEFAULT_CONFLUENCE_API_PREFIX;
+	}
+
+	const prefixedApiPrefix = trimmedApiPrefix.startsWith("/")
+		? trimmedApiPrefix
+		: `/${trimmedApiPrefix}`;
+
+	return prefixedApiPrefix.replace(/\/+$/, "");
+}
+
+function hasRequestHeaders(headers: Record<string, string>): boolean {
+	return Object.keys(headers).length > 0;
+}

--- a/packages/lib/src/MarkdownWorkspace.test.ts
+++ b/packages/lib/src/MarkdownWorkspace.test.ts
@@ -2,7 +2,7 @@ import { FileSystem } from "effect/FileSystem";
 import { Path } from "effect/Path";
 import { afterEach, expect, test } from "@effect/vitest";
 import { Effect } from "effect";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 import { RuntimeEnvironmentService, runEffect } from "./effects";
 import { loadMarkdownWorkspace } from "./MarkdownWorkspace";
 
@@ -135,6 +135,7 @@ test("updates markdown values for an absolute file path inside contentRoot", asy
 });
 
 const testSettings: ConfluenceSettings = {
+	...DEFAULT_SETTINGS,
 	confluenceBaseUrl: "https://example.atlassian.net",
 	confluenceParentId: "123456",
 	atlassianUserName: "user@example.com",

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -2,7 +2,7 @@
 import { expect, test } from "@effect/vitest";
 import { MarkdownFile } from "./MarkdownWorkspace";
 import { convertMDtoADF } from "./MdToADF";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 
 const markdownTestCases: MarkdownFile[] = [
 	{
@@ -247,6 +247,7 @@ const markdownTestCases: MarkdownFile[] = [
 ];
 test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 	const settings: ConfluenceSettings = {
+		...DEFAULT_SETTINGS,
 		confluenceBaseUrl: "https://example.com",
 		confluenceParentId: "asdf",
 		atlassianUserName: "asdf@asdf.com",
@@ -278,6 +279,7 @@ test("parses callout with adjacent wikilink image", () => {
 		frontmatter: {},
 	};
 	const settings: ConfluenceSettings = {
+		...DEFAULT_SETTINGS,
 		confluenceBaseUrl: "https://example.com",
 		confluenceParentId: "asdf",
 		atlassianUserName: "asdf@asdf.com",

--- a/packages/lib/src/PublisherErrors.test.ts
+++ b/packages/lib/src/PublisherErrors.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@effect/vitest";
 import { RequiredConfluenceClient } from "./ConfluenceClient";
 import { Publisher } from "./Publisher";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 
 test("explains how to resolve a missing parent page space key", async () => {
 	const publisher = new Publisher(testSettings, createConfluenceClientWithoutParentSpace(), []);
@@ -28,6 +28,7 @@ function createConfluenceClientWithoutParentSpace(): RequiredConfluenceClient {
 }
 
 const testSettings: ConfluenceSettings = {
+	...DEFAULT_SETTINGS,
 	confluenceBaseUrl: "https://example.atlassian.net",
 	confluenceParentId: "123456",
 	atlassianUserName: "user@example.com",

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -1,10 +1,15 @@
 import { Context } from "effect";
 
+export type ConfluenceAuthType = "basic" | "bearer";
+
 export type ConfluenceSettings = {
 	confluenceBaseUrl: string;
 	confluenceParentId: string;
 	atlassianUserName: string;
 	atlassianApiToken: string;
+	confluenceAuthType: ConfluenceAuthType;
+	confluenceApiPrefix: string;
+	confluenceRequestHeaders: Record<string, string>;
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
@@ -15,6 +20,9 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	confluenceParentId: "",
 	atlassianUserName: "",
 	atlassianApiToken: "",
+	confluenceAuthType: "basic",
+	confluenceApiPrefix: "/wiki/rest",
+	confluenceRequestHeaders: {},
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -37,6 +37,11 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 					confluenceParentId: "file-parent",
 					atlassianUserName: "file-user@example.com",
 					atlassianApiToken: "file-token",
+					confluenceAuthType: "basic",
+					confluenceApiPrefix: "/file/rest",
+					confluenceRequestHeaders: {
+						"X-File-Header": "file-value",
+					},
 					folderToPublish: "file-folder",
 					contentRoot: "file-root",
 					firstHeadingPageTitle: true,
@@ -60,6 +65,12 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 			"cli-parent",
 			"--apiToken",
 			"cli-token",
+			"--authType",
+			"bearer",
+			"--apiPrefix",
+			"cli-rest",
+			"--requestHeaders",
+			"X-Cli-Header=cli-value",
 			"--contentRoot",
 			"cli-root",
 		],
@@ -67,6 +78,7 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 		env: {
 			CONFLUENCE_BASE_URL: "https://env.example.atlassian.net",
 			ATLASSIAN_USERNAME: "env-user@example.com",
+			CONFLUENCE_API_PREFIX: "/env/rest",
 			FOLDER_TO_PUBLISH: "env-folder",
 		},
 	});
@@ -88,6 +100,11 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 		confluenceParentId: "cli-parent",
 		atlassianUserName: "env-user@example.com",
 		atlassianApiToken: "cli-token",
+		confluenceAuthType: "bearer",
+		confluenceApiPrefix: "cli-rest",
+		confluenceRequestHeaders: {
+			"X-Cli-Header": "cli-value",
+		},
 		folderToPublish: "env-folder",
 		contentRoot: expectedCliContentRoot,
 		firstHeadingPageTitle: true,
@@ -105,6 +122,9 @@ test("keeps explicit false values from config providers", async () => {
 					confluenceParentId: "file-parent",
 					atlassianUserName: "file-user@example.com",
 					atlassianApiToken: "file-token",
+					confluenceAuthType: "basic",
+					confluenceApiPrefix: "/wiki/rest",
+					confluenceRequestHeaders: {},
 					folderToPublish: "file-folder",
 					contentRoot,
 					firstHeadingPageTitle: false,
@@ -120,6 +140,28 @@ test("keeps explicit false values from config providers", async () => {
 
 	expect(settings.firstHeadingPageTitle).toBe(false);
 	expect(settings.contentRoot).toBe(expectedContentRoot);
+});
+
+test("allows bearer auth without an Atlassian user name", async () => {
+	const settings = await runEffect(
+		parseConfluenceSettingsEffect(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: "https://file.example.atlassian.net",
+				confluenceParentId: "file-parent",
+				atlassianUserName: "",
+				atlassianApiToken: "personal-access-token",
+				confluenceAuthType: "bearer",
+				confluenceApiPrefix: "/rest",
+				confluenceRequestHeaders: {},
+				folderToPublish: "file-folder",
+				contentRoot: "docs",
+				firstHeadingPageTitle: false,
+			}),
+		),
+	);
+
+	expect(settings.confluenceAuthType).toBe("bearer");
+	expect(settings.atlassianUserName).toBe("");
 });
 
 test("parses boolean CLI values passed as separate arguments", async () => {

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -1,15 +1,21 @@
 import { FileSystem } from "effect/FileSystem";
 import { Path } from "effect/Path";
-import { Config, ConfigProvider, Effect, Layer } from "effect";
+import { Config, ConfigProvider, Effect, Layer, Schema } from "effect";
 import {
 	MarkdownConfluencePlatform,
 	runEffect,
 	RuntimeEnvironment,
 	RuntimeEnvironmentService,
 } from "./effects";
-import { ConfluenceSettings, ConfluenceSettingsService, DEFAULT_SETTINGS } from "./Settings";
+import {
+	ConfluenceAuthType,
+	ConfluenceSettings,
+	ConfluenceSettingsService,
+	DEFAULT_SETTINGS,
+} from "./Settings";
 
 const CONFLUENCE_SETTINGS_KEYS = Object.keys(DEFAULT_SETTINGS) as (keyof ConfluenceSettings)[];
+const CONFLUENCE_AUTH_TYPES: readonly ConfluenceAuthType[] = ["basic", "bearer"];
 
 type ArgumentDefinition = {
 	name: string;
@@ -24,6 +30,12 @@ export const confluenceSettingsConfig = Config.all({
 	confluenceParentId: Config.string("confluenceParentId"),
 	atlassianUserName: Config.string("atlassianUserName"),
 	atlassianApiToken: Config.string("atlassianApiToken"),
+	confluenceAuthType: Config.schema(Schema.Literals(CONFLUENCE_AUTH_TYPES), "confluenceAuthType"),
+	confluenceApiPrefix: Config.string("confluenceApiPrefix"),
+	confluenceRequestHeaders: Config.schema(
+		Config.Record(Schema.String, Schema.String),
+		"confluenceRequestHeaders",
+	),
 	folderToPublish: Config.string("folderToPublish"),
 	contentRoot: Config.string("contentRoot"),
 	firstHeadingPageTitle: Config.boolean("firstHeadingPageTitle"),
@@ -109,12 +121,24 @@ function validateConfluenceSettingsEffect(
 			return yield* Effect.fail(new Error("Confluence parent ID is required"));
 		}
 
-		if (!settings.atlassianUserName) {
+		if (!CONFLUENCE_AUTH_TYPES.includes(settings.confluenceAuthType)) {
+			return yield* Effect.fail(
+				new Error(
+					`Confluence auth type must be one of: ${CONFLUENCE_AUTH_TYPES.join(", ")}`,
+				),
+			);
+		}
+
+		if (settings.confluenceAuthType === "basic" && !settings.atlassianUserName) {
 			return yield* Effect.fail(new Error("Atlassian user name is required"));
 		}
 
 		if (!settings.atlassianApiToken) {
 			return yield* Effect.fail(new Error("Atlassian API token is required"));
+		}
+
+		if (!settings.confluenceApiPrefix) {
+			return yield* Effect.fail(new Error("Confluence API prefix is required"));
 		}
 
 		if (!settings.folderToPublish) {
@@ -188,6 +212,11 @@ function makeEnvironmentProvider(
 				confluenceParentId: yield* runtimeEnvironment.getEnv("CONFLUENCE_PARENT_ID"),
 				atlassianUserName: yield* runtimeEnvironment.getEnv("ATLASSIAN_USERNAME"),
 				atlassianApiToken: yield* runtimeEnvironment.getEnv("ATLASSIAN_API_TOKEN"),
+				confluenceAuthType: yield* runtimeEnvironment.getEnv("CONFLUENCE_AUTH_TYPE"),
+				confluenceApiPrefix: yield* runtimeEnvironment.getEnv("CONFLUENCE_API_PREFIX"),
+				confluenceRequestHeaders: yield* runtimeEnvironment.getEnv(
+					"CONFLUENCE_REQUEST_HEADERS",
+				),
 				folderToPublish: yield* runtimeEnvironment.getEnv("FOLDER_TO_PUBLISH"),
 				contentRoot: yield* runtimeEnvironment.getEnv("CONFLUENCE_CONTENT_ROOT"),
 				firstHeadingPageTitle:
@@ -203,6 +232,9 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "parentId", aliases: ["p"], type: "string" },
 		{ name: "userName", aliases: ["u"], type: "string" },
 		{ name: "apiToken", type: "string" },
+		{ name: "authType", type: "string" },
+		{ name: "apiPrefix", type: "string" },
+		{ name: "requestHeaders", type: "string" },
 		{ name: "enableFolder", aliases: ["f"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
@@ -214,6 +246,9 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			confluenceParentId: options["parentId"],
 			atlassianUserName: options["userName"],
 			atlassianApiToken: options["apiToken"],
+			confluenceAuthType: options["authType"],
+			confluenceApiPrefix: options["apiPrefix"],
+			confluenceRequestHeaders: options["requestHeaders"],
 			folderToPublish: options["enableFolder"],
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],
@@ -295,12 +330,29 @@ function pickConfluenceSettings(config: Record<string, unknown>): Partial<Conflu
 		}
 
 		const value = config[key];
-		if (typeof value === typeof DEFAULT_SETTINGS[key]) {
+		if (isConfluenceSettingValue(key, value)) {
 			(result as Record<string, unknown>)[key] = value;
 		}
 	}
 
 	return result;
+}
+
+function isConfluenceSettingValue(key: keyof ConfluenceSettings, value: unknown): boolean {
+	if (key === "confluenceRequestHeaders") {
+		return isStringRecord(value);
+	}
+
+	return typeof value === typeof DEFAULT_SETTINGS[key];
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+	return (
+		value !== null &&
+		!Array.isArray(value) &&
+		typeof value === "object" &&
+		Object.values(value).every((entry) => typeof entry === "string")
+	);
 }
 
 function compactRecord<T extends Record<string, unknown>>(record: T): Record<string, string> {

--- a/packages/lib/src/TreeConfluence.test.ts
+++ b/packages/lib/src/TreeConfluence.test.ts
@@ -4,7 +4,7 @@ import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { Effect } from "effect";
 import { ConfluencePerPageAllValues } from "./ConniePageConfig";
 import { RequiredConfluenceClient } from "./ConfluenceClient";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 import { ensureAllFilesExistInConfluence } from "./TreeConfluence";
 import { LocalAdfFileTreeNode } from "./Publisher";
 import { BinaryFile, FilesToUpload, MarkdownFile, MarkdownWorkspace } from "./MarkdownWorkspace";
@@ -190,6 +190,7 @@ function createRootNode(
 }
 
 const testSettings: ConfluenceSettings = {
+	...DEFAULT_SETTINGS,
 	confluenceBaseUrl: "https://example.atlassian.net",
 	confluenceParentId: "123456",
 	atlassianUserName: "user@example.com",

--- a/packages/lib/src/TreeLocal.test.ts
+++ b/packages/lib/src/TreeLocal.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@effect/vitest";
 import { Effect } from "effect";
 import { runEffect } from "./effects";
 import { MarkdownFile } from "./MarkdownWorkspace";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 import { createFolderStructure } from "./TreeLocal";
 
 test("uses the containing directory as the root for one markdown file", async () => {
@@ -75,6 +75,7 @@ function createMarkdownFile(filesystemPath: Path, absoluteFilePath: string): Mar
 }
 
 const testSettings: ConfluenceSettings = {
+	...DEFAULT_SETTINGS,
 	confluenceBaseUrl: "https://example.atlassian.net",
 	confluenceParentId: "123456",
 	atlassianUserName: "user@example.com",

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -13,6 +13,11 @@ import {
 	type PublisherFunctions,
 } from "./ADFProcessingPlugins";
 import { renderADFDoc } from "./ADFToMarkdown";
+import {
+	createConfluenceClientConfig,
+	DEFAULT_CONFLUENCE_API_PREFIX,
+	normalizeConfluenceApiPrefix,
+} from "./ConfluenceClientConfig";
 import { type RequiredConfluenceClient } from "./ConfluenceClient";
 import {
 	MarkdownConfluencePlatformLive,
@@ -57,6 +62,7 @@ export {
 	ConfluencePageConfig,
 	ConfluenceSettingsLive,
 	ConfluenceUploadSettings,
+	DEFAULT_CONFLUENCE_API_PREFIX,
 	MarkdownConfluencePlatformLive,
 	MarkdownConfluenceRuntime,
 	MarkdownWorkspaceLive,
@@ -67,6 +73,7 @@ export {
 	RuntimeEnvironmentService,
 	confluenceSettingsConfig,
 	convertMDtoADF,
+	createConfluenceClientConfig,
 	createPublisherFunctions,
 	executeADFProcessingPipeline,
 	executeADFProcessingPipelineEffect,
@@ -76,6 +83,7 @@ export {
 	loadMarkdownWorkspace,
 	makeConfluenceSettingsConfigProvider,
 	makeMarkdownWorkspaceEffect,
+	normalizeConfluenceApiPrefix,
 	parseConfluenceSettingsEffect,
 	parseMarkdownToADF,
 	renderADFDoc,

--- a/packages/obsidian/README.md
+++ b/packages/obsidian/README.md
@@ -27,6 +27,9 @@ Please log issues to https://github.com/markdown-confluence/markdown-confluence/
 - `Confluence Parent Id`: The Confluence page ID where your notes will be published as child pages
 - `Atlassian User Name`: Your Atlassian account's email address
 - `Atlassian API Token`: Your Atlassian API token. You can generate one from your [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens).
+- `Authentication Type`: Basic for Confluence Cloud API tokens, or Bearer / PAT for bearer-token endpoints.
+- `Confluence API Prefix`: The REST API prefix, defaulting to `/wiki/rest`.
+- `Custom Request Headers`: Optional JSON object of extra headers to send with Confluence requests.
 - `Folder To Publish`: The name of the folder in Obsidian containing the notes you want to publish (default: "Confluence Pages")
 
 ![Settings](./docs/screenshots/settings.png)

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -58,6 +58,57 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Authentication Type")
+			.setDesc("Use basic for Confluence Cloud API tokens or bearer for PAT-style tokens")
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOptions({
+						basic: "Basic",
+						bearer: "Bearer / PAT",
+					})
+					.setValue(this.plugin.settings.confluenceAuthType)
+					.onChange(async (value) => {
+						if (!isConfluenceAuthType(value)) {
+							return;
+						}
+
+						this.plugin.settings.confluenceAuthType = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Confluence API Prefix")
+			.setDesc('API route prefix eg "/wiki/rest" or "/rest"')
+			.addText((text) =>
+				text
+					.setPlaceholder("/wiki/rest")
+					.setValue(this.plugin.settings.confluenceApiPrefix)
+					.onChange(async (value) => {
+						this.plugin.settings.confluenceApiPrefix = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Custom Request Headers")
+			.setDesc('JSON object eg {"X-Custom-Header":"value"}')
+			.addTextArea((text) =>
+				text
+					.setPlaceholder('{"X-Custom-Header":"value"}')
+					.setValue(formatRequestHeaders(this.plugin.settings.confluenceRequestHeaders))
+					.onChange(async (value) => {
+						const requestHeaders = parseRequestHeaders(value);
+						if (!requestHeaders) {
+							return;
+						}
+
+						this.plugin.settings.confluenceRequestHeaders = requestHeaders;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
 			.setName("Confluence Parent Page ID")
 			.setDesc("Page ID to publish files under")
 			.addText((text) =>
@@ -131,4 +182,35 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 				/* eslint-enable @typescript-eslint/naming-convention */
 			});
 	}
+}
+
+function isConfluenceAuthType(value: string): value is "basic" | "bearer" {
+	return value === "basic" || value === "bearer";
+}
+
+function formatRequestHeaders(headers: Record<string, string>): string {
+	return Object.keys(headers).length === 0 ? "" : JSON.stringify(headers, null, 2);
+}
+
+function parseRequestHeaders(value: string): Record<string, string> | undefined {
+	const trimmedValue = value.trim();
+	if (!trimmedValue) {
+		return {};
+	}
+
+	try {
+		const headers = JSON.parse(trimmedValue) as unknown;
+		if (
+			headers !== null &&
+			!Array.isArray(headers) &&
+			typeof headers === "object" &&
+			Object.values(headers).every((entry) => typeof entry === "string")
+		) {
+			return headers as Record<string, string>;
+		}
+	} catch {
+		return undefined;
+	}
+
+	return undefined;
 }

--- a/packages/obsidian/src/MyBaseClient.ts
+++ b/packages/obsidian/src/MyBaseClient.ts
@@ -7,15 +7,21 @@ import {
 	getAuthenticationToken,
 } from "confluence.js";
 import { requestUrl } from "obsidian";
-import { RequiredConfluenceClient } from "@markdown-confluence/lib";
+import {
+	DEFAULT_CONFLUENCE_API_PREFIX,
+	normalizeConfluenceApiPrefix,
+	RequiredConfluenceClient,
+} from "@markdown-confluence/lib";
 
 const ATLASSIAN_TOKEN_CHECK_FLAG = "X-Atlassian-Token";
 const ATLASSIAN_TOKEN_CHECK_NOCHECK_VALUE = "no-check";
 
 export class MyBaseClient implements Client {
-	protected urlSuffix = "/wiki/rest";
-
 	constructor(protected readonly config: Config) {}
+
+	protected get urlSuffix(): string {
+		return normalizeConfluenceApiPrefix(this.config.apiPrefix ?? DEFAULT_CONFLUENCE_API_PREFIX);
+	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	protected paramSerializer(parameters: Record<string, any>): string {

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -9,6 +9,7 @@ import {
 	MarkdownConfluencePlatform,
 	MarkdownWorkspaceLive,
 	MarkdownWorkspaceService,
+	createConfluenceClientConfig,
 } from "@markdown-confluence/lib";
 import { Effect, Layer } from "effect";
 import { ElectronMermaidRenderer } from "@markdown-confluence/mermaid-electron-renderer";
@@ -85,25 +86,20 @@ export default class ConfluencePlugin extends Plugin {
 			mermaidItems.mermaidConfig,
 			mermaidItems.bodyStyles,
 		);
-		const confluenceClient = new ObsidianConfluenceClient({
-			host: this.settings.confluenceBaseUrl,
-			authentication: {
-				basic: {
-					email: this.settings.atlassianUserName,
-					apiToken: this.settings.atlassianApiToken,
+		const confluenceClient = new ObsidianConfluenceClient(
+			createConfluenceClientConfig(this.settings, {
+				middlewares: {
+					onError(e) {
+						if ("response" in e && "data" in e.response) {
+							e.message =
+								typeof e.response.data === "string"
+									? e.response.data
+									: JSON.stringify(e.response.data);
+						}
+					},
 				},
-			},
-			middlewares: {
-				onError(e) {
-					if ("response" in e && "data" in e.response) {
-						e.message =
-							typeof e.response.data === "string"
-								? e.response.data
-								: JSON.stringify(e.response.data);
-					}
-				},
-			},
-		});
+			}),
+		);
 
 		this.publisher = new Publisher(this.settings, confluenceClient, [
 			new MermaidRendererPlugin(mermaidRenderer),
@@ -238,15 +234,9 @@ export default class ConfluencePlugin extends Plugin {
 				);
 				console.log({ json });
 
-				const confluenceClient = new ObsidianConfluenceClient({
-					host: this.settings.confluenceBaseUrl,
-					authentication: {
-						basic: {
-							email: this.settings.atlassianUserName,
-							apiToken: this.settings.atlassianApiToken,
-						},
-					},
-				});
+				const confluenceClient = new ObsidianConfluenceClient(
+					createConfluenceClientConfig(this.settings),
+				);
 				const testingPage = await confluenceClient.content.getContentById({
 					id: "9732097",
 					expand: ["body.atlas_doc_format", "space"],


### PR DESCRIPTION
## Summary
- add shared Confluence client config creation for Basic and Bearer/PAT-style auth
- expose `confluenceApiPrefix` and `confluenceRequestHeaders` through config, env, CLI, and Obsidian settings
- wire CLI and Obsidian clients through the shared config helper and document the new options

## Issue coverage
- Closes #350
- Closes #625
- Refs #351, #536, and #621 by adding bearer-token request auth, but this does not claim full Confluence Server/Data Center publishing support
- Refs #91; full on-prem support still needs Confluence storage-format publishing rather than only client/auth configuration
- Does not close #635 or #670; those look like Cloud permission/API-version triage items needing maintainer guidance or a larger v2 endpoint migration

## Validation
- `vp test run packages/lib/src/SettingsConfig.test.ts packages/lib/src/ConfluenceClientConfig.test.ts`
- `vp run check`
- `vp test run`
- `vp run build`