### PR TITLE
fix: handle media sizing and non-image embeds

### DIFF
--- a/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.test.ts
+++ b/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@effect/vitest";
+import { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import { UploadedImageData } from "../Attachments";
+import { ImageUploaderPlugin } from "./ImageUploaderPlugin";
+
+test("keeps requested media width after uploading an image", () => {
+	const adf = docWithMedia({
+		type: "file",
+		url: "file://img/chewbacca.png",
+		width: "111",
+		height: null,
+	});
+
+	const result = ImageUploaderPlugin.load(adf, {
+		"file://img/chewbacca.png": uploadedImage,
+	});
+
+	const mediaAttrs = getFirstMediaAttrs(result);
+	expect(mediaAttrs).toMatchObject({
+		collection: "contentId-page-id",
+		id: "attachment-id",
+		type: "file",
+		width: "111",
+	});
+	expect(mediaAttrs?.["height"]).toBeUndefined();
+	expect(mediaAttrs?.["url"]).toBeUndefined();
+});
+
+test("uses uploaded media dimensions when markdown did not request a size", () => {
+	const adf = docWithMedia({
+		type: "file",
+		url: "file://img/chewbacca.png",
+	});
+
+	const result = ImageUploaderPlugin.load(adf, {
+		"file://img/chewbacca.png": uploadedImage,
+	});
+
+	expect(getFirstMediaAttrs(result)).toMatchObject({
+		collection: "contentId-page-id",
+		height: 480,
+		id: "attachment-id",
+		type: "file",
+		width: 640,
+	});
+});
+
+const uploadedImage: UploadedImageData = {
+	collection: "contentId-page-id",
+	filename: "chewbacca.png",
+	height: 480,
+	id: "attachment-id",
+	status: "uploaded",
+	width: 640,
+};
+
+function docWithMedia(mediaAttrs: Record<string, unknown>): JSONDocNode {
+	return {
+		version: 1,
+		type: "doc",
+		content: [
+			{
+				type: "mediaSingle",
+				attrs: {
+					layout: "center",
+				},
+				content: [
+					{
+						type: "media",
+						attrs: {
+							collection: "",
+							id: "",
+							...mediaAttrs,
+						},
+					},
+				],
+			},
+		],
+	} as JSONDocNode;
+}
+
+function getFirstMediaAttrs(adf: JSONDocNode): Record<string, unknown> | undefined {
+	const mediaSingle = adf.content?.[0];
+	const media = mediaSingle?.content?.[0];
+	return media?.attrs as Record<string, unknown> | undefined;
+}

--- a/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.ts
+++ b/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.ts
@@ -69,10 +69,28 @@ export const ImageUploaderPlugin: ADFProcessingPlugin<
 						}
 						const mappedImage = imageMap[node.attrs["url"]];
 						if (mappedImage) {
+							const requestedWidth = node.attrs["width"];
+							const requestedHeight = node.attrs["height"];
+							const hasRequestedDimensions =
+								hasMediaDimension(requestedWidth) ||
+								hasMediaDimension(requestedHeight);
+
 							node.attrs["collection"] = mappedImage.collection;
 							node.attrs["id"] = mappedImage.id;
-							node.attrs["width"] = mappedImage.width;
-							node.attrs["height"] = mappedImage.height;
+							if (hasMediaDimension(requestedWidth)) {
+								node.attrs["width"] = requestedWidth;
+							} else if (hasRequestedDimensions) {
+								delete node.attrs["width"];
+							} else {
+								node.attrs["width"] = mappedImage.width;
+							}
+							if (hasMediaDimension(requestedHeight)) {
+								node.attrs["height"] = requestedHeight;
+							} else if (hasRequestedDimensions) {
+								delete node.attrs["height"];
+							} else {
+								node.attrs["height"] = mappedImage.height;
+							}
 							delete node.attrs["url"];
 							return node;
 						}
@@ -98,3 +116,7 @@ export const ImageUploaderPlugin: ADFProcessingPlugin<
 		return afterAdf as JSONDocNode;
 	},
 };
+
+function hasMediaDimension(value: unknown): boolean {
+	return value !== undefined && value !== null && value !== "";
+}

--- a/packages/lib/src/Attachments.test.ts
+++ b/packages/lib/src/Attachments.test.ts
@@ -60,6 +60,56 @@ test("derives upload buffer content type from the filename", async () => {
 	expect(getUploadedAttachment(uploadRequests).contentType).toBe("text/plain");
 });
 
+test("falls back to octet-stream for unknown upload buffer file types", async () => {
+	const uploadRequests: unknown[] = [];
+
+	const result = await Effect.runPromise(
+		uploadBufferEffect(
+			makeConfluenceClient(uploadRequests),
+			"page-id",
+			"profile.not-a-known-type",
+			Buffer.from("profile data"),
+			{},
+		),
+	);
+
+	expect(result?.status).toBe("uploaded");
+	expect(getUploadedAttachment(uploadRequests).contentType).toBe("application/octet-stream");
+});
+
+test("uploads non-image files without requiring image dimensions", async () => {
+	const uploadRequests: unknown[] = [];
+	const workspace = new TestMarkdownWorkspace((searchPath) =>
+		searchPath === "movie.mp4"
+			? {
+					filename: "movie.mp4",
+					filePath: "assets/movie.mp4",
+					mimeType: "video/mp4",
+					contents: Buffer.from("not an image"),
+				}
+			: false,
+	);
+
+	const result = await Effect.runPromise(
+		uploadFileEffect(
+			makeConfluenceClient(uploadRequests),
+			"page-id",
+			"page.md",
+			"movie.mp4",
+			{},
+		).pipe(Effect.provideService(MarkdownWorkspaceService, workspace)),
+	);
+
+	expect(result).toMatchObject({
+		filename: "movie.mp4",
+		height: 0,
+		id: "file-id",
+		status: "uploaded",
+		width: 0,
+	});
+	expect(getUploadedAttachment(uploadRequests).contentType).toBe("video/mp4");
+});
+
 class TestMarkdownWorkspace implements MarkdownWorkspace {
 	readonly getMarkdownFilesToUpload: Effect.Effect<FilesToUpload, Error> = Effect.succeed([]);
 

--- a/packages/lib/src/MarkdownTransformer/media.ts
+++ b/packages/lib/src/MarkdownTransformer/media.ts
@@ -21,7 +21,8 @@ export interface MdState {
 }
 
 function createRule() {
-	const regx = /!\[[^\]]*\]\([^)]+\)|!\[[^\]]*\]\[[^\]]*]|!\[\[.*\..*]]/g;
+	const mediaRegex = /!\[[^\]]*]\([^)]+\)|!\[[^\]]*]\[[^\]]*]|!\[\[[^\]]+\.[^\]]+]]/;
+	const mediaGlobalRegex = /!\[[^\]]*]\([^)]+\)|!\[[^\]]*]\[[^\]]*]|!\[\[[^\]]+\.[^\]]+]]/g;
 	const referenceImageRegex = /^!\[(?<alt>[^\]]*)]\[(?<label>[^\]]*)]$/;
 	const validParentTokens = [
 		"blockquote_open",
@@ -55,6 +56,22 @@ function createRule() {
 	 * remaining inline content (bold, links, etc.) is kept intact!
 	 */
 	return function media(State: MdState) {
+		const createSizeAttrs = (sizeText: string | undefined): string[][] => {
+			const match = sizeText?.trim().match(/^(?<width>\d+)(?:x(?<height>\d+))?$/);
+			if (!match?.groups) {
+				return [];
+			}
+
+			const { width, height } = match.groups;
+			return [...(width ? [["width", width]] : []), ...(height ? [["height", height]] : [])];
+		};
+
+		const getAltSize = (str: string): string | undefined => {
+			const altEnd = str.indexOf("]");
+			const alt = altEnd > 2 ? str.slice(2, altEnd) : "";
+			return alt.includes("|") ? alt.split("|").at(-1) : undefined;
+		};
+
 		const createUrlAttrs = (href: string) => {
 			if (href.startsWith("http")) {
 				return [
@@ -77,7 +94,7 @@ function createRule() {
 			if (res.ok) {
 				const href = State.md.normalizeLink(res.str);
 				if (State.md.validateLink(href)) {
-					return createUrlAttrs(href);
+					return [...createUrlAttrs(href), ...createSizeAttrs(getAltSize(str))];
 				}
 			}
 
@@ -95,7 +112,10 @@ function createRule() {
 			const href = State.env?.references?.[normalizedReference]?.href;
 
 			if (href && State.md.validateLink(href)) {
-				return createUrlAttrs(State.md.normalizeLink(href));
+				return [
+					...createUrlAttrs(State.md.normalizeLink(href)),
+					...createSizeAttrs(getAltSize(str)),
+				];
 			}
 
 			return [
@@ -109,15 +129,11 @@ function createRule() {
 			const contentSplit = content.split("|");
 
 			const filename = contentSplit[0];
-			const widthHeight = contentSplit[1]?.split("x");
-			const width = widthHeight ? widthHeight[0] : undefined;
-			const height = !!widthHeight && widthHeight.length > 1 ? widthHeight[1] : undefined;
 
 			return [
 				["url", `file://${filename}`],
 				["type", "file"],
-				...(width ? [["width", `${width}`]] : []),
-				...(height ? [["height", `${height}`]] : []),
+				...createSizeAttrs(contentSplit[1]),
 			];
 		};
 
@@ -153,7 +169,7 @@ function createRule() {
 		let processedTokens: string[] = [];
 		const newTokens = State.tokens.reduce(
 			(tokens: Token[], token: Token, i: number, arr: Token[]) => {
-				if (token.type === "inline" && regx.test(token.content)) {
+				if (token.type === "inline" && mediaRegex.test(token.content)) {
 					const openingTokens: Token[] = [];
 					let cursor = i - 1;
 					let previousToken = arr[cursor];
@@ -182,7 +198,7 @@ function createRule() {
 						.reverse();
 
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					const matches = token.content.match(regx)!;
+					const matches = token.content.match(mediaGlobalRegex)!;
 					let inlineContentStack = token.content;
 					matches.forEach((match) => {
 						const start = inlineContentStack.indexOf(match);

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -245,17 +245,19 @@ const markdownTestCases: MarkdownFile[] = [
 		},
 	},
 ];
+
+const testSettings: ConfluenceSettings = {
+	confluenceBaseUrl: "https://example.com",
+	confluenceParentId: "asdf",
+	atlassianUserName: "asdf@asdf.com",
+	atlassianApiToken: "asdfasdf",
+	folderToPublish: ".",
+	contentRoot: "./",
+	firstHeadingPageTitle: false,
+};
+
 test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
-	const settings: ConfluenceSettings = {
-		confluenceBaseUrl: "https://example.com",
-		confluenceParentId: "asdf",
-		atlassianUserName: "asdf@asdf.com",
-		atlassianApiToken: "asdfasdf",
-		folderToPublish: ".",
-		contentRoot: "./",
-		firstHeadingPageTitle: false,
-	};
-	const adfFile = convertMDtoADF(markdown, settings);
+	const adfFile = convertMDtoADF(markdown, testSettings);
 	expect(adfFile).toMatchSnapshot();
 });
 
@@ -277,18 +279,103 @@ test("parses callout with adjacent wikilink image", () => {
 		pageTitle: "Callouts",
 		frontmatter: {},
 	};
-	const settings: ConfluenceSettings = {
-		confluenceBaseUrl: "https://example.com",
-		confluenceParentId: "asdf",
-		atlassianUserName: "asdf@asdf.com",
-		atlassianApiToken: "asdfasdf",
-		folderToPublish: ".",
-		contentRoot: "./",
-		firstHeadingPageTitle: false,
-	};
 
-	const adfFile = convertMDtoADF(markdown, settings);
+	const adfFile = convertMDtoADF(markdown, testSettings);
 
 	expect(adfFile.contents.content?.[0]?.type).toBe("panel");
 	expect(JSON.stringify(adfFile.contents)).toContain("file://Pasted image 20231006155212.png");
 });
+
+test("parses wikilink images inside nested lists without dropping later images", () => {
+	const markdown: MarkdownFile = {
+		folderName: "lists",
+		absoluteFilePath: "/path/to/lists.md",
+		fileName: "lists.md",
+		contents: [
+			"## Main",
+			"Word paragraph",
+			"1. List 1",
+			"2. List 2",
+			"\t1. Sub list (images)",
+			"\t   ",
+			"\t\t![[Pasted image 20231010114953.png]]",
+			"\t\t",
+			"\t\t![[Pasted image 20231010115214.png]]",
+		].join("\n"),
+		pageTitle: "Nested List Images",
+		frontmatter: {},
+	};
+
+	const adfFile = convertMDtoADF(markdown, testSettings);
+
+	expect(collectMediaUrls(adfFile.contents)).toEqual([
+		"file://Pasted image 20231010114953.png",
+		"file://Pasted image 20231010115214.png",
+	]);
+});
+
+test("parses image size hints from wikilink and markdown image syntax", () => {
+	const markdown: MarkdownFile = {
+		folderName: "images",
+		absoluteFilePath: "/path/to/images.md",
+		fileName: "images.md",
+		contents: [
+			"![[./img/chewbacca.png|111]]",
+			"",
+			"![chewy|222x333](./img/chewbacca.png)",
+		].join("\n"),
+		pageTitle: "Sized Images",
+		frontmatter: {},
+	};
+
+	const adfFile = convertMDtoADF(markdown, testSettings);
+	const mediaAttrs = collectMediaAttrs(adfFile.contents);
+
+	expect(mediaAttrs[0]).toMatchObject({
+		type: "file",
+		url: "file://./img/chewbacca.png",
+		width: 111,
+	});
+	expect(mediaAttrs[1]).toMatchObject({
+		height: 333,
+		type: "file",
+		url: "file://./img/chewbacca.png",
+		width: 222,
+	});
+});
+
+test("parses non-image wikilink embeds as uploadable file media", () => {
+	const markdown: MarkdownFile = {
+		folderName: "attachments",
+		absoluteFilePath: "/path/to/attachments.md",
+		fileName: "attachments.md",
+		contents: "![[profiles/render.cpuprofile]]",
+		pageTitle: "Profile",
+		frontmatter: {},
+	};
+
+	const adfFile = convertMDtoADF(markdown, testSettings);
+
+	expect(collectMediaUrls(adfFile.contents)).toEqual(["file://profiles/render.cpuprofile"]);
+});
+
+function collectMediaUrls(node: unknown): string[] {
+	return collectMediaAttrs(node)
+		.map((attrs) => attrs["url"])
+		.filter((url): url is string => typeof url === "string");
+}
+
+function collectMediaAttrs(node: unknown): Record<string, unknown>[] {
+	if (!node || typeof node !== "object") {
+		return [];
+	}
+
+	const record = node as Record<string, unknown>;
+	const attrs =
+		record["type"] === "media" && record["attrs"] && typeof record["attrs"] === "object"
+			? [record["attrs"] as Record<string, unknown>]
+			: [];
+	const content = Array.isArray(record["content"]) ? record["content"] : [];
+
+	return [...attrs, ...content.flatMap(collectMediaAttrs)];
+}


### PR DESCRIPTION
## Summary
- parse media embeds with non-stateful detection so repeated/list wikilink images are not skipped
- preserve requested image dimensions after attachment upload, including Obsidian `![[image.png|111]]` and Markdown `![alt|222x333](image.png)` syntax
- add regression coverage for non-image wikilink embeds, MP4 uploads, and unknown file-type fallback handling

Closes #657
Closes #539
Closes #501
Closes #364
Refs #630

## Validation
- `vp install --frozen-lockfile`
- `vp test run packages/lib/src/MdToADF.test.ts packages/lib/src/Attachments.test.ts packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.test.ts`
- `vp run fmt:check`
- `vp run check`
- `vp test run`
- `vp run build`

All validation was run with Node.js 24.15.0 via `vp env use 24.15.0`.