### PR TITLE
fix: clarify publishing hierarchy mapping

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -147,6 +147,16 @@ This scans `phil` and publishes only files under `phil/thingy`:
 }
 ```
 
+### Publishing Hierarchy and Folder Notes
+
+Markdown Confluence builds the Confluence page tree from the relative paths of the Markdown files it publishes. The common local root maps to `confluenceParentId`; it is not created as an extra child page.
+
+To publish each repository under a repo-named sub-page such as `parent-page/hello-world`, either set `confluenceParentId` to the existing `hello-world` page ID for that repository run, or keep a `hello-world` folder in the scanned Markdown tree so the folder becomes the sub-page under `confluenceParentId`. There is no separate global "sub-parent page name" setting.
+
+A folder can provide its own page content with a folder note. The folder note can be named the same as the folder, `index.md`, `README.md`, or `readme.md`. When an `index.md` or `README.md` folder note has no explicit `connie-title` and no first-heading title, the folder name is used as the Confluence page title. At the publishing root, an `index.md` or `README.md` folder note updates the configured parent page's content instead of creating a child page named `index` or `README`.
+
+Only local Markdown files are published. Pages created directly in Confluence are not pulled into the local tree or published automatically. To manage an existing Confluence page from Markdown, create a local Markdown file and set `connie-page-id` to that page ID.
+
 ### Per-page Frontmatter
 
 Individual Markdown files can override publishing behavior with frontmatter:

--- a/packages/lib/src/TreeConfluence.test.ts
+++ b/packages/lib/src/TreeConfluence.test.ts
@@ -9,12 +9,20 @@ import { ensureAllFilesExistInConfluence } from "./TreeConfluence";
 import { LocalAdfFileTreeNode } from "./Publisher";
 import { BinaryFile, FilesToUpload, MarkdownFile, MarkdownWorkspace } from "./MarkdownWorkspace";
 
-test("writes the parent page id back to a markdown-backed root page", async () => {
+test("publishes a markdown-backed root page as the configured parent page", async () => {
 	const updateCalls: UpdateCall[] = [];
 	const workspace = new TestMarkdownWorkspace(updateCalls);
+	const confluenceClient = createConfluenceClientWithPages({
+		"123456": createContentPage({
+			id: "123456",
+			title: "Docs Home",
+			spaceKey: "SPACE",
+			ancestors: [{ id: "space-root" }],
+		}),
+	});
 
 	const pages = await ensureAllFilesExistInConfluence(
-		{} as RequiredConfluenceClient,
+		confluenceClient,
 		workspace,
 		createRootNode("docs/index.md"),
 		"SPACE",
@@ -23,7 +31,9 @@ test("writes the parent page id back to a markdown-backed root page", async () =
 		testSettings,
 	);
 
-	expect(pages).toEqual([]);
+	expect(pages.map((page) => page.file.pageId)).toEqual(["123456"]);
+	expect(pages[0]?.file.pageTitle).toBe("Docs Home");
+	expect(pages[0]?.ancestors).toEqual(["space-root"]);
 	expect(updateCalls).toEqual([
 		{
 			absoluteFilePath: "docs/index.md",
@@ -59,9 +69,18 @@ test("clears stale page ids and creates the page by title", async () => {
 	const notFound = Object.assign(new Error("Not Found"), {
 		response: { status: 404 },
 	});
+	const parentPage = createContentPage({
+		id: "123456",
+		title: "Docs Home",
+		spaceKey: "SPACE",
+		ancestors: [{ id: "space-root" }],
+	});
 	const confluenceClient = {
 		content: {
-			getContentById: async () => {
+			getContentById: async ({ id }: { id: string }) => {
+				if (id === parentPage.id) {
+					return parentPage;
+				}
 				throw notFound;
 			},
 			getContent: async () => ({ results: [] }),
@@ -101,7 +120,7 @@ test("clears stale page ids and creates the page by title", async () => {
 		testSettings,
 	);
 
-	expect(pages.map((page) => page.file.pageId)).toEqual(["new-child-page"]);
+	expect(pages.map((page) => page.file.pageId)).toEqual(["123456", "new-child-page"]);
 	expect(updateCalls).toEqual([
 		{
 			absoluteFilePath: "docs/index.md",
@@ -123,6 +142,80 @@ test("clears stale page ids and creates the page by title", async () => {
 				publish: true,
 				pageId: "new-child-page",
 			},
+		},
+	]);
+});
+
+test("creates children in the space resolved from an explicit parent page id", async () => {
+	const updateCalls: UpdateCall[] = [];
+	const workspace = new TestMarkdownWorkspace(updateCalls);
+	const createContentCalls: unknown[] = [];
+	const confluenceClient = {
+		content: {
+			getContentById: async ({ id }: { id: string }) => {
+				if (id === "123456") {
+					return createContentPage({
+						id: "123456",
+						title: "Docs Home",
+						spaceKey: "SPACE",
+					});
+				}
+				return createContentPage({
+					id: "other-space-parent",
+					title: "Other Space Parent",
+					spaceKey: "OTHER",
+				});
+			},
+			getContent: async () => ({ results: [] }),
+			createContent: async (request: unknown) => {
+				createContentCalls.push(request);
+				return createContentPage({
+					id: "other-space-child",
+					title: "Child",
+					spaceKey: "OTHER",
+					ancestors: [{ id: "other-space-parent" }],
+				});
+			},
+		},
+	} as unknown as RequiredConfluenceClient;
+
+	const pages = await ensureAllFilesExistInConfluence(
+		confluenceClient,
+		workspace,
+		createRootNode("docs/index.md", [
+			createRootNode(
+				"docs/other-parent.md",
+				[
+					createRootNode("docs/child.md", {
+						absoluteFilePath: "docs/child.md",
+						pageTitle: "Child",
+					}),
+				],
+				{
+					absoluteFilePath: "docs/other-parent.md",
+					pageId: "other-space-parent",
+					pageTitle: "Other Space Parent",
+				},
+			),
+		]),
+		"SPACE",
+		"123456",
+		"123456",
+		testSettings,
+	);
+
+	expect(pages.map((page) => [page.file.pageId, page.file.spaceKey])).toEqual([
+		["123456", "SPACE"],
+		["other-space-parent", "OTHER"],
+		["other-space-child", "OTHER"],
+	]);
+	expect(pages[1]?.ancestors).toEqual([]);
+	expect(pages[2]?.ancestors).toEqual(["other-space-parent"]);
+	expect(createContentCalls).toMatchObject([
+		{
+			space: { key: "OTHER" },
+			ancestors: [{ id: "other-space-parent" }],
+			title: "Child",
 		},
 	]);
 });
@@ -165,9 +258,12 @@ function createRootNode(
 	childrenOrOverrides:
 		| LocalAdfFileTreeNode[]
 		| Partial<NonNullable<LocalAdfFileTreeNode["file"]>> = [],
+	overridesWhenChildren: Partial<NonNullable<LocalAdfFileTreeNode["file"]>> = {},
 ): LocalAdfFileTreeNode {
 	const children = Array.isArray(childrenOrOverrides) ? childrenOrOverrides : [];
-	const overrides = Array.isArray(childrenOrOverrides) ? {} : childrenOrOverrides;
+	const overrides = Array.isArray(childrenOrOverrides)
+		? overridesWhenChildren
+		: childrenOrOverrides;
 
 	return {
 		name: "docs",
@@ -185,6 +281,50 @@ function createRootNode(
 			contentType: "page",
 			blogPostDate: undefined,
 			...overrides,
+		},
+	};
+}
+
+function createConfluenceClientWithPages(
+	pagesById: Record<string, ReturnType<typeof createContentPage>>,
+): RequiredConfluenceClient {
+	return {
+		content: {
+			getContentById: async ({ id }: { id: string }) => pagesById[id],
+		},
+	} as unknown as RequiredConfluenceClient;
+}
+
+function createContentPage({
+	id,
+	title,
+	spaceKey,
+	ancestors = [],
+}: {
+	id: string;
+	title: string;
+	spaceKey: string;
+	ancestors?: { id: string }[];
+}) {
+	return {
+		id,
+		title,
+		type: "page",
+		version: {
+			number: 1,
+			by: {
+				accountId: "current-user",
+			},
+		},
+		body: {
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			atlas_doc_format: {
+				value: JSON.stringify(doc(p("Existing page"))),
+			},
+		},
+		ancestors,
+		space: {
+			key: spaceKey,
 		},
 	};
 }

--- a/packages/lib/src/TreeConfluence.ts
+++ b/packages/lib/src/TreeConfluence.ts
@@ -30,23 +30,39 @@ interface PageDetails {
 	contentType: string;
 }
 
-function flattenTree(node: ConfluenceTreeNode, ancestors: string[] = []): ConfluenceNode[] {
+function flattenTree(
+	node: ConfluenceTreeNode,
+	ancestors: string[] = [],
+	includeCurrent = ancestors.length > 0,
+	parentSpaceKey?: string,
+): ConfluenceNode[] {
 	const nodes: ConfluenceNode[] = [];
 	const { file, version, lastUpdatedBy, existingPageData, children } = node;
+	const crossesSpace = parentSpaceKey !== undefined && parentSpaceKey !== file.spaceKey;
 
-	if (ancestors.length > 0) {
+	if (includeCurrent) {
 		nodes.push({
 			file,
 			version,
 			lastUpdatedBy,
 			existingPageData,
-			ancestors,
+			ancestors:
+				ancestors.length > 0 && !crossesSpace
+					? ancestors
+					: existingPageData.ancestors.map((ancestor) => ancestor.id),
 		});
 	}
 
 	if (children) {
 		children.forEach((child) => {
-			nodes.push(...flattenTree(child, [...ancestors, file.pageId]));
+			nodes.push(
+				...flattenTree(
+					child,
+					crossesSpace ? [file.pageId] : [...ancestors, file.pageId],
+					true,
+					file.spaceKey,
+				),
+			);
 		});
 	}
 
@@ -72,7 +88,7 @@ export function ensureAllFilesExistInConfluenceEffect(
 			false,
 		);
 
-		const pages = flattenTree(confluenceNode);
+		const pages = flattenTree(confluenceNode, [], confluenceNode.version > 0);
 
 		yield* Effect.sync(() => prepareAdfToUpload(pages, settings));
 
@@ -125,7 +141,7 @@ function createFileStructureInConfluenceEffect(
 		let contentType = "page";
 		let ancestors: { id: string }[] = [];
 		let lastUpdatedBy: string | undefined;
-		const file: ConfluenceAdfFile = {
+		let file: ConfluenceAdfFile = {
 			...node.file,
 			pageId: parentPageId,
 			spaceKey,
@@ -154,35 +170,57 @@ function createFileStructureInConfluenceEffect(
 			contentType = pageDetails.contentType;
 		} else {
 			if (isMarkdownBackedFile(node.file)) {
+				const pageDetails = yield* getPageDetailsByIdEffect(
+					confluenceClient,
+					parentPageId,
+					settings,
+				);
 				yield* updateMarkdownValuesEffect(node.file.absoluteFilePath, {
 					publish: true,
-					pageId: parentPageId,
+					pageId: pageDetails.id,
 				});
-			}
 
-			version = 0;
-			adfContent = doc(p());
-			pageTitle = "";
-			ancestors = [];
-			contentType = "page";
+				file = {
+					...file,
+					pageId: pageDetails.id,
+					spaceKey: pageDetails.spaceKey,
+					pageTitle: pageDetails.pageTitle,
+				};
+				version = pageDetails.version;
+				adfContent = yield* Effect.try({
+					try: () => JSON.parse(pageDetails.existingAdf ?? "{}") as JSONDocNode,
+					catch: toError,
+				});
+				pageTitle = pageDetails.pageTitle;
+				ancestors = pageDetails.ancestors;
+				lastUpdatedBy = pageDetails.lastUpdatedBy;
+				contentType = pageDetails.contentType;
+			} else {
+				version = 0;
+				adfContent = doc(p());
+				pageTitle = "";
+				ancestors = [];
+				contentType = "page";
+			}
 		}
 
+		const childTopPageId = file.spaceKey === spaceKey ? topPageId : file.pageId;
 		const childDetails: ConfluenceTreeNode[] = yield* Effect.all(
 			node.children.map((childNode) =>
 				createFileStructureInConfluenceEffect(
 					settings,
 					confluenceClient,
 					childNode,
-					spaceKey,
+					file.spaceKey,
 					file.pageId,
-					topPageId,
+					childTopPageId,
 					true,
 				),
 			),
 			{ concurrency: "unbounded" },
 		);
 
-		const pageUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${spaceKey}/pages/${file.pageId}/`;
+		const pageUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${file.spaceKey}/pages/${file.pageId}/`;
 		return {
 			file: { ...file, pageUrl },
 			version,
@@ -202,6 +240,42 @@ function isMarkdownBackedFile(file: LocalAdfFile): boolean {
 	return file.absoluteFilePath.toLowerCase().endsWith(".md");
 }
 
+function getPageDetailsByIdEffect(
+	confluenceClient: RequiredConfluenceClient,
+	pageId: string,
+	settings: ConfluenceSettings,
+): Effect.Effect<PageDetails, unknown> {
+	return Effect.tryPromise({
+		try: () =>
+			confluenceClient.content.getContentById({
+				id: pageId,
+				expand: ["version", "body.atlas_doc_format", "ancestors", "space"],
+			}),
+		catch: identity,
+	}).pipe(
+		Effect.flatMap((contentById) => {
+			if (!contentById.space?.key) {
+				return Effect.fail(createMissingSpaceKeyError(pageId, settings.confluenceBaseUrl));
+			}
+
+			return Effect.succeed({
+				id: contentById.id,
+				title: contentById.title,
+				version: contentById?.version?.number ?? 1,
+				lastUpdatedBy: contentById?.version?.by?.accountId ?? "NO ACCOUNT ID",
+				existingAdf: contentById?.body?.atlas_doc_format?.value,
+				spaceKey: contentById.space.key,
+				pageTitle: contentById.title,
+				ancestors:
+					contentById.ancestors?.map((ancestor) => ({
+						id: ancestor.id,
+					})) ?? [],
+				contentType: contentById.type,
+			});
+		}),
+	);
+}
+
 function ensurePageExistsEffect(
 	confluenceClient: RequiredConfluenceClient,
 	file: LocalAdfFile,
@@ -213,41 +287,25 @@ function ensurePageExistsEffect(
 	if (file.pageId) {
 		const pageId = file.pageId;
 
-		return Effect.tryPromise({
-			try: () =>
-				confluenceClient.content.getContentById({
-					id: pageId,
-					expand: ["version", "body.atlas_doc_format", "ancestors", "space"],
-				}),
-			catch: identity,
-		}).pipe(
-			Effect.flatMap((contentById) => {
-				if (!contentById.space?.key) {
-					return Effect.fail(
-						createMissingSpaceKeyError(pageId, settings.confluenceBaseUrl),
-					);
-				}
-
-				return updateMarkdownValuesEffect(file.absoluteFilePath, {
+		return getPageDetailsByIdEffect(confluenceClient, pageId, settings).pipe(
+			Effect.flatMap((pageDetails) =>
+				updateMarkdownValuesEffect(file.absoluteFilePath, {
 					publish: true,
-					pageId: contentById.id,
+					pageId: pageDetails.id,
 				}).pipe(
 					Effect.as({
-						id: contentById.id,
+						id: pageDetails.id,
 						title: file.pageTitle,
-						version: contentById?.version?.number ?? 1,
-						lastUpdatedBy: contentById?.version?.by?.accountId ?? "NO ACCOUNT ID",
-						existingAdf: contentById?.body?.atlas_doc_format?.value,
-						spaceKey: contentById.space.key,
-						pageTitle: contentById.title,
-						ancestors:
-							contentById.ancestors?.map((ancestor) => ({
-								id: ancestor.id,
-							})) ?? [],
-						contentType: contentById.type,
+						version: pageDetails.version,
+						lastUpdatedBy: pageDetails.lastUpdatedBy,
+						existingAdf: pageDetails.existingAdf,
+						spaceKey: pageDetails.spaceKey,
+						pageTitle: pageDetails.pageTitle,
+						ancestors: pageDetails.ancestors,
+						contentType: pageDetails.contentType,
 					}),
-				);
-			}),
+				),
+			),
 			Effect.catch((error) => {
 				if (isNotFoundError(error)) {
 					return updateMarkdownValuesEffect(file.absoluteFilePath, {

--- a/packages/lib/src/TreeLocal.test.ts
+++ b/packages/lib/src/TreeLocal.test.ts
@@ -61,7 +61,116 @@ test("preserves nested synthetic folder paths", async () => {
 	expect(subsection?.file?.absoluteFilePath).toBe(result.expectedSubsectionPath);
 });
 
-function createMarkdownFile(filesystemPath: Path, absoluteFilePath: string): MarkdownFile {
+test("uses folder names for README folder notes without explicit titles", async () => {
+	const result = await runEffect(
+		Effect.gen(function* () {
+			const filesystemPath = yield* Path;
+			const tree = createFolderStructure(
+				[
+					createMarkdownFile(
+						filesystemPath,
+						filesystemPath.join("docs", "folder-one", "README.md"),
+					),
+					createMarkdownFile(
+						filesystemPath,
+						filesystemPath.join("docs", "folder-two", "README.md"),
+					),
+				],
+				testSettings,
+			);
+
+			return tree;
+		}),
+	);
+
+	expect(result.children.map((child) => child.file?.pageTitle)).toEqual([
+		"folder-one",
+		"folder-two",
+	]);
+});
+
+test("preserves explicit README folder note titles", async () => {
+	const result = await runEffect(
+		Effect.gen(function* () {
+			const filesystemPath = yield* Path;
+			const tree = createFolderStructure(
+				[
+					createMarkdownFile(
+						filesystemPath,
+						filesystemPath.join("docs", "folder-one", "README.md"),
+						{
+							contents: "# Explicit Title",
+							frontmatter: { "connie-title": "Explicit Title" },
+						},
+					),
+					createMarkdownFile(filesystemPath, filesystemPath.join("docs", "sibling.md")),
+				],
+				testSettings,
+			);
+
+			return tree;
+		}),
+	);
+
+	expect(result.children[0]?.file?.pageTitle).toBe("Explicit Title");
+});
+
+test("allows duplicate page titles when every duplicate has an explicit page id", async () => {
+	const tree = await runEffect(
+		Effect.gen(function* () {
+			const filesystemPath = yield* Path;
+			return createFolderStructure(
+				[
+					createMarkdownFile(filesystemPath, filesystemPath.join("docs", "one.md"), {
+						frontmatter: {
+							"connie-title": "Shared Title",
+							"connie-page-id": "111",
+						},
+					}),
+					createMarkdownFile(filesystemPath, filesystemPath.join("docs", "two.md"), {
+						frontmatter: {
+							"connie-title": "Shared Title",
+							"connie-page-id": "222",
+						},
+					}),
+				],
+				testSettings,
+			);
+		}),
+	);
+
+	expect(tree.children.map((child) => child.file?.pageTitle)).toEqual([
+		"Shared Title",
+		"Shared Title",
+	]);
+});
+
+test("rejects duplicate page titles without explicit page ids", async () => {
+	await expect(
+		runEffect(
+			Effect.gen(function* () {
+				const filesystemPath = yield* Path;
+				return createFolderStructure(
+					[
+						createMarkdownFile(filesystemPath, filesystemPath.join("docs", "one.md"), {
+							frontmatter: { "connie-title": "Shared Title" },
+						}),
+						createMarkdownFile(filesystemPath, filesystemPath.join("docs", "two.md"), {
+							frontmatter: { "connie-title": "Shared Title" },
+						}),
+					],
+					testSettings,
+				);
+			}),
+		),
+	).rejects.toThrow('Page title "Shared Title" is not unique across all files.');
+});
+
+function createMarkdownFile(
+	filesystemPath: Path,
+	absoluteFilePath: string,
+	overrides: Partial<MarkdownFile> = {},
+): MarkdownFile {
 	const parsedFilePath = filesystemPath.parse(absoluteFilePath);
 
 	return {
@@ -71,6 +180,7 @@ function createMarkdownFile(filesystemPath: Path, absoluteFilePath: string): Mar
 		contents: `# ${parsedFilePath.name}`,
 		pageTitle: parsedFilePath.name,
 		frontmatter: {},
+		...overrides,
 	};
 }
 

--- a/packages/lib/src/TreeLocal.ts
+++ b/packages/lib/src/TreeLocal.ts
@@ -37,6 +37,8 @@ const createTreeNode = (name: string): LocalAdfFileTreeNode => ({
 	children: [],
 });
 
+const folderNoteFileNames = ["index", "README", "readme"];
+
 const resolveTreeNodePath = (contentRootPath: string, nodeName: string, path: Path): string => {
 	if (nodeName === contentRootPath) {
 		return nodeName;
@@ -76,16 +78,21 @@ const addFileToTree = (
 
 const processNode = (treeRootPath: string, node: LocalAdfFileTreeNode, path: Path) => {
 	if (!node.file) {
-		let indexFile = node.children.find((child) => path.parse(child.name).name === node.name);
+		const nodePageTitle = path.basename(node.name);
+		let indexFile = node.children.find(
+			(child) => path.parse(child.name).name === nodePageTitle,
+		);
 		if (!indexFile) {
-			// Support FolderFile with a file name of "index.md"
-			indexFile = node.children.find((child) =>
-				["index", "README", "readme"].includes(path.parse(child.name).name),
-			);
+			// Support FolderFile with file names such as "index.md" and "README.md".
+			indexFile = folderNoteFileNames
+				.map((fileName) =>
+					node.children.find((child) => path.parse(child.name).name === fileName),
+				)
+				.find((child) => child !== undefined);
 		}
 
 		if (indexFile && indexFile.file) {
-			node.file = indexFile.file;
+			node.file = withFolderNotePageTitle(indexFile.file, nodePageTitle, path);
 			node.children = node.children.filter((child) => child !== indexFile);
 		} else {
 			node.file = {
@@ -105,6 +112,9 @@ const processNode = (treeRootPath: string, node: LocalAdfFileTreeNode, path: Pat
 	}
 
 	const nodeFile = node.file;
+	if (!nodeFile) {
+		throw new Error("Missing file on node");
+	}
 	const childTreeRootPath =
 		nodeFile.contents === (folderFile as JSONDocNode)
 			? nodeFile.absoluteFilePath
@@ -112,6 +122,24 @@ const processNode = (treeRootPath: string, node: LocalAdfFileTreeNode, path: Pat
 
 	node.children.forEach((childNode) => processNode(childTreeRootPath, childNode, path));
 };
+
+function withFolderNotePageTitle(
+	file: NonNullable<LocalAdfFileTreeNode["file"]>,
+	nodePageTitle: string,
+	path: Path,
+): NonNullable<LocalAdfFileTreeNode["file"]> {
+	if (!nodePageTitle) {
+		return file;
+	}
+
+	const fileTitle = path.parse(file.fileName).name;
+	const shouldUseFolderTitle =
+		folderNoteFileNames.includes(fileTitle) &&
+		file.pageTitle === fileTitle &&
+		typeof file.frontmatter["connie-title"] !== "string";
+
+	return shouldUseFolderTitle ? { ...file, pageTitle: nodePageTitle } : file;
+}
 
 export const createFolderStructure = (
 	markdownFiles: MarkdownFile[],
@@ -148,14 +176,26 @@ export const createFolderStructureEffect = (
 
 function checkUniquePageTitle(
 	rootNode: LocalAdfFileTreeNode,
-	pageTitles: Set<string> = new Set<string>(),
+	pageTitles: Map<string, NonNullable<LocalAdfFileTreeNode["file"]>[]> = new Map(),
 ) {
-	const currentPageTitle = rootNode.file?.pageTitle ?? "";
+	const currentFile = rootNode.file;
 
-	if (pageTitles.has(currentPageTitle)) {
+	if (!currentFile) {
+		rootNode.children.forEach((child) => checkUniquePageTitle(child, pageTitles));
+		return;
+	}
+
+	const currentPageTitle = currentFile.pageTitle;
+	const existingFiles = pageTitles.get(currentPageTitle) ?? [];
+
+	if (
+		existingFiles.length > 0 &&
+		!existingFiles.concat(currentFile).every((file) => file.pageId)
+	) {
 		throw new Error(`Page title "${currentPageTitle}" is not unique across all files.`);
 	}
-	pageTitles.add(currentPageTitle);
+
+	pageTitles.set(currentPageTitle, existingFiles.concat(currentFile));
 	rootNode.children.forEach((child) => checkUniquePageTitle(child, pageTitles));
 }
 

--- a/packages/obsidian/README.md
+++ b/packages/obsidian/README.md
@@ -62,6 +62,14 @@ connie-publish: true
 3. Add notes to this folder or add the connie-publish frontmatter to other notes.
 4. Click the cloud icon in the ribbon or use the "Publish All to Confluence" command to publish your notes to Confluence.
 
+### Publishing hierarchy
+
+The configured `Confluence Parent Id` is the Confluence page that represents the root of the local publishing tree. The `Folder To Publish` folder is not created as an extra child page under that parent.
+
+To publish the root parent page's content from Obsidian, add a folder note at the root of `Folder To Publish`. The folder note can be named the same as the folder, `index.md`, `README.md`, or `readme.md`. Subfolders use the same folder-note names for their folder pages.
+
+Pages created directly in Confluence are not imported into Obsidian or published automatically. To manage an existing Confluence page from Obsidian, create a local note and set its `connie-page-id` frontmatter to the Confluence page ID.
+
 ### Contributing
 Contributions are welcome! If you have a feature request, bug report, or want to improve the plugin, please open an issue or submit a pull request on the GitHub repository.
 


### PR DESCRIPTION
## Summary
- publish a Markdown-backed root folder note as the configured Confluence parent page content while preserving that parent page's existing title and ancestors
- make README/index folder notes without explicit titles use their folder name, and keep duplicate title protection except when every duplicate is page-id-backed
- carry page-id-resolved spaces into child page creation and document hierarchy, sub-parent, folder-note, and existing-Confluence-page behavior

## Issues
- Closes #58
- Closes #553
- Closes #596
- Closes #622
- Closes #638
- Closes #641
- Closes #655
- Refs #61; current code already avoids creating the configured sync folder as an extra child page, and this PR documents that mapping

## Validation
- `vp env exec --node 24.15.0 vp install --frozen-lockfile`
- `vp env exec --node 24.15.0 vp test run packages/lib/src/TreeLocal.test.ts packages/lib/src/TreeConfluence.test.ts`
- `vp env exec --node 24.15.0 vp run fmt:check`
- `vp env exec --node 24.15.0 vp run check`
- `vp env exec --node 24.15.0 vp test run`
- `vp env exec --node 24.15.0 vp run build`
