### PR TITLE
fix: reduce unchanged publish churn

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,7 +100,8 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
   "atlassianApiToken": "optional-token-from-config",
   "folderToPublish": "docs",
   "contentRoot": ".",
-  "firstHeadingPageTitle": false
+  "firstHeadingPageTitle": false,
+  "forceOverwrite": false
 }
 ```
 
@@ -115,6 +116,7 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
 | `folderToPublish` | `FOLDER_TO_PUBLISH` | `--enableFolder`, `-f` | The folder, relative to `contentRoot`, whose Markdown files default to `connie-publish: true`. Use `.` to publish all Markdown files under `contentRoot`. |
 | `contentRoot` | `CONFLUENCE_CONTENT_ROOT` | `--contentRoot`, `--cr` | The root directory to scan for Markdown files and referenced content. |
 | `firstHeadingPageTitle` | `CONFLUENCE_FIRST_HEADING_PAGE_TITLE` | `--firstHeaderPageTitle`, `--fh` | When `true`, use the first heading as the page title when `connie-title` is not set. |
+| `forceOverwrite` | `CONFLUENCE_FORCE_OVERWRITE` | `--forceOverwrite`, `--fo` | When `true`, publish over pages last updated by another user. Leave this `false` to preserve Confluence-side edits. |
 
 ### `folderToPublish` vs `contentRoot`
 

--- a/packages/lib/src/AdfEqual.test.ts
+++ b/packages/lib/src/AdfEqual.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@effect/vitest";
+import { ADFEntity } from "@atlaskit/adf-utils/types";
+import { adfEqual } from "./AdfEqual";
+
+test("ignores Confluence macro metadata when comparing raw ADF", () => {
+	const serverAdf = docWithJiraMacro({
+		macroParams: {
+			jqlQuery: { value: "assignee=currentUser() AND resolution is empty" },
+			maximumIssues: { value: "10" },
+		},
+		macroMetadata: {
+			macroId: { value: "2b8fb396-76b2-43ac-81a8-aaf75bb8d229" },
+			schemaVersion: { value: "1" },
+			title: "Jira",
+		},
+	});
+	const generatedAdf = docWithJiraMacro({
+		macroParams: {
+			jqlQuery: { value: "assignee=currentUser() AND resolution is empty" },
+			maximumIssues: { value: "10" },
+		},
+	});
+
+	expect(adfEqual(serverAdf, generatedAdf)).toBe(true);
+	expect(getMacroParameters(serverAdf)["macroMetadata"]).toBeDefined();
+});
+
+test("keeps semantic macro parameter differences in the ADF comparison", () => {
+	const serverAdf = docWithJiraMacro({
+		macroParams: {
+			jqlQuery: { value: "assignee=currentUser() AND resolution is empty" },
+			maximumIssues: { value: "10" },
+		},
+		macroMetadata: {
+			macroId: { value: "2b8fb396-76b2-43ac-81a8-aaf75bb8d229" },
+		},
+	});
+	const generatedAdf = docWithJiraMacro({
+		macroParams: {
+			jqlQuery: { value: "project = DOCS" },
+			maximumIssues: { value: "10" },
+		},
+	});
+
+	expect(adfEqual(serverAdf, generatedAdf)).toBe(false);
+});
+
+function docWithJiraMacro(parameters: Record<string, unknown>): ADFEntity {
+	return {
+		type: "doc",
+		version: 1,
+		content: [
+			{
+				type: "extension",
+				attrs: {
+					layout: "full-width",
+					extensionType: "com.atlassian.confluence.macro.core",
+					extensionKey: "jira",
+					parameters,
+				},
+			},
+		],
+	} as ADFEntity;
+}
+
+function getMacroParameters(adf: ADFEntity): Record<string, unknown> {
+	const extension = adf.content?.[0];
+	if (!extension?.attrs || typeof extension.attrs !== "object") {
+		throw new Error("Missing extension attrs");
+	}
+
+	const parameters = extension.attrs["parameters"];
+	if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+		throw new Error("Missing extension parameters");
+	}
+
+	return parameters as Record<string, unknown>;
+}

--- a/packages/lib/src/AdfEqual.ts
+++ b/packages/lib/src/AdfEqual.ts
@@ -31,8 +31,33 @@ export function orderMarks(adf: ADFEntity) {
 	});
 }
 
+export function normalizeAdfForComparison(adf: ADFEntity): ADFEntity {
+	return traverse(cloneAdf(adf), {
+		any: (node, __parent) => {
+			if (node.marks) {
+				node.marks = sortDeep(node.marks);
+			}
+
+			const parameters = node.attrs?.["parameters"];
+			if (
+				isRecord(parameters) &&
+				Object.prototype.hasOwnProperty.call(parameters, "macroMetadata")
+			) {
+				const semanticParameters = { ...parameters };
+				delete semanticParameters["macroMetadata"];
+				node.attrs = {
+					...node.attrs,
+					parameters: semanticParameters,
+				};
+			}
+
+			return node;
+		},
+	}) as ADFEntity;
+}
+
 export function adfEqual(first: ADFEntity, second: ADFEntity): boolean {
-	return isEqual(orderMarks(first), orderMarks(second));
+	return isEqual(normalizeAdfForComparison(first), normalizeAdfForComparison(second));
 }
 
 export function marksEqual(
@@ -44,4 +69,12 @@ export function marksEqual(
 	}
 
 	return isEqual(sortDeep(first), sortDeep(second));
+}
+
+function cloneAdf(adf: ADFEntity): ADFEntity {
+	return JSON.parse(JSON.stringify(adf)) as ADFEntity;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -96,4 +96,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	forceOverwrite: false,
 };

--- a/packages/lib/src/MarkdownWorkspace.test.ts
+++ b/packages/lib/src/MarkdownWorkspace.test.ts
@@ -142,4 +142,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	forceOverwrite: false,
 };

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -254,6 +254,7 @@ test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 		folderToPublish: ".",
 		contentRoot: "./",
 		firstHeadingPageTitle: false,
+		forceOverwrite: false,
 	};
 	const adfFile = convertMDtoADF(markdown, settings);
 	expect(adfFile).toMatchSnapshot();
@@ -285,6 +286,7 @@ test("parses callout with adjacent wikilink image", () => {
 		folderToPublish: ".",
 		contentRoot: "./",
 		firstHeadingPageTitle: false,
+		forceOverwrite: false,
 	};
 
 	const adfFile = convertMDtoADF(markdown, settings);

--- a/packages/lib/src/Publisher.test.ts
+++ b/packages/lib/src/Publisher.test.ts
@@ -3,10 +3,16 @@
 import { expect, test } from "@effect/vitest";
 import { ConfluenceClient } from "confluence.js";
 import { Effect } from "effect";
+import SparkMD5 from "spark-md5";
 import { orderMarks } from "./AdfEqual";
+import { ADFProcessingPlugin, PublisherFunctions } from "./ADFProcessingPlugins";
+import { UploadedImageData } from "./Attachments";
 import { ConfluencePerPageAllValues } from "./ConniePageConfig";
+import { RequiredConfluenceClient } from "./ConfluenceClient";
 import { Publisher } from "./Publisher";
 import { loadConfluenceSettings } from "./SettingsConfig";
+import { ConfluenceSettings } from "./Settings";
+import { parseMarkdownToADF } from "./MdToADF";
 import {
 	ChartData,
 	MermaidRenderer,
@@ -250,6 +256,93 @@ class InMemoryMarkdownWorkspace implements MarkdownWorkspace {
 	}
 }
 
+test("reports reused attachments as unchanged without uploading them again", async () => {
+	const attachmentBuffer = Buffer.from("unchanged attachment");
+	const attachmentHash = md5(attachmentBuffer);
+	const uploadRequests: unknown[] = [];
+
+	const { result, updateContentRequests } = await publishSinglePage({
+		plugins: [new UploadBufferPlugin("diagram.txt", attachmentBuffer, "text/plain")],
+		attachments: [
+			{
+				title: "diagram.txt",
+				filehash: attachmentHash,
+				fileId: "existing-file-id",
+				collectionName: "contentId-page-id",
+			},
+		],
+		uploadRequests,
+	});
+
+	expect(result[0]?.successfulUploadResult?.imageResult).toBe("same");
+	expect(uploadRequests).toEqual([]);
+	expect(updateContentRequests).toEqual([]);
+});
+
+test("keeps the default last-updated-by guard when force overwrite is disabled", async () => {
+	const { result, updateContentRequests } = await publishSinglePage({
+		markdown: "Local content",
+		existingAdf: parseMarkdownToADF("Remote content", testPublishSettings.confluenceBaseUrl),
+		lastUpdatedBy: "other-user",
+	});
+
+	expect(result[0]?.reason).toContain("Page last updated by another user");
+	expect(updateContentRequests).toEqual([]);
+});
+
+test("allows publishing over another user's update when force overwrite is enabled", async () => {
+	const { result, updateContentRequests } = await publishSinglePage({
+		settings: {
+			...testPublishSettings,
+			forceOverwrite: true,
+		},
+		markdown: "Local content",
+		existingAdf: parseMarkdownToADF("Remote content", testPublishSettings.confluenceBaseUrl),
+		lastUpdatedBy: "other-user",
+	});
+
+	expect(result[0]?.successfulUploadResult?.contentResult).toBe("updated");
+	expect(updateContentRequests).toHaveLength(1);
+	expect(updateContentRequests[0]?.version).toEqual({ number: 2 });
+});
+
+test("preserves the current page space when the parent page should not change", async () => {
+	const { updateContentRequests } = await publishSinglePage({
+		markdown: "Local content",
+		existingAdf: parseMarkdownToADF("Remote content", testPublishSettings.confluenceBaseUrl),
+		pageSpaceKey: "SHARED",
+		dontChangeParentPageId: true,
+	});
+
+	expect(updateContentRequests).toHaveLength(1);
+	expect(updateContentRequests[0]?.ancestors).toBeUndefined();
+	expect(updateContentRequests[0]?.space).toEqual({ key: "SHARED" });
+});
+
+test("refetches the page version and retries content updates after a conflict", async () => {
+	let latestVersion = 2;
+	let shouldConflict = true;
+	const { updateContentRequests } = await publishSinglePage({
+		markdown: "Local content",
+		existingAdf: parseMarkdownToADF("Remote content", testPublishSettings.confluenceBaseUrl),
+		initialVersion: latestVersion,
+		getLatestVersion: () => latestVersion,
+		updateContent: async (request) => {
+			if (shouldConflict) {
+				shouldConflict = false;
+				latestVersion = 3;
+				throw Object.assign(new Error("Version conflict"), {
+					response: { status: 409 },
+				});
+			}
+			latestVersion = request.version.number;
+			return request;
+		},
+	});
+
+	expect(updateContentRequests.map((request) => request.version.number)).toEqual([3, 4]);
+});
+
 confluenceIntegrationTest(
 	"Upload to Confluence",
 	async () => {
@@ -306,3 +399,222 @@ confluenceIntegrationTest(
 	},
 	300000,
 );
+
+class UploadBufferPlugin implements ADFProcessingPlugin<undefined, UploadedImageData | null> {
+	constructor(
+		private readonly uploadFilename: string,
+		private readonly buffer: Buffer,
+		private readonly contentType: string,
+	) {}
+
+	extract(): undefined {
+		return undefined;
+	}
+
+	async transform(
+		_items: undefined,
+		supportFunctions: PublisherFunctions,
+	): Promise<UploadedImageData | null> {
+		return supportFunctions.uploadBuffer(this.uploadFilename, this.buffer, this.contentType);
+	}
+
+	load(adf: JSONDocNode): JSONDocNode {
+		return adf;
+	}
+}
+
+type AttachmentFixture = {
+	title: string;
+	filehash: string;
+	fileId: string;
+	collectionName: string;
+};
+
+type UpdateContentRequest = {
+	id: string;
+	title: string;
+	type: string;
+	version: { number: number };
+	body: {
+		atlas_doc_format: {
+			value: string;
+			representation: string;
+		};
+	};
+	ancestors?: { id: string }[];
+	space?: { key: string };
+};
+
+async function publishSinglePage({
+	settings = testPublishSettings,
+	markdown = "Hello",
+	existingAdf = parseMarkdownToADF(markdown, settings.confluenceBaseUrl),
+	lastUpdatedBy = "current-user",
+	initialVersion = 1,
+	pageSpaceKey = "SPACE",
+	dontChangeParentPageId = false,
+	plugins = [],
+	attachments = [],
+	uploadRequests = [],
+	getLatestVersion = () => initialVersion,
+	updateContent = async (request) => request,
+}: {
+	settings?: ConfluenceSettings;
+	markdown?: string;
+	existingAdf?: JSONDocNode;
+	lastUpdatedBy?: string;
+	initialVersion?: number;
+	pageSpaceKey?: string;
+	dontChangeParentPageId?: boolean;
+	plugins?: ADFProcessingPlugin<unknown, unknown>[];
+	attachments?: AttachmentFixture[];
+	uploadRequests?: unknown[];
+	getLatestVersion?: () => number;
+	updateContent?: (request: UpdateContentRequest) => Promise<unknown>;
+} = {}) {
+	const updateContentRequests: UpdateContentRequest[] = [];
+	const confluenceClient = makePublisherTestConfluenceClient({
+		existingAdf,
+		lastUpdatedBy,
+		initialVersion,
+		pageSpaceKey,
+		attachments,
+		uploadRequests,
+		getLatestVersion,
+		updateContent: async (request) => {
+			updateContentRequests.push(request);
+			return updateContent(request);
+		},
+	});
+	const workspace = new InMemoryMarkdownWorkspace([
+		{
+			folderName: "docs",
+			absoluteFilePath: "/docs/page.md",
+			fileName: "page.md",
+			contents: markdown,
+			pageTitle: "Page",
+			frontmatter: {
+				"connie-page-id": "page-id",
+				"connie-dont-change-parent-page": dontChangeParentPageId,
+			},
+		},
+	]);
+	const publisher = new Publisher(settings, confluenceClient, plugins);
+
+	const result = await runEffect(
+		publisher.publishEffect().pipe(Effect.provideService(MarkdownWorkspaceService, workspace)),
+	);
+
+	return {
+		result,
+		updateContentRequests,
+	};
+}
+
+function makePublisherTestConfluenceClient({
+	existingAdf,
+	lastUpdatedBy,
+	initialVersion,
+	pageSpaceKey,
+	attachments,
+	uploadRequests,
+	getLatestVersion,
+	updateContent,
+}: {
+	existingAdf: JSONDocNode;
+	lastUpdatedBy: string;
+	initialVersion: number;
+	pageSpaceKey: string;
+	attachments: AttachmentFixture[];
+	uploadRequests: unknown[];
+	getLatestVersion: () => number;
+	updateContent: (request: UpdateContentRequest) => Promise<unknown>;
+}): RequiredConfluenceClient {
+	return {
+		users: {
+			getCurrentUser: async () => ({ accountId: "current-user" }),
+		},
+		content: {
+			getContentById: async ({ id, expand }: { id: string; expand?: string[] }) => {
+				if (id === "parent-id") {
+					return {
+						id: "parent-id",
+						space: { key: "SPACE" },
+					};
+				}
+
+				const versionNumber =
+					expand?.length === 1 && expand[0] === "version"
+						? getLatestVersion()
+						: initialVersion;
+
+				return {
+					id: "page-id",
+					title: "Page",
+					type: "page",
+					version: {
+						number: versionNumber,
+						by: { accountId: lastUpdatedBy },
+					},
+					body: {
+						// eslint-disable-next-line @typescript-eslint/naming-convention
+						atlas_doc_format: {
+							value: JSON.stringify(existingAdf),
+						},
+					},
+					ancestors: [{ id: "parent-id" }],
+					space: { key: pageSpaceKey },
+				};
+			},
+			updateContent,
+		},
+		contentAttachments: {
+			getAttachments: async () => ({
+				results: attachments.map((attachment) => ({
+					title: attachment.title,
+					metadata: { comment: attachment.filehash },
+					extensions: {
+						fileId: attachment.fileId,
+						collectionName: attachment.collectionName,
+					},
+				})),
+			}),
+			createOrUpdateAttachments: async (request: unknown) => {
+				uploadRequests.push(request);
+				return {
+					results: [
+						{
+							extensions: {
+								fileId: "new-file-id",
+							},
+							container: {
+								id: "page-id",
+							},
+						},
+					],
+				};
+			},
+		},
+		contentLabels: {
+			getLabelsForContent: async () => ({ results: [] }),
+			removeLabelFromContentUsingQueryParameter: async () => undefined,
+			addLabelsToContent: async () => undefined,
+		},
+	} as unknown as RequiredConfluenceClient;
+}
+
+function md5(contents: Buffer): string {
+	const spark = new SparkMD5.ArrayBuffer();
+	return spark.append(Uint8Array.from(contents).buffer).end();
+}
+
+const testPublishSettings: ConfluenceSettings = {
+	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceParentId: "parent-id",
+	atlassianUserName: "user@example.com",
+	atlassianApiToken: "token",
+	folderToPublish: ".",
+	contentRoot: ".",
+	firstHeadingPageTitle: false,
+	forceOverwrite: false,
+};

--- a/packages/lib/src/Publisher.ts
+++ b/packages/lib/src/Publisher.ts
@@ -74,6 +74,11 @@ interface ConfluencePageExistingData {
 	contentType: string;
 }
 
+type UpdateContentDetails = Omit<
+	Parameters<RequiredConfluenceClient["content"]["updateContent"]>[0],
+	"version"
+>;
+
 export interface ConfluenceNode {
 	file: ConfluenceAdfFile;
 	version: number;
@@ -231,14 +236,13 @@ export class Publisher {
 	> {
 		const confluenceClient = this.confluenceClient;
 		const adfProcessingPlugins = this.adfProcessingPlugins;
+		const settings = this.settings;
 		const getMyAccountId = () => this.myAccountId;
 
 		return Effect.gen(function* () {
-			if (lastUpdatedBy !== getMyAccountId()) {
+			if (!settings.forceOverwrite && lastUpdatedBy !== getMyAccountId()) {
 				return yield* Effect.fail(
-					new Error(
-						`Page last updated by another user. Won't publish over their changes. MyAccountId: ${getMyAccountId()}, Last Updated By: ${lastUpdatedBy}`,
-					),
+					createUpdatedByAnotherUserError(getMyAccountId(), lastUpdatedBy),
 				);
 			}
 			if (existingPageData.contentType !== adfFile.contentType) {
@@ -277,7 +281,7 @@ export class Publisher {
 				}, {});
 
 			const workspace = yield* MarkdownWorkspaceService;
-			let processedAttachment = false;
+			let uploadedAttachment = false;
 			const supportFunctions = trackProcessedAttachments(
 				createPublisherFunctions(
 					confluenceClient,
@@ -287,8 +291,8 @@ export class Publisher {
 					currentAttachments,
 				),
 				(uploaded) => {
-					if (uploaded) {
-						processedAttachment = true;
+					if (uploaded?.status === "uploaded") {
+						uploadedAttachment = true;
 					}
 				},
 			);
@@ -298,22 +302,27 @@ export class Publisher {
 				supportFunctions,
 			);
 
-			if (processedAttachment) {
+			if (uploadedAttachment) {
 				result.imageResult = "updated";
 			}
 
+			const shouldPreserveParent =
+				adfFile.contentType === "blogpost" || adfFile.dontChangeParentPageId;
+			const currentSpaceDetails = adfFile.dontChangeParentPageId
+				? { space: { key: adfFile.spaceKey } }
+				: {};
 			const existingPageDetails = {
 				title: existingPageData.pageTitle,
 				type: existingPageData.contentType,
-				...(adfFile.contentType === "blogpost" || adfFile.dontChangeParentPageId
-					? {}
-					: { ancestors: existingPageData.ancestors }),
+				...currentSpaceDetails,
+				...(shouldPreserveParent ? {} : { ancestors: existingPageData.ancestors }),
 			};
 
 			const newPageDetails = {
 				title: adfFile.pageTitle,
 				type: adfFile.contentType,
-				...(adfFile.contentType === "blogpost" || adfFile.dontChangeParentPageId
+				...currentSpaceDetails,
+				...(shouldPreserveParent
 					? {}
 					: {
 							ancestors: ancestors.map((ancestor) => ({
@@ -330,7 +339,6 @@ export class Publisher {
 				const updateContentDetails = {
 					...newPageDetails,
 					id: adfFile.pageId,
-					version: { number: pageVersionNumber + 1 },
 					body: {
 						// eslint-disable-next-line @typescript-eslint/naming-convention
 						atlas_doc_format: {
@@ -339,10 +347,15 @@ export class Publisher {
 						},
 					},
 				};
-				yield* Effect.tryPromise({
-					try: () => confluenceClient.content.updateContent(updateContentDetails),
-					catch: identity,
-				});
+				yield* updateContentWithLatestVersionEffect(
+					confluenceClient,
+					updateContentDetails,
+					adfFile.pageId,
+					pageVersionNumber,
+					lastUpdatedBy,
+					getMyAccountId(),
+					settings.forceOverwrite,
+				);
 			}
 
 			const getLabelsForContent = {
@@ -425,6 +438,125 @@ function trackProcessedAttachments(
 				.uploadBufferEffect(uploadFilename, fileBuffer, contentType)
 				.pipe(Effect.tap((uploaded) => Effect.sync(() => onProcessedAttachment(uploaded)))),
 	};
+}
+
+function updateContentWithLatestVersionEffect(
+	confluenceClient: RequiredConfluenceClient,
+	updateContentDetails: UpdateContentDetails,
+	pageId: string,
+	fallbackVersionNumber: number,
+	fallbackLastUpdatedBy: string,
+	myAccountId: string | undefined,
+	forceOverwrite: boolean,
+	attemptsRemaining = 2,
+): Effect.Effect<unknown, unknown, never> {
+	return getLatestPageVersionDetailsEffect(
+		confluenceClient,
+		pageId,
+		fallbackVersionNumber,
+		fallbackLastUpdatedBy,
+	).pipe(
+		Effect.flatMap((versionDetails) => {
+			if (
+				!forceOverwrite &&
+				versionDetails.lastUpdatedBy &&
+				versionDetails.lastUpdatedBy !== myAccountId
+			) {
+				return Effect.fail(
+					createUpdatedByAnotherUserError(myAccountId, versionDetails.lastUpdatedBy),
+				);
+			}
+
+			return Effect.tryPromise({
+				try: () =>
+					confluenceClient.content.updateContent({
+						...updateContentDetails,
+						version: { number: versionDetails.number + 1 },
+					}),
+				catch: identity,
+			}).pipe(
+				Effect.catch((error) => {
+					if (attemptsRemaining > 0 && isVersionConflictError(error)) {
+						return updateContentWithLatestVersionEffect(
+							confluenceClient,
+							updateContentDetails,
+							pageId,
+							fallbackVersionNumber,
+							fallbackLastUpdatedBy,
+							myAccountId,
+							forceOverwrite,
+							attemptsRemaining - 1,
+						);
+					}
+
+					return Effect.fail(error);
+				}),
+			);
+		}),
+	);
+}
+
+function getLatestPageVersionDetailsEffect(
+	confluenceClient: RequiredConfluenceClient,
+	pageId: string,
+	fallbackVersionNumber: number,
+	fallbackLastUpdatedBy: string,
+): Effect.Effect<{ number: number; lastUpdatedBy: string }, unknown, never> {
+	return Effect.tryPromise({
+		try: () =>
+			confluenceClient.content.getContentById({
+				id: pageId,
+				expand: ["version"],
+			}),
+		catch: identity,
+	}).pipe(
+		Effect.map((pageDetails) => ({
+			number: pageDetails.version?.number ?? fallbackVersionNumber,
+			lastUpdatedBy: pageDetails.version?.by?.accountId ?? fallbackLastUpdatedBy,
+		})),
+	);
+}
+
+function createUpdatedByAnotherUserError(
+	myAccountId: string | undefined,
+	lastUpdatedBy: string,
+): Error {
+	return new Error(
+		`Page last updated by another user. Won't publish over their changes. MyAccountId: ${myAccountId}, Last Updated By: ${lastUpdatedBy}`,
+	);
+}
+
+function isVersionConflictError(error: unknown): boolean {
+	const status = getErrorStatus(error);
+	return status === 409;
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+	if (!error || typeof error !== "object") {
+		return undefined;
+	}
+
+	if ("status" in error && typeof error.status === "number") {
+		return error.status;
+	}
+
+	if ("statusCode" in error && typeof error.statusCode === "number") {
+		return error.statusCode;
+	}
+
+	if ("response" in error) {
+		const response = error.response;
+		if (response && typeof response === "object") {
+			if ("status" in response && typeof response.status === "number") {
+				return response.status;
+			}
+			if ("statusCode" in response && typeof response.statusCode === "number") {
+				return response.statusCode;
+			}
+		}
+	}
+
+	return undefined;
 }
 
 function identity(error: unknown): unknown {

--- a/packages/lib/src/PublisherErrors.test.ts
+++ b/packages/lib/src/PublisherErrors.test.ts
@@ -35,4 +35,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	forceOverwrite: false,
 };

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -8,6 +8,7 @@ export type ConfluenceSettings = {
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
+	forceOverwrite: boolean;
 };
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
@@ -18,6 +19,7 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	forceOverwrite: false,
 };
 
 export class ConfluenceSettingsService extends Context.Service<

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -40,6 +40,7 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 					folderToPublish: "file-folder",
 					contentRoot: "file-root",
 					firstHeadingPageTitle: true,
+					forceOverwrite: false,
 				}),
 			);
 
@@ -68,6 +69,7 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 			CONFLUENCE_BASE_URL: "https://env.example.atlassian.net",
 			ATLASSIAN_USERNAME: "env-user@example.com",
 			FOLDER_TO_PUBLISH: "env-folder",
+			CONFLUENCE_FORCE_OVERWRITE: "true",
 		},
 	});
 
@@ -91,6 +93,7 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 		folderToPublish: "env-folder",
 		contentRoot: expectedCliContentRoot,
 		firstHeadingPageTitle: true,
+		forceOverwrite: true,
 	});
 });
 
@@ -108,6 +111,7 @@ test("keeps explicit false values from config providers", async () => {
 					folderToPublish: "file-folder",
 					contentRoot,
 					firstHeadingPageTitle: false,
+					forceOverwrite: false,
 				}),
 			);
 
@@ -119,6 +123,7 @@ test("keeps explicit false values from config providers", async () => {
 	);
 
 	expect(settings.firstHeadingPageTitle).toBe(false);
+	expect(settings.forceOverwrite).toBe(false);
 	expect(settings.contentRoot).toBe(expectedContentRoot);
 });
 
@@ -145,6 +150,8 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 					contentRoot,
 					"--fh",
 					"false",
+					"--forceOverwrite",
+					"false",
 				],
 				cwd: ".",
 				env: {},
@@ -167,6 +174,7 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 	);
 
 	expect(settings.firstHeadingPageTitle).toBe(false);
+	expect(settings.forceOverwrite).toBe(false);
 	expect(settings.contentRoot).toBe(expectedContentRoot);
 });
 

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -27,6 +27,7 @@ export const confluenceSettingsConfig = Config.all({
 	folderToPublish: Config.string("folderToPublish"),
 	contentRoot: Config.string("contentRoot"),
 	firstHeadingPageTitle: Config.boolean("firstHeadingPageTitle"),
+	forceOverwrite: Config.boolean("forceOverwrite"),
 });
 
 export const ConfluenceSettingsLive: Layer.Layer<
@@ -181,6 +182,7 @@ function makeEnvironmentProvider(
 		const firstHeadingPageTitle = yield* runtimeEnvironment.getEnv(
 			"CONFLUENCE_FIRST_HEADING_PAGE_TITLE",
 		);
+		const forceOverwrite = yield* runtimeEnvironment.getEnv("CONFLUENCE_FORCE_OVERWRITE");
 
 		return ConfigProvider.fromEnv({
 			env: compactRecord({
@@ -192,6 +194,7 @@ function makeEnvironmentProvider(
 				contentRoot: yield* runtimeEnvironment.getEnv("CONFLUENCE_CONTENT_ROOT"),
 				firstHeadingPageTitle:
 					firstHeadingPageTitle === "true" ? firstHeadingPageTitle : undefined,
+				forceOverwrite: forceOverwrite === "true" ? forceOverwrite : undefined,
 			}),
 		});
 	});
@@ -206,6 +209,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "enableFolder", aliases: ["f"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
+		{ name: "forceOverwrite", aliases: ["fo"], type: "boolean" },
 	]);
 
 	return ConfigProvider.fromUnknown(
@@ -217,6 +221,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			folderToPublish: options["enableFolder"],
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],
+			forceOverwrite: options["forceOverwrite"],
 		}),
 	);
 }

--- a/packages/lib/src/TreeConfluence.test.ts
+++ b/packages/lib/src/TreeConfluence.test.ts
@@ -197,4 +197,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	forceOverwrite: false,
 };

--- a/packages/lib/src/TreeLocal.test.ts
+++ b/packages/lib/src/TreeLocal.test.ts
@@ -82,4 +82,5 @@ const testSettings: ConfluenceSettings = {
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	forceOverwrite: false,
 };

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -96,6 +96,16 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Force Overwrite")
+			.setDesc("Publish over pages last updated by another user")
+			.addToggle((toggle) =>
+				toggle.setValue(this.plugin.settings.forceOverwrite).onChange(async (value) => {
+					this.plugin.settings.forceOverwrite = value;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
 			.setName("Show Publish Results Dialog")
 			.setDesc("Show a dialog after publishing finishes")
 			.addToggle((toggle) =>


### PR DESCRIPTION
## Summary

- normalize ADF comparisons so Confluence-added macro metadata does not make raw ADF Jira macros look changed
- add a `forceOverwrite` setting for JSON/env/CLI/Obsidian and refetch/retry page versions before content updates
- preserve the current page space when `connie-dont-change-parent-page` is set and report reused attachments as unchanged

Closes #337
Closes #650
Closes #558
Closes #671

## Validation

- `VP_NODE_VERSION=24.15.0 /Users/andrewmcclenaghan/.vite-plus/current/bin/vp install --frozen-lockfile`
- `VP_NODE_VERSION=24.15.0 /Users/andrewmcclenaghan/.vite-plus/current/bin/vp test run packages/lib/src/AdfEqual.test.ts packages/lib/src/Publisher.test.ts packages/lib/src/SettingsConfig.test.ts`
- `VP_NODE_VERSION=24.15.0 /Users/andrewmcclenaghan/.vite-plus/current/bin/vp run fmt:check`
- `VP_NODE_VERSION=24.15.0 /Users/andrewmcclenaghan/.vite-plus/current/bin/vp run check`
- `VP_NODE_VERSION=24.15.0 /Users/andrewmcclenaghan/.vite-plus/current/bin/vp test run`
- `VP_NODE_VERSION=24.15.0 /Users/andrewmcclenaghan/.vite-plus/current/bin/vp run build`
- `git diff --check`
