### PR TITLE
fix: sanitize Obsidian Mermaid theme colors

### DIFF
--- a/packages/mermaid-electron-renderer/src/index.ts
+++ b/packages/mermaid-electron-renderer/src/index.ts
@@ -2,6 +2,7 @@ import { BrowserWindow } from "@electron/remote";
 import { ChartData, MermaidRenderer } from "@markdown-confluence/lib";
 import mermaid, { MermaidConfig } from "mermaid";
 import { v4 as uuidv4 } from "uuid";
+import { sanitizeMermaidConfig } from "./mermaidConfig";
 
 let mermaidRenderHtml: string;
 
@@ -59,7 +60,9 @@ export class ElectronMermaidRenderer implements MermaidRenderer {
 
 			await chartWindow.loadURL(mermaidRenderHtml);
 
-			const { themeVariables, ...mermaidInitConfig } = this.mermaidConfig;
+			const { themeVariables, ...mermaidInitConfig } = sanitizeMermaidConfig(
+				this.mermaidConfig,
+			);
 
 			mermaid.initialize({ ...mermaidInitConfig, startOnLoad: false });
 

--- a/packages/mermaid-electron-renderer/src/mermaidConfig.test.ts
+++ b/packages/mermaid-electron-renderer/src/mermaidConfig.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@effect/vitest";
+import { MermaidConfig } from "mermaid";
+import { sanitizeMermaidConfig } from "./mermaidConfig";
+
+test("removes Obsidian CSS color variables from Mermaid theme variables", () => {
+	const config = {
+		theme: "base",
+		themeVariables: {
+			fontFamily: "var(--font-text)",
+			primaryColor: "var(--background-primary)",
+			primaryTextColor: "#ffffff",
+			secondaryColor: "color-mix(in srgb, red 50%, blue)",
+		},
+	} satisfies MermaidConfig;
+
+	const sanitizedConfig = sanitizeMermaidConfig(config);
+
+	expect(sanitizedConfig.themeVariables).toEqual({
+		fontFamily: "var(--font-text)",
+		primaryTextColor: "#ffffff",
+	});
+	expect(config.themeVariables).toHaveProperty("primaryColor");
+});
+
+test("removes empty theme variables after sanitizing unsupported values", () => {
+	const sanitizedConfig = sanitizeMermaidConfig({
+		theme: "base",
+		themeVariables: {
+			primaryColor: "light-dark(#ffffff, #000000)",
+		},
+	});
+
+	expect("themeVariables" in sanitizedConfig).toBe(false);
+});

--- a/packages/mermaid-electron-renderer/src/mermaidConfig.ts
+++ b/packages/mermaid-electron-renderer/src/mermaidConfig.ts
@@ -1,0 +1,47 @@
+import { MermaidConfig } from "mermaid";
+
+const unsupportedCssColorFunctionPattern = /\b(?:color-mix|light-dark|var)\(/iu;
+const fontThemeVariablePattern = /^font/iu;
+
+export function sanitizeMermaidConfig(mermaidConfig: MermaidConfig): MermaidConfig {
+	const sanitizedConfig = { ...mermaidConfig };
+	const themeVariables = sanitizeThemeVariables(mermaidConfig.themeVariables);
+
+	delete sanitizedConfig.themeVariables;
+	if (themeVariables) {
+		sanitizedConfig.themeVariables = themeVariables;
+	}
+
+	return sanitizedConfig;
+}
+
+function sanitizeThemeVariables(
+	themeVariables: MermaidConfig["themeVariables"],
+): MermaidConfig["themeVariables"] | undefined {
+	if (!themeVariables) {
+		return undefined;
+	}
+
+	const sanitizedThemeVariables: Record<string, unknown> = {};
+	for (const [name, value] of Object.entries(themeVariables as Record<string, unknown>)) {
+		if (isUnsupportedCssColorToken(name, value)) {
+			continue;
+		}
+
+		sanitizedThemeVariables[name] = value;
+	}
+
+	if (Object.keys(sanitizedThemeVariables).length === 0) {
+		return undefined;
+	}
+
+	return sanitizedThemeVariables as MermaidConfig["themeVariables"];
+}
+
+function isUnsupportedCssColorToken(name: string, value: unknown): boolean {
+	return (
+		typeof value === "string" &&
+		!fontThemeVariablePattern.test(name) &&
+		unsupportedCssColorFunctionPattern.test(value)
+	);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from "vite-plus/test/config";
 export default defineConfig({
 	test: {
 		environment: "node",
-		include: ["packages/lib/src/**/*.test.ts", "scripts/**/*.test.js"],
+		include: [
+			"packages/lib/src/**/*.test.ts",
+			"packages/mermaid-electron-renderer/src/**/*.test.ts",
+			"scripts/**/*.test.js",
+		],
 		testTimeout: 300000,
 	},
 });


### PR DESCRIPTION
## Summary

- sanitize Obsidian-provided Mermaid theme variables before rendering in Electron
- drop CSS color functions that Mermaid cannot parse while preserving supported values and font variables
- include the Mermaid Electron renderer test file in the repo test config

Closes #634

## Test plan

- [x] vp test run packages/mermaid-electron-renderer/src/mermaidConfig.test.ts
- [x] vp run check
- [x] vp run build
- [x] vp test run