### PR TITLE
feat: add markdown extension page transforms

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,7 +100,10 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
   "atlassianApiToken": "optional-token-from-config",
   "folderToPublish": "docs",
   "contentRoot": ".",
-  "firstHeadingPageTitle": false
+  "firstHeadingPageTitle": false,
+  "pageHeaderMarkdown": "",
+  "pageFooterMarkdown": "",
+  "ignoredCodeBlockLanguages": ["dataview", "button"]
 }
 ```
 
@@ -115,6 +118,9 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
 | `folderToPublish` | `FOLDER_TO_PUBLISH` | `--enableFolder`, `-f` | The folder, relative to `contentRoot`, whose Markdown files default to `connie-publish: true`. Use `.` to publish all Markdown files under `contentRoot`. |
 | `contentRoot` | `CONFLUENCE_CONTENT_ROOT` | `--contentRoot`, `--cr` | The root directory to scan for Markdown files and referenced content. |
 | `firstHeadingPageTitle` | `CONFLUENCE_FIRST_HEADING_PAGE_TITLE` | `--firstHeaderPageTitle`, `--fh` | When `true`, use the first heading as the page title when `connie-title` is not set. |
+| `pageHeaderMarkdown` | `CONFLUENCE_PAGE_HEADER_MARKDOWN` | `--pageHeaderMarkdown` | Markdown inserted at the top of every generated Confluence page. |
+| `pageFooterMarkdown` | `CONFLUENCE_PAGE_FOOTER_MARKDOWN` | `--pageFooterMarkdown` | Markdown inserted at the bottom of every generated Confluence page. |
+| `ignoredCodeBlockLanguages` | n/a | n/a | Fenced code block languages to remove from generated pages, configured as a JSON array in `.markdown-confluence.json`. |
 
 ### `folderToPublish` vs `contentRoot`
 
@@ -167,3 +173,50 @@ tags:
 ```
 
 These keys apply to one Markdown file at a time and are not global `.markdown-confluence.json` settings.
+
+### Markdown Extensions And Macros
+
+To publish a Confluence table of contents, put an empty `toc` fence where the macro should appear:
+
+````markdown
+```toc
+```
+````
+
+The converter also accepts standalone Confluence wiki-style TOC macro markup:
+
+```markdown
+{toc:printable=true|maxLevel=3}
+```
+
+For advanced macro or ADF templates, use an `adf` fenced code block containing the ADF JSON that should be inserted into the page:
+
+````markdown
+```adf
+{
+  "type": "paragraph",
+  "content": [
+    {
+      "type": "inlineExtension",
+      "attrs": {
+        "extensionType": "com.atlassian.confluence.macro.core",
+        "extensionKey": "status",
+        "parameters": {
+          "macroParams": {
+            "title": { "value": "Draft" }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+````
+
+Use `ignoredCodeBlockLanguages` to drop source-only Obsidian plugin blocks from published pages:
+
+```json
+{
+  "ignoredCodeBlockLanguages": ["dataview", "button"]
+}
+```

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -292,3 +292,78 @@ test("parses callout with adjacent wikilink image", () => {
 	expect(adfFile.contents.content?.[0]?.type).toBe("panel");
 	expect(JSON.stringify(adfFile.contents)).toContain("file://Pasted image 20231006155212.png");
 });
+
+test("converts toc code fences and wiki markup to Confluence TOC macros", () => {
+	const markdown: MarkdownFile = {
+		folderName: "macros",
+		absoluteFilePath: "/path/to/macros.md",
+		fileName: "macros.md",
+		contents: ["```toc", "```", "", "{toc:printable=true|maxLevel=3}", "", "# Body"].join("\n"),
+		pageTitle: "Macros",
+		frontmatter: {},
+	};
+
+	const adfFile = convertMDtoADF(markdown, createTestSettings());
+	const [tocFenceMacro, wikiTocMacro] = adfFile.contents.content ?? [];
+
+	expect(tocFenceMacro?.type).toBe("paragraph");
+	expect(JSON.stringify(tocFenceMacro)).toContain('"extensionKey":"toc"');
+	expect(JSON.stringify(tocFenceMacro)).toContain('"title":"Table of Contents"');
+	expect(JSON.stringify(wikiTocMacro)).toContain('"printable":{"value":"true"}');
+	expect(JSON.stringify(wikiTocMacro)).toContain('"maxLevel":{"value":"3"}');
+});
+
+test("adds configured page header and footer while ignoring configured code blocks", () => {
+	const markdown: MarkdownFile = {
+		folderName: "transforms",
+		absoluteFilePath: "/path/to/transforms.md",
+		fileName: "transforms.md",
+		contents: [
+			"# Body",
+			"",
+			"```dataview",
+			"LIST FROM #project",
+			"```",
+			"",
+			"```button",
+			"name Publish",
+			"```",
+			"",
+			"```ts",
+			"const keep = true;",
+			"```",
+		].join("\n"),
+		pageTitle: "Transforms",
+		frontmatter: {},
+	};
+
+	const adfFile = convertMDtoADF(
+		markdown,
+		createTestSettings({
+			pageHeaderMarkdown: "Generated from source",
+			pageFooterMarkdown: "_End of synced content_",
+			ignoredCodeBlockLanguages: ["dataview", "button"],
+		}),
+	);
+	const serializedAdf = JSON.stringify(adfFile.contents);
+
+	expect(serializedAdf).toContain("Generated from source");
+	expect(serializedAdf).toContain("End of synced content");
+	expect(serializedAdf).not.toContain("LIST FROM #project");
+	expect(serializedAdf).not.toContain("name Publish");
+	expect(serializedAdf).toContain("const keep = true;");
+	expect(adfFile.contents.content?.[0]?.content?.[0]?.text).toBe("Generated from source");
+});
+
+function createTestSettings(overrides: Partial<ConfluenceSettings> = {}): ConfluenceSettings {
+	return {
+		confluenceBaseUrl: "https://example.com",
+		confluenceParentId: "asdf",
+		atlassianUserName: "asdf@asdf.com",
+		atlassianApiToken: "asdfasdf",
+		folderToPublish: ".",
+		contentRoot: "./",
+		firstHeadingPageTitle: false,
+		...overrides,
+	};
+}

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -9,6 +9,7 @@ import { MarkdownToConfluenceCodeBlockLanguageMap } from "./CodeBlockLanguageMap
 import { isSafeUrl } from "@atlaskit/adf-schema";
 import { ConfluenceSettings } from "./Settings";
 import { cleanUpUrlIfConfluence } from "./ConfluenceUrlParser";
+import SparkMD5 from "spark-md5";
 
 const frontmatterRegex = /^\s*?---\n([\s\S]*?)\n---\s*/g;
 
@@ -104,7 +105,7 @@ export function parseMarkdownToADF(markdown: string, confluenceBaseUrl: string) 
 	const prosenodes = transformer.parse(stripMarkdownHtmlComments(markdown));
 	const adfNodes = serializer.encode(prosenodes);
 	const nodes = processADF(adfNodes, confluenceBaseUrl);
-	return nodes;
+	return replaceSupportedMacroPlaceholders(nodes);
 }
 
 function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
@@ -226,10 +227,207 @@ export function convertMDtoADF(file: MarkdownFile, settings: ConfluenceSettings)
 	const adfContent = parseMarkdownToADF(file.contents, settings.confluenceBaseUrl);
 
 	const results = processConniePerPageConfig(file, settings, adfContent);
+	stripIgnoredCodeBlocks(adfContent as ADFNode, settings.ignoredCodeBlockLanguages ?? []);
+	addConfiguredPageChrome(adfContent, settings);
 
 	return {
 		...file,
 		...results,
 		contents: adfContent,
 	};
+}
+
+type ADFNode = {
+	type: string;
+	attrs?: Record<string, unknown>;
+	content?: ADFNode[];
+	text?: string;
+	marks?: unknown[];
+};
+
+function replaceSupportedMacroPlaceholders(adf: JSONDocNode): JSONDocNode {
+	if (!adf.content) {
+		return adf;
+	}
+
+	let macroIndex = 0;
+	adf.content = adf.content.map((node) => {
+		if (isEmptyTocCodeBlock(node as ADFNode)) {
+			const macroNode = createConfluenceMacroParagraph(
+				"toc",
+				"Table of Contents",
+				{},
+				macroIndex,
+			);
+			macroIndex++;
+			return macroNode;
+		}
+
+		const tocParameters = getStandaloneTocWikiMacroParameters(node as ADFNode);
+		if (tocParameters) {
+			const macroNode = createConfluenceMacroParagraph(
+				"toc",
+				"Table of Contents",
+				tocParameters,
+				macroIndex,
+			);
+			macroIndex++;
+			return macroNode;
+		}
+
+		return node;
+	});
+
+	return adf;
+}
+
+function isEmptyTocCodeBlock(node: ADFNode): boolean {
+	return (
+		node.type === "codeBlock" &&
+		normalizeCodeBlockLanguage(node.attrs?.["language"]) === "toc" &&
+		getCodeBlockText(node).trim() === ""
+	);
+}
+
+function getStandaloneTocWikiMacroParameters(node: ADFNode): Record<string, string> | undefined {
+	if (node.type !== "paragraph" || node.content?.length !== 1) {
+		return undefined;
+	}
+
+	const [textNode] = node.content;
+	if (textNode?.type !== "text" || typeof textNode.text !== "string" || textNode.marks?.length) {
+		return undefined;
+	}
+
+	const match = textNode.text.trim().match(/^\{toc(?::(?<parameters>[^}]+))?}$/i);
+	if (!match) {
+		return undefined;
+	}
+
+	return parseWikiMacroParameters(match.groups?.["parameters"] ?? "");
+}
+
+function parseWikiMacroParameters(parameters: string): Record<string, string> {
+	const parsed: Record<string, string> = {};
+
+	for (const parameter of parameters.split("|")) {
+		const trimmedParameter = parameter.trim();
+		if (!trimmedParameter) {
+			continue;
+		}
+
+		const equalsIndex = trimmedParameter.indexOf("=");
+		if (equalsIndex === -1) {
+			parsed[trimmedParameter] = "true";
+			continue;
+		}
+
+		const key = trimmedParameter.slice(0, equalsIndex).trim();
+		const value = trimmedParameter.slice(equalsIndex + 1).trim();
+		if (key) {
+			parsed[key] = value;
+		}
+	}
+
+	return parsed;
+}
+
+function createConfluenceMacroParagraph(
+	extensionKey: string,
+	title: string,
+	parameters: Record<string, string>,
+	index: number,
+): ADFNode {
+	const seed = `${extensionKey}:${JSON.stringify(parameters)}:${index}`;
+	const macroId = SparkMD5.hash(seed);
+
+	return {
+		type: "paragraph",
+		content: [
+			{
+				type: "inlineExtension",
+				attrs: {
+					extensionType: "com.atlassian.confluence.macro.core",
+					extensionKey,
+					parameters: {
+						macroParams: Object.fromEntries(
+							Object.entries(parameters).map(([key, value]) => [key, { value }]),
+						),
+						macroMetadata: {
+							macroId: { value: macroId },
+							schemaVersion: { value: "1" },
+							title,
+						},
+					},
+					localId: formatHashAsUuid(SparkMD5.hash(`local:${seed}`)),
+				},
+			},
+		],
+	};
+}
+
+function formatHashAsUuid(hash: string): string {
+	return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-${hash.slice(12, 16)}-${hash.slice(16, 20)}-${hash.slice(20, 32)}`;
+}
+
+function stripIgnoredCodeBlocks(
+	node: ADFNode,
+	ignoredCodeBlockLanguages: readonly string[],
+): ADFNode {
+	const ignoredLanguages = new Set(
+		ignoredCodeBlockLanguages.map(normalizeCodeBlockLanguage).filter(Boolean),
+	);
+
+	if (ignoredLanguages.size === 0 || !node.content) {
+		return node;
+	}
+
+	node.content = node.content.flatMap((child) => {
+		if (
+			child.type === "codeBlock" &&
+			ignoredLanguages.has(normalizeCodeBlockLanguage(child.attrs?.["language"]))
+		) {
+			return [];
+		}
+
+		return [stripIgnoredCodeBlocks(child, ignoredCodeBlockLanguages)];
+	});
+
+	return node;
+}
+
+function addConfiguredPageChrome(adfContent: JSONDocNode, settings: ConfluenceSettings): void {
+	const headerContent = parseConfiguredPageChromeMarkdown(
+		settings.pageHeaderMarkdown,
+		settings.confluenceBaseUrl,
+	);
+	const footerContent = parseConfiguredPageChromeMarkdown(
+		settings.pageFooterMarkdown,
+		settings.confluenceBaseUrl,
+	);
+
+	if (headerContent.length === 0 && footerContent.length === 0) {
+		return;
+	}
+
+	adfContent.content = [...headerContent, ...(adfContent.content ?? []), ...footerContent];
+}
+
+function parseConfiguredPageChromeMarkdown(
+	markdown: string | undefined,
+	confluenceBaseUrl: string,
+): ADFNode[] {
+	if (!markdown?.trim()) {
+		return [];
+	}
+
+	return (parseMarkdownToADF(markdown, confluenceBaseUrl).content ?? []) as ADFNode[];
+}
+
+function getCodeBlockText(node: ADFNode): string {
+	return node.content?.map((child) => child.text ?? "").join("") ?? "";
+}
+
+function normalizeCodeBlockLanguage(language: unknown): string {
+	return typeof language === "string" ? language.trim().toLowerCase() : "";
 }

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -8,6 +8,9 @@ export type ConfluenceSettings = {
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
+	pageHeaderMarkdown?: string;
+	pageFooterMarkdown?: string;
+	ignoredCodeBlockLanguages?: readonly string[];
 };
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
@@ -18,6 +21,9 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	pageHeaderMarkdown: "",
+	pageFooterMarkdown: "",
+	ignoredCodeBlockLanguages: [],
 };
 
 export class ConfluenceSettingsService extends Context.Service<

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -40,6 +40,9 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 					folderToPublish: "file-folder",
 					contentRoot: "file-root",
 					firstHeadingPageTitle: true,
+					pageHeaderMarkdown: "File header",
+					pageFooterMarkdown: "File footer",
+					ignoredCodeBlockLanguages: ["dataview"],
 				}),
 			);
 
@@ -68,6 +71,7 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 			CONFLUENCE_BASE_URL: "https://env.example.atlassian.net",
 			ATLASSIAN_USERNAME: "env-user@example.com",
 			FOLDER_TO_PUBLISH: "env-folder",
+			CONFLUENCE_PAGE_HEADER_MARKDOWN: "Env header",
 		},
 	});
 
@@ -91,6 +95,9 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 		folderToPublish: "env-folder",
 		contentRoot: expectedCliContentRoot,
 		firstHeadingPageTitle: true,
+		pageHeaderMarkdown: "Env header",
+		pageFooterMarkdown: "File footer",
+		ignoredCodeBlockLanguages: ["dataview"],
 	});
 });
 
@@ -108,6 +115,9 @@ test("keeps explicit false values from config providers", async () => {
 					folderToPublish: "file-folder",
 					contentRoot,
 					firstHeadingPageTitle: false,
+					pageHeaderMarkdown: "",
+					pageFooterMarkdown: "",
+					ignoredCodeBlockLanguages: [],
 				}),
 			);
 
@@ -145,6 +155,8 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 					contentRoot,
 					"--fh",
 					"false",
+					"--pageFooterMarkdown",
+					"CLI footer",
 				],
 				cwd: ".",
 				env: {},
@@ -167,6 +179,7 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 	);
 
 	expect(settings.firstHeadingPageTitle).toBe(false);
+	expect(settings.pageFooterMarkdown).toBe("CLI footer");
 	expect(settings.contentRoot).toBe(expectedContentRoot);
 });
 

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -1,6 +1,6 @@
 import { FileSystem } from "effect/FileSystem";
 import { Path } from "effect/Path";
-import { Config, ConfigProvider, Effect, Layer } from "effect";
+import { Config, ConfigProvider, Effect, Layer, Schema } from "effect";
 import {
 	MarkdownConfluencePlatform,
 	runEffect,
@@ -27,6 +27,12 @@ export const confluenceSettingsConfig = Config.all({
 	folderToPublish: Config.string("folderToPublish"),
 	contentRoot: Config.string("contentRoot"),
 	firstHeadingPageTitle: Config.boolean("firstHeadingPageTitle"),
+	pageHeaderMarkdown: Config.string("pageHeaderMarkdown"),
+	pageFooterMarkdown: Config.string("pageFooterMarkdown"),
+	ignoredCodeBlockLanguages: Config.schema(
+		Schema.Array(Schema.String),
+		"ignoredCodeBlockLanguages",
+	),
 });
 
 export const ConfluenceSettingsLive: Layer.Layer<
@@ -192,6 +198,12 @@ function makeEnvironmentProvider(
 				contentRoot: yield* runtimeEnvironment.getEnv("CONFLUENCE_CONTENT_ROOT"),
 				firstHeadingPageTitle:
 					firstHeadingPageTitle === "true" ? firstHeadingPageTitle : undefined,
+				pageHeaderMarkdown: yield* runtimeEnvironment.getEnv(
+					"CONFLUENCE_PAGE_HEADER_MARKDOWN",
+				),
+				pageFooterMarkdown: yield* runtimeEnvironment.getEnv(
+					"CONFLUENCE_PAGE_FOOTER_MARKDOWN",
+				),
 			}),
 		});
 	});
@@ -206,6 +218,8 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "enableFolder", aliases: ["f"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
+		{ name: "pageHeaderMarkdown", type: "string" },
+		{ name: "pageFooterMarkdown", type: "string" },
 	]);
 
 	return ConfigProvider.fromUnknown(
@@ -217,6 +231,8 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			folderToPublish: options["enableFolder"],
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],
+			pageHeaderMarkdown: options["pageHeaderMarkdown"],
+			pageFooterMarkdown: options["pageFooterMarkdown"],
 		}),
 	);
 }
@@ -295,7 +311,15 @@ function pickConfluenceSettings(config: Record<string, unknown>): Partial<Conflu
 		}
 
 		const value = config[key];
-		if (typeof value === typeof DEFAULT_SETTINGS[key]) {
+		const defaultValue = DEFAULT_SETTINGS[key];
+		if (Array.isArray(defaultValue)) {
+			if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+				(result as Record<string, unknown>)[key] = value;
+			}
+			continue;
+		}
+
+		if (typeof value === typeof defaultValue) {
 			(result as Record<string, unknown>)[key] = value;
 		}
 	}


### PR DESCRIPTION
## Summary
- add configurable page header/footer markdown for generated Confluence pages
- add `ignoredCodeBlockLanguages` to drop source-only fenced blocks such as Dataview/Button blocks
- convert empty `toc` fences and standalone `{toc:...}` wiki-style markup into Confluence TOC macro ADF
- document TOC macros, ignored code blocks, page chrome settings, and the existing `adf` template escape hatch

Closes #654.
Closes #577.
Closes #567.
Closes #667.
Refs #256.

## Validation
- `npm exec --package=node@24.15.0 -- ./node_modules/.bin/vp run check`
- `npm exec --package=node@24.15.0 -- ./node_modules/.bin/vp test run`
- `npm exec --package=node@24.15.0 -- ./node_modules/.bin/vp run build`