### PR TITLE
fix: publish arm64 Docker image

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -75,6 +75,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.RELEASE_PLEASE_PAT }}
 
+      - name: Set up QEMU
+        if: ${{ steps.release-please.outputs.release_created }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.release-please.outputs.release_created }}
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         if: ${{ steps.release-please.outputs.release_created }}
         id: meta
@@ -92,6 +102,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: packages/cli
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,9 +1,23 @@
-FROM ghcr.io/puppeteer/puppeteer:25.0.4@sha256:dd3ccf9c72cbaec14baea3f8fa8f9eb8b73ea069a57108366f2e5e8a80f7f661
+FROM node:24.15.0-bookworm-slim
 
-COPY ./dist /app
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates chromium fonts-liberation \
+	&& rm -rf /var/lib/apt/lists/*
 
-ENV NODE_OPTIONS=--enable-source-maps PUPPETEER_CACHE_DIR="/home/pptruser/.cache/puppeteer"
+RUN groupadd --system pptruser \
+	&& useradd --system --gid pptruser --groups audio,video --create-home pptruser \
+	&& mkdir -p /home/pptruser/.cache/puppeteer /content \
+	&& chown -R pptruser:pptruser /home/pptruser /content
+
+COPY --chown=pptruser:pptruser ./dist /app
+
+ENV NODE_OPTIONS=--enable-source-maps \
+	PUPPETEER_CACHE_DIR="/home/pptruser/.cache/puppeteer" \
+	PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium" \
+	PUPPETEER_SKIP_DOWNLOAD="true"
 
 WORKDIR "/content"
+
+USER pptruser
 
 CMD ["node", "/app/index.js"]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,6 +50,8 @@ vp dlx @markdown-confluence/cli
 docker run -it --rm -v "$(pwd):/content" -e ATLASSIAN_API_TOKEN ghcr.io/markdown-confluence/publish:latest
 ```
 
+The published image includes `linux/amd64` and `linux/arm64` variants. Docker Desktop on Apple Silicon should select the `linux/arm64` image automatically.
+
 ### GitHub Actions
 
 **Example setup**


### PR DESCRIPTION
## Summary
- replace the amd64-only Puppeteer base image with multi-arch Node.js 24.15.0 slim plus Debian Chromium
- configure Puppeteer to use system Chromium and skip runtime browser downloads
- publish Docker images for both `linux/amd64` and `linux/arm64` with Buildx/QEMU
- document that Apple Silicon should receive the arm64 image automatically

Closes #675.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "release workflow yaml ok"'`\n- Node registry manifest check for `node:24.15.0-bookworm-slim` returned both `linux/amd64` and `linux/arm64`\n- `PATH=/Users/andrewmcclenaghan/.asdf/installs/nodejs/24.15.0/bin:$PATH corepack pnpm exec vp run build`\n- `git diff --check`\n\n## Not run\n- `PATH=/Users/andrewmcclenaghan/.asdf/installs/nodejs/24.15.0/bin:$PATH corepack pnpm exec vp run -r build:docker` could not run locally because Docker daemon is unavailable: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`