### PR TITLE
feat(cli): OAuth 2.0 client-credentials authentication

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -108,13 +108,50 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
 
 | JSON key | Environment variable | CLI option | Description |
 | --- | --- | --- | --- |
-| `confluenceBaseUrl` | `CONFLUENCE_BASE_URL` | `--baseUrl`, `-b` | Your Confluence site URL. For Confluence Cloud, use the Atlassian site URL without `/wiki`, for example `https://your-domain.atlassian.net`. |
+| `confluenceBaseUrl` | `CONFLUENCE_BASE_URL` | `--baseUrl`, `-b` | Your Confluence site URL. For Confluence Cloud, use the Atlassian site URL without `/wiki`, for example `https://your-domain.atlassian.net`. When authenticating with OAuth 2.0, set this to the API gateway URL `https://api.atlassian.com/ex/confluence/{cloudId}`. |
+| `confluenceSiteUrl` | `CONFLUENCE_SITE_URL` | `--siteUrl` | The browsable Confluence site URL used to build and match display links (for example `https://your-domain.atlassian.net`). Falls back to `confluenceBaseUrl` when unset. Required when `confluenceBaseUrl` points at the API gateway, otherwise published links would be unresolvable. |
 | `confluenceParentId` | `CONFLUENCE_PARENT_ID` | `--parentId`, `-p` | The numeric ID of an existing Confluence parent page. The parent page determines the target space. |
-| `atlassianUserName` | `ATLASSIAN_USERNAME` | `--userName`, `-u` | The Atlassian user name or email address used for publishing. |
-| `atlassianApiToken` | `ATLASSIAN_API_TOKEN` | `--apiToken` | The Atlassian API token. Prefer an environment variable or GitHub secret instead of committing this value to JSON. |
+| `authMethod` | `CONFLUENCE_AUTH_METHOD` | `--authMethod` | Authentication method: `basic` (default) or `oauth2`. |
+| `atlassianUserName` | `ATLASSIAN_USERNAME` | `--userName`, `-u` | The Atlassian user name or email address used for publishing. Required when `authMethod` is `basic`. |
+| `atlassianApiToken` | `ATLASSIAN_API_TOKEN` | `--apiToken` | The Atlassian API token. Required when `authMethod` is `basic`. Prefer an environment variable or GitHub secret instead of committing this value to JSON. |
+| `atlassianClientId` | `ATLASSIAN_CLIENT_ID` | `--clientId` | OAuth 2.0 client ID. Required when `authMethod` is `oauth2`. |
+| `atlassianClientSecret` | `ATLASSIAN_CLIENT_SECRET` | `--clientSecret` | OAuth 2.0 client secret. Required when `authMethod` is `oauth2`. Prefer an environment variable or GitHub secret instead of committing this value to JSON. |
 | `folderToPublish` | `FOLDER_TO_PUBLISH` | `--enableFolder`, `-f` | The folder, relative to `contentRoot`, whose Markdown files default to `connie-publish: true`. Use `.` to publish all Markdown files under `contentRoot`. |
 | `contentRoot` | `CONFLUENCE_CONTENT_ROOT` | `--contentRoot`, `--cr` | The root directory to scan for Markdown files and referenced content. |
 | `firstHeadingPageTitle` | `CONFLUENCE_FIRST_HEADING_PAGE_TITLE` | `--firstHeaderPageTitle`, `--fh` | When `true`, use the first heading as the page title when `connie-title` is not set. |
+
+### OAuth 2.0 Service Account Authentication
+
+By default the CLI authenticates with Basic Auth using `atlassianUserName` and `atlassianApiToken`. You can instead authenticate as a service account using the OAuth 2.0 client-credentials grant. The CLI exchanges the credentials for a short-lived bearer token itself, so this works for the CLI, the Docker image, and the GitHub Action without any pre-steps.
+
+To use OAuth 2.0:
+
+1. Set `authMethod` to `oauth2`.
+2. Supply `atlassianClientId` and `atlassianClientSecret` (prefer environment variables or secrets).
+3. Set `confluenceBaseUrl` to the API gateway URL `https://api.atlassian.com/ex/confluence/{cloudId}`.
+4. Set `confluenceSiteUrl` to your browsable site URL `https://your-domain.atlassian.net` so published links resolve correctly.
+
+`.markdown-confluence.json`:
+
+```json
+{
+  "authMethod": "oauth2",
+  "confluenceBaseUrl": "https://api.atlassian.com/ex/confluence/your-cloud-id",
+  "confluenceSiteUrl": "https://your-domain.atlassian.net",
+  "confluenceParentId": "123456",
+  "folderToPublish": "docs",
+  "contentRoot": "."
+}
+```
+
+```bash
+export ATLASSIAN_CLIENT_ID="YOUR CLIENT ID"
+export ATLASSIAN_CLIENT_SECRET="YOUR CLIENT SECRET"
+```
+
+The CLI exchanges these credentials for a bearer token against the Atlassian token endpoint (`https://auth.atlassian.com/oauth/token`) and uses it for all Confluence API requests.
+
+> **Note:** The bearer token is fetched once at startup and is short-lived. This is sufficient for normal publishes, but a very large publish run could exceed the token lifetime and begin failing partway through. If you hit this, split the publish into smaller runs.
 
 ### `folderToPublish` vs `contentRoot`
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
 	Publisher,
 	MermaidRendererPlugin,
 	RuntimeEnvironmentService,
+	fetchOAuthAccessToken,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { ConfluenceClient } from "confluence.js";
@@ -22,14 +23,11 @@ const program = Effect.gen(function* () {
 
 	const settings = yield* ConfluenceUploadSettings.ConfluenceSettingsService as any;
 
+	const authentication = yield* resolveAuthentication(settings);
+
 	const confluenceClient = new ConfluenceClient({
 		host: settings.confluenceBaseUrl,
-		authentication: {
-			basic: {
-				email: settings.atlassianUserName,
-				apiToken: settings.atlassianApiToken,
-			},
-		},
+		authentication,
 		middlewares: {
 			onError(e) {
 				if ("response" in e && "data" in e.response) {
@@ -85,4 +83,25 @@ NodeRuntime.runMain(
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : JSON.stringify(error);
+}
+
+type ConfluenceClientConfig = ConstructorParameters<typeof ConfluenceClient>[0];
+type ConfluenceAuthentication = ConfluenceClientConfig["authentication"];
+
+function resolveAuthentication(
+	settings: ConfluenceUploadSettings.ConfluenceSettings,
+): Effect.Effect<ConfluenceAuthentication, Error> {
+	if (settings.authMethod === "oauth2") {
+		return fetchOAuthAccessToken(
+			settings.atlassianClientId,
+			settings.atlassianClientSecret,
+		).pipe(Effect.map((accessToken) => ({ oauth2: { accessToken } })));
+	}
+
+	return Effect.succeed({
+		basic: {
+			email: settings.atlassianUserName,
+			apiToken: settings.atlassianApiToken,
+		},
+	});
 }

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -5,6 +5,14 @@ import { Effect, Layer } from "effect";
 import { defineConfig, type Plugin } from "vite-plus";
 import { generatedBanner, isNodeBuiltin } from "../../vite.package-build.ts";
 
+// The CLI is bundled as ESM but pulls in CommonJS dependencies (for example
+// `mime-types`) that call `require(...)` for Node built-ins at runtime.
+// ESM modules have no `require` in scope, so rolldown's CJS interop shim throws.
+// Provide a real `require` via `createRequire` so those calls resolve natively.
+const cliBanner = `${generatedBanner}import { createRequire as __createRequire } from "node:module";
+const require = __createRequire(import.meta.url);
+`;
+
 const NodePlatformLive = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
 
 function runNodePlatform<A>(effect: Effect.Effect<A, unknown, FileSystem | Path>) {
@@ -45,7 +53,7 @@ export default defineConfig({
 		rollupOptions: {
 			external: isNodeBuiltin,
 			output: {
-				banner: generatedBanner,
+				banner: cliBanner,
 				codeSplitting: false,
 			},
 		},

--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -90,9 +90,13 @@ function createNode(file: Partial<ConfluenceAdfFile>): ConfluenceNode {
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "1",
+	authMethod: "basic",
 	atlassianUserName: "test@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/AdfProcessing.ts
+++ b/packages/lib/src/AdfProcessing.ts
@@ -1,7 +1,7 @@
 import { traverse } from "@atlaskit/adf-utils/traverse";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { ConfluenceAdfFile, ConfluenceNode } from "./Publisher";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 import { adfEqual, marksEqual } from "./AdfEqual";
 import { ADFEntity } from "@atlaskit/adf-utils/types";
 import { heading, li, ol, p, text } from "@atlaskit/adf-utils/builders";
@@ -583,7 +583,7 @@ function processWikilinkToActualLink(
 					const linkPage = fileToPageIdMap[pagename];
 
 					if (linkPage) {
-						const confluenceUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${linkPage.spaceKey}/pages/${linkPage.pageId}${wikilinkUrl.hash}`;
+						const confluenceUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${linkPage.spaceKey}/pages/${linkPage.pageId}${wikilinkUrl.hash}`;
 						node.marks[0].attrs["href"] = confluenceUrl;
 						if (
 							node.text === `${pathName}${wikilinkUrl.hash}` ||

--- a/packages/lib/src/ConfluenceUrlParser.ts
+++ b/packages/lib/src/ConfluenceUrlParser.ts
@@ -1,4 +1,4 @@
-export function cleanUpUrlIfConfluence(input: string, confluenceBaseUrl: string): string {
+export function cleanUpUrlIfConfluence(input: string, siteUrl: string): string {
 	let url: URL;
 
 	// Check if the input is a valid URL
@@ -8,7 +8,7 @@ export function cleanUpUrlIfConfluence(input: string, confluenceBaseUrl: string)
 		return "#";
 	}
 
-	const confluenceUrl = new URL(confluenceBaseUrl);
+	const confluenceUrl = new URL(siteUrl);
 	if (url.hostname !== confluenceUrl.hostname) {
 		return input;
 	}

--- a/packages/lib/src/ConniePageConfig.ts
+++ b/packages/lib/src/ConniePageConfig.ts
@@ -1,5 +1,5 @@
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 import { MarkdownFile } from "./MarkdownWorkspace";
 import { parseMarkdownToADF } from "./MdToADF";
 
@@ -143,7 +143,7 @@ export const conniePerPageConfig: ConfluencePerPageConfig = {
 					}
 				}
 
-				const newADF = parseMarkdownToADF(frontmatterHeader, settings.confluenceBaseUrl);
+				const newADF = parseMarkdownToADF(frontmatterHeader, resolveSiteUrl(settings));
 
 				adfContent.content = [...newADF.content, ...adfContent.content];
 			}

--- a/packages/lib/src/MarkdownWorkspace.test.ts
+++ b/packages/lib/src/MarkdownWorkspace.test.ts
@@ -136,9 +136,13 @@ test("updates markdown values for an absolute file path inside contentRoot", asy
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -248,9 +248,13 @@ const markdownTestCases: MarkdownFile[] = [
 test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 	const settings: ConfluenceSettings = {
 		confluenceBaseUrl: "https://example.com",
+		confluenceSiteUrl: "",
 		confluenceParentId: "asdf",
+		authMethod: "basic",
 		atlassianUserName: "asdf@asdf.com",
 		atlassianApiToken: "asdfasdf",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
 		folderToPublish: ".",
 		contentRoot: "./",
 		firstHeadingPageTitle: false,
@@ -279,9 +283,13 @@ test("parses callout with adjacent wikilink image", () => {
 	};
 	const settings: ConfluenceSettings = {
 		confluenceBaseUrl: "https://example.com",
+		confluenceSiteUrl: "",
 		confluenceParentId: "asdf",
+		authMethod: "basic",
 		atlassianUserName: "asdf@asdf.com",
 		atlassianApiToken: "asdfasdf",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
 		folderToPublish: ".",
 		contentRoot: "./",
 		firstHeadingPageTitle: false,
@@ -291,4 +299,70 @@ test("parses callout with adjacent wikilink image", () => {
 
 	expect(adfFile.contents.content?.[0]?.type).toBe("panel");
 	expect(JSON.stringify(adfFile.contents)).toContain("file://Pasted image 20231006155212.png");
+});
+
+test("matches bare Confluence links against confluenceSiteUrl, not the API gateway base", () => {
+	const pageLink =
+		"https://site.example.atlassian.net/wiki/spaces/TEAM/pages/12345/Some+Page+Title";
+	const markdown: MarkdownFile = {
+		folderName: "links",
+		absoluteFilePath: "/path/to/links.md",
+		fileName: "links.md",
+		contents: pageLink,
+		pageTitle: "Links",
+		frontmatter: {},
+	};
+	const settings: ConfluenceSettings = {
+		confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+		confluenceSiteUrl: "https://site.example.atlassian.net",
+		confluenceParentId: "asdf",
+		authMethod: "oauth2",
+		atlassianUserName: "",
+		atlassianApiToken: "",
+		atlassianClientId: "client-id",
+		atlassianClientSecret: "client-secret",
+		folderToPublish: ".",
+		contentRoot: "./",
+		firstHeadingPageTitle: false,
+	};
+
+	const adfFile = convertMDtoADF(markdown, settings);
+	const serialized = JSON.stringify(adfFile.contents);
+
+	expect(serialized).toContain('"type":"inlineCard"');
+	// The trailing slug is stripped because the host matches confluenceSiteUrl.
+	expect(serialized).toContain("https://site.example.atlassian.net/wiki/spaces/TEAM/pages/12345");
+	expect(serialized).not.toContain("Some+Page+Title");
+});
+
+test("falls back to confluenceBaseUrl for link matching when confluenceSiteUrl is empty", () => {
+	const pageLink =
+		"https://site.example.atlassian.net/wiki/spaces/TEAM/pages/12345/Some+Page+Title";
+	const markdown: MarkdownFile = {
+		folderName: "links",
+		absoluteFilePath: "/path/to/links-fallback.md",
+		fileName: "links-fallback.md",
+		contents: pageLink,
+		pageTitle: "Links Fallback",
+		frontmatter: {},
+	};
+	const settings: ConfluenceSettings = {
+		confluenceBaseUrl: "https://site.example.atlassian.net",
+		confluenceSiteUrl: "",
+		confluenceParentId: "asdf",
+		authMethod: "basic",
+		atlassianUserName: "user@example.com",
+		atlassianApiToken: "token",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
+		folderToPublish: ".",
+		contentRoot: "./",
+		firstHeadingPageTitle: false,
+	};
+
+	const adfFile = convertMDtoADF(markdown, settings);
+	const serialized = JSON.stringify(adfFile.contents);
+
+	expect(serialized).toContain('"type":"inlineCard"');
+	expect(serialized).not.toContain("Some+Page+Title");
 });

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -7,7 +7,7 @@ import { processConniePerPageConfig } from "./ConniePageConfig";
 import { p } from "@atlaskit/adf-utils/builders";
 import { MarkdownToConfluenceCodeBlockLanguageMap } from "./CodeBlockLanguageMap";
 import { isSafeUrl } from "@atlaskit/adf-schema";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 import { cleanUpUrlIfConfluence } from "./ConfluenceUrlParser";
 
 const frontmatterRegex = /^\s*?---\n([\s\S]*?)\n---\s*/g;
@@ -100,14 +100,14 @@ function countBacktickRun(line: string, position: number): number {
 	return count;
 }
 
-export function parseMarkdownToADF(markdown: string, confluenceBaseUrl: string) {
+export function parseMarkdownToADF(markdown: string, confluenceSiteUrl: string) {
 	const prosenodes = transformer.parse(stripMarkdownHtmlComments(markdown));
 	const adfNodes = serializer.encode(prosenodes);
-	const nodes = processADF(adfNodes, confluenceBaseUrl);
+	const nodes = processADF(adfNodes, confluenceSiteUrl);
 	return nodes;
 }
 
-function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
+function processADF(adf: JSONDocNode, confluenceSiteUrl: string): JSONDocNode {
 	const olivia = traverse(adf, {
 		text: (node, _parent) => {
 			if (_parent.parent?.node?.type == "listItem" && node.text) {
@@ -141,7 +141,7 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 			if (node.marks[0].attrs["href"] === node.text) {
 				const cleanedUrl = cleanUpUrlIfConfluence(
 					node.marks[0].attrs["href"],
-					confluenceBaseUrl,
+					confluenceSiteUrl,
 				);
 				node.type = "inlineCard";
 				node.attrs = { url: cleanedUrl };
@@ -223,7 +223,7 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 export function convertMDtoADF(file: MarkdownFile, settings: ConfluenceSettings): LocalAdfFile {
 	file.contents = file.contents.replace(frontmatterRegex, "");
 
-	const adfContent = parseMarkdownToADF(file.contents, settings.confluenceBaseUrl);
+	const adfContent = parseMarkdownToADF(file.contents, resolveSiteUrl(settings));
 
 	const results = processConniePerPageConfig(file, settings, adfContent);
 

--- a/packages/lib/src/OAuthToken.test.ts
+++ b/packages/lib/src/OAuthToken.test.ts
@@ -26,6 +26,7 @@ test("returns the access token on a successful response", async () => {
 	const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 	expect(url).toBe(ATLASSIAN_OAUTH_TOKEN_URL);
 	expect(init.method).toBe("POST");
+	expect(init.signal).toBeInstanceOf(AbortSignal);
 	const body = JSON.parse(String(init.body));
 	expect(body).toMatchObject({
 		grant_type: "client_credentials",

--- a/packages/lib/src/OAuthToken.test.ts
+++ b/packages/lib/src/OAuthToken.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, expect, test, vi } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+import { ATLASSIAN_OAUTH_TOKEN_URL, fetchOAuthAccessToken } from "./OAuthToken";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+test("returns the access token on a successful response", async () => {
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(JSON.stringify({ access_token: "token-123" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+	);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const token = await Effect.runPromise(fetchOAuthAccessToken("client-id", "client-secret"));
+
+	expect(token).toBe("token-123");
+	expect(fetchMock).toHaveBeenCalledTimes(1);
+	const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+	expect(url).toBe(ATLASSIAN_OAUTH_TOKEN_URL);
+	expect(init.method).toBe("POST");
+	const body = JSON.parse(String(init.body));
+	expect(body).toMatchObject({
+		grant_type: "client_credentials",
+		client_id: "client-id",
+		client_secret: "client-secret",
+		audience: "api.atlassian.com",
+	});
+});
+
+test("fails with a clear message on a non-2xx response", async () => {
+	globalThis.fetch = vi.fn(
+		async () => new Response("invalid_client", { status: 401, statusText: "Unauthorized" }),
+	) as unknown as typeof fetch;
+
+	const exit = await Effect.runPromiseExit(fetchOAuthAccessToken("client-id", "bad-secret"));
+
+	expect(Exit.isFailure(exit)).toBe(true);
+	const message = Exit.isFailure(exit) ? String(exit.cause) : "";
+	expect(message).toContain("401");
+	expect(message).toContain("invalid_client");
+});
+
+test("fails with a clear message on a network error", async () => {
+	globalThis.fetch = vi.fn(async () => {
+		throw new Error("connection refused");
+	}) as unknown as typeof fetch;
+
+	const exit = await Effect.runPromiseExit(fetchOAuthAccessToken("client-id", "client-secret"));
+
+	expect(Exit.isFailure(exit)).toBe(true);
+	const message = Exit.isFailure(exit) ? String(exit.cause) : "";
+	expect(message).toContain("Failed to reach the Atlassian OAuth token endpoint");
+	expect(message).toContain("connection refused");
+});
+
+test("fails when the response is missing an access token", async () => {
+	globalThis.fetch = vi.fn(
+		async () =>
+			new Response(JSON.stringify({ token_type: "Bearer" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+	) as unknown as typeof fetch;
+
+	const exit = await Effect.runPromiseExit(fetchOAuthAccessToken("client-id", "client-secret"));
+
+	expect(Exit.isFailure(exit)).toBe(true);
+	const message = Exit.isFailure(exit) ? String(exit.cause) : "";
+	expect(message).toContain("did not include an access_token");
+});

--- a/packages/lib/src/OAuthToken.ts
+++ b/packages/lib/src/OAuthToken.ts
@@ -1,0 +1,87 @@
+import { Effect } from "effect";
+
+/**
+ * Atlassian OAuth 2.0 token endpoint used for the client-credentials grant.
+ */
+export const ATLASSIAN_OAUTH_TOKEN_URL = "https://auth.atlassian.com/oauth/token";
+
+/**
+ * Audience required by Atlassian for service-account access tokens.
+ */
+export const ATLASSIAN_OAUTH_AUDIENCE = "api.atlassian.com";
+
+type OAuthTokenResponse = {
+	access_token?: unknown;
+};
+
+/**
+ * Exchanges an Atlassian service-account client ID and secret for a short-lived
+ * OAuth 2.0 bearer access token using the client-credentials grant.
+ *
+ * The returned token is suitable for the `confluence.js` client via
+ * `authentication: { oauth2: { accessToken } }`, which sends it as
+ * `Authorization: Bearer <token>`.
+ *
+ * Note: the token is short-lived. Callers that hold it for the duration of a
+ * long-running operation may need to re-fetch it if it expires; this function
+ * performs a single exchange and does not refresh.
+ */
+export function fetchOAuthAccessToken(
+	clientId: string,
+	clientSecret: string,
+): Effect.Effect<string, Error> {
+	return Effect.gen(function* () {
+		const response = yield* Effect.tryPromise({
+			try: () =>
+				fetch(ATLASSIAN_OAUTH_TOKEN_URL, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						grant_type: "client_credentials",
+						client_id: clientId,
+						client_secret: clientSecret,
+						audience: ATLASSIAN_OAUTH_AUDIENCE,
+					}),
+				}),
+			catch: (error) =>
+				new Error(
+					`Failed to reach the Atlassian OAuth token endpoint: ${getErrorMessage(error)}`,
+				),
+		});
+
+		if (!response.ok) {
+			const detail = yield* Effect.tryPromise({
+				try: () => response.text(),
+				catch: () => new Error(""),
+			}).pipe(Effect.orElseSucceed(() => ""));
+
+			return yield* Effect.fail(
+				new Error(
+					`Atlassian OAuth token request failed with status ${response.status} ${response.statusText}${
+						detail ? `: ${detail}` : ""
+					}`,
+				),
+			);
+		}
+
+		const payload = yield* Effect.tryPromise({
+			try: () => response.json() as Promise<OAuthTokenResponse>,
+			catch: (error) =>
+				new Error(
+					`Failed to parse the Atlassian OAuth token response: ${getErrorMessage(error)}`,
+				),
+		});
+
+		if (typeof payload.access_token !== "string" || payload.access_token.length === 0) {
+			return yield* Effect.fail(
+				new Error("Atlassian OAuth token response did not include an access_token"),
+			);
+		}
+
+		return payload.access_token;
+	});
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/lib/src/OAuthToken.ts
+++ b/packages/lib/src/OAuthToken.ts
@@ -10,6 +10,12 @@ export const ATLASSIAN_OAUTH_TOKEN_URL = "https://auth.atlassian.com/oauth/token
  */
 export const ATLASSIAN_OAUTH_AUDIENCE = "api.atlassian.com";
 
+/**
+ * Maximum time to wait for the Atlassian OAuth token endpoint before aborting,
+ * so a stalled network path can't hang CLI startup indefinitely.
+ */
+const ATLASSIAN_OAUTH_TIMEOUT_MS = 15_000;
+
 type OAuthTokenResponse = {
 	access_token?: unknown;
 };
@@ -36,6 +42,7 @@ export function fetchOAuthAccessToken(
 				fetch(ATLASSIAN_OAUTH_TOKEN_URL, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
+					signal: AbortSignal.timeout(ATLASSIAN_OAUTH_TIMEOUT_MS),
 					body: JSON.stringify({
 						grant_type: "client_credentials",
 						client_id: clientId,

--- a/packages/lib/src/PublisherErrors.test.ts
+++ b/packages/lib/src/PublisherErrors.test.ts
@@ -29,9 +29,13 @@ function createConfluenceClientWithoutParentSpace(): RequiredConfluenceClient {
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -1,10 +1,16 @@
 import { Context } from "effect";
 
+export type ConfluenceAuthMethod = "basic" | "oauth2";
+
 export type ConfluenceSettings = {
 	confluenceBaseUrl: string;
+	confluenceSiteUrl: string;
 	confluenceParentId: string;
+	authMethod: ConfluenceAuthMethod;
 	atlassianUserName: string;
 	atlassianApiToken: string;
+	atlassianClientId: string;
+	atlassianClientSecret: string;
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
@@ -12,13 +18,28 @@ export type ConfluenceSettings = {
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	confluenceBaseUrl: "",
+	confluenceSiteUrl: "",
 	confluenceParentId: "",
+	authMethod: "basic",
 	atlassianUserName: "",
 	atlassianApiToken: "",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
 };
+
+/**
+ * The human-facing Atlassian site URL used to build and match browser-facing
+ * links (e.g. https://your-site.atlassian.net). Falls back to
+ * `confluenceBaseUrl` when `confluenceSiteUrl` is unset, preserving existing
+ * behaviour for deployments that talk directly to the site rather than the
+ * API gateway (https://api.atlassian.com/ex/confluence/{cloudId}).
+ */
+export function resolveSiteUrl(settings: ConfluenceSettings): string {
+	return settings.confluenceSiteUrl || settings.confluenceBaseUrl;
+}
 
 export class ConfluenceSettingsService extends Context.Service<
 	ConfluenceSettingsService,

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -85,9 +85,13 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 
 	expect(settings).toEqual({
 		confluenceBaseUrl: "https://env.example.atlassian.net",
+		confluenceSiteUrl: "",
 		confluenceParentId: "cli-parent",
+		authMethod: "basic",
 		atlassianUserName: "env-user@example.com",
 		atlassianApiToken: "cli-token",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
 		folderToPublish: "env-folder",
 		contentRoot: expectedCliContentRoot,
 		firstHeadingPageTitle: true,
@@ -168,6 +172,146 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 
 	expect(settings.firstHeadingPageTitle).toBe(false);
 	expect(settings.contentRoot).toBe(expectedContentRoot);
+});
+
+test("loads OAuth client-credentials settings and leaves basic credentials optional", async () => {
+	const settings = await runEffect(
+		parseConfluenceSettingsEffect(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+				confluenceSiteUrl: "https://site.example.atlassian.net",
+				confluenceParentId: "parent",
+				authMethod: "oauth2",
+				atlassianClientId: "client-id",
+				atlassianClientSecret: "client-secret",
+				folderToPublish: "docs",
+				contentRoot: "docs",
+				firstHeadingPageTitle: false,
+			}),
+		),
+	);
+
+	expect(settings.authMethod).toBe("oauth2");
+	expect(settings.atlassianClientId).toBe("client-id");
+	expect(settings.atlassianClientSecret).toBe("client-secret");
+	expect(settings.confluenceSiteUrl).toBe("https://site.example.atlassian.net");
+	expect(settings.atlassianUserName).toBe("");
+	expect(settings.atlassianApiToken).toBe("");
+});
+
+test("defaults authMethod to basic and confluenceSiteUrl to empty string", async () => {
+	const settings = await runEffect(
+		parseConfluenceSettingsEffect(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: "https://site.example.atlassian.net",
+				confluenceParentId: "parent",
+				atlassianUserName: "user@example.com",
+				atlassianApiToken: "token",
+				folderToPublish: "docs",
+				contentRoot: "docs",
+				firstHeadingPageTitle: false,
+			}),
+		),
+	);
+
+	expect(settings.authMethod).toBe("basic");
+	expect(settings.confluenceSiteUrl).toBe("");
+});
+
+test("fails when basic auth is missing the API token", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://site.example.atlassian.net",
+					confluenceParentId: "parent",
+					authMethod: "basic",
+					atlassianUserName: "user@example.com",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(/Atlassian API token is required when authMethod is basic/);
+});
+
+test("fails when oauth2 auth is missing the client secret", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+					confluenceParentId: "parent",
+					authMethod: "oauth2",
+					atlassianClientId: "client-id",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(/Atlassian client secret is required when authMethod is oauth2/);
+});
+
+test("requires confluenceSiteUrl when confluenceBaseUrl is the Atlassian API gateway", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+					confluenceParentId: "parent",
+					authMethod: "oauth2",
+					atlassianClientId: "client-id",
+					atlassianClientSecret: "client-secret",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(
+		/Confluence site URL is required when confluenceBaseUrl points at the Atlassian API gateway/,
+	);
+});
+
+test("accepts the Atlassian API gateway base URL when confluenceSiteUrl is provided", async () => {
+	const settings = await runEffect(
+		parseConfluenceSettingsEffect(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+				confluenceSiteUrl: "https://site.example.atlassian.net",
+				confluenceParentId: "parent",
+				authMethod: "oauth2",
+				atlassianClientId: "client-id",
+				atlassianClientSecret: "client-secret",
+				folderToPublish: "docs",
+				contentRoot: "docs",
+				firstHeadingPageTitle: false,
+			}),
+		),
+	);
+
+	expect(settings.confluenceSiteUrl).toBe("https://site.example.atlassian.net");
+});
+
+test("rejects an unsupported authMethod value", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://site.example.atlassian.net",
+					confluenceParentId: "parent",
+					authMethod: "saml",
+					atlassianUserName: "user@example.com",
+					atlassianApiToken: "token",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(/Unsupported authMethod "saml"/);
 });
 
 function makeRuntimeEnvironment({

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -7,7 +7,12 @@ import {
 	RuntimeEnvironment,
 	RuntimeEnvironmentService,
 } from "./effects";
-import { ConfluenceSettings, ConfluenceSettingsService, DEFAULT_SETTINGS } from "./Settings";
+import {
+	ConfluenceAuthMethod,
+	ConfluenceSettings,
+	ConfluenceSettingsService,
+	DEFAULT_SETTINGS,
+} from "./Settings";
 
 const CONFLUENCE_SETTINGS_KEYS = Object.keys(DEFAULT_SETTINGS) as (keyof ConfluenceSettings)[];
 
@@ -21,9 +26,23 @@ type ArgumentValue = boolean | string | undefined;
 
 export const confluenceSettingsConfig = Config.all({
 	confluenceBaseUrl: Config.string("confluenceBaseUrl"),
+	confluenceSiteUrl: Config.string("confluenceSiteUrl").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.confluenceSiteUrl),
+	),
 	confluenceParentId: Config.string("confluenceParentId"),
-	atlassianUserName: Config.string("atlassianUserName"),
-	atlassianApiToken: Config.string("atlassianApiToken"),
+	authMethod: Config.string("authMethod").pipe(Config.withDefault(DEFAULT_SETTINGS.authMethod)),
+	atlassianUserName: Config.string("atlassianUserName").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianUserName),
+	),
+	atlassianApiToken: Config.string("atlassianApiToken").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianApiToken),
+	),
+	atlassianClientId: Config.string("atlassianClientId").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianClientId),
+	),
+	atlassianClientSecret: Config.string("atlassianClientSecret").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianClientSecret),
+	),
 	folderToPublish: Config.string("folderToPublish"),
 	contentRoot: Config.string("contentRoot"),
 	firstHeadingPageTitle: Config.boolean("firstHeadingPageTitle"),
@@ -95,8 +114,12 @@ export function makeConfluenceSettingsConfigProvider(): Effect.Effect<
 	});
 }
 
+type ParsedConfluenceSettings = Omit<ConfluenceSettings, "authMethod"> & {
+	authMethod: string;
+};
+
 function validateConfluenceSettingsEffect(
-	settings: ConfluenceSettings,
+	settings: ParsedConfluenceSettings,
 ): Effect.Effect<ConfluenceSettings, Error, Path> {
 	return Effect.gen(function* () {
 		const path = yield* Path;
@@ -109,12 +132,40 @@ function validateConfluenceSettingsEffect(
 			return yield* Effect.fail(new Error("Confluence parent ID is required"));
 		}
 
-		if (!settings.atlassianUserName) {
-			return yield* Effect.fail(new Error("Atlassian user name is required"));
+		const authMethod = yield* validateAuthMethod(settings.authMethod);
+
+		if (authMethod === "oauth2") {
+			if (!settings.atlassianClientId) {
+				return yield* Effect.fail(
+					new Error("Atlassian client ID is required when authMethod is oauth2"),
+				);
+			}
+
+			if (!settings.atlassianClientSecret) {
+				return yield* Effect.fail(
+					new Error("Atlassian client secret is required when authMethod is oauth2"),
+				);
+			}
+		} else {
+			if (!settings.atlassianUserName) {
+				return yield* Effect.fail(
+					new Error("Atlassian user name is required when authMethod is basic"),
+				);
+			}
+
+			if (!settings.atlassianApiToken) {
+				return yield* Effect.fail(
+					new Error("Atlassian API token is required when authMethod is basic"),
+				);
+			}
 		}
 
-		if (!settings.atlassianApiToken) {
-			return yield* Effect.fail(new Error("Atlassian API token is required"));
+		if (isAtlassianApiGatewayUrl(settings.confluenceBaseUrl) && !settings.confluenceSiteUrl) {
+			return yield* Effect.fail(
+				new Error(
+					"Confluence site URL is required when confluenceBaseUrl points at the Atlassian API gateway",
+				),
+			);
 		}
 
 		if (!settings.folderToPublish) {
@@ -127,11 +178,37 @@ function validateConfluenceSettingsEffect(
 
 		return {
 			...settings,
+			authMethod,
 			contentRoot: settings.contentRoot.endsWith(path.sep)
 				? settings.contentRoot
 				: `${settings.contentRoot}${path.sep}`,
 		};
 	});
+}
+
+function validateAuthMethod(value: string): Effect.Effect<ConfluenceAuthMethod, Error> {
+	if (value === "basic" || value === "oauth2") {
+		return Effect.succeed(value);
+	}
+
+	return Effect.fail(
+		new Error(`Unsupported authMethod "${value}". Expected "basic" or "oauth2".`),
+	);
+}
+
+/**
+ * Detects the Atlassian API gateway base URL
+ * (https://api.atlassian.com/ex/confluence/{cloudId}). When the base URL points
+ * at the gateway, browser-facing links cannot be derived from it, so a separate
+ * `confluenceSiteUrl` must be supplied.
+ */
+function isAtlassianApiGatewayUrl(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return url.hostname === "api.atlassian.com" && url.pathname.startsWith("/ex/confluence/");
+	} catch {
+		return false;
+	}
 }
 
 function getConfigPath(
@@ -185,9 +262,13 @@ function makeEnvironmentProvider(
 		return ConfigProvider.fromEnv({
 			env: compactRecord({
 				confluenceBaseUrl: yield* runtimeEnvironment.getEnv("CONFLUENCE_BASE_URL"),
+				confluenceSiteUrl: yield* runtimeEnvironment.getEnv("CONFLUENCE_SITE_URL"),
 				confluenceParentId: yield* runtimeEnvironment.getEnv("CONFLUENCE_PARENT_ID"),
+				authMethod: yield* runtimeEnvironment.getEnv("CONFLUENCE_AUTH_METHOD"),
 				atlassianUserName: yield* runtimeEnvironment.getEnv("ATLASSIAN_USERNAME"),
 				atlassianApiToken: yield* runtimeEnvironment.getEnv("ATLASSIAN_API_TOKEN"),
+				atlassianClientId: yield* runtimeEnvironment.getEnv("ATLASSIAN_CLIENT_ID"),
+				atlassianClientSecret: yield* runtimeEnvironment.getEnv("ATLASSIAN_CLIENT_SECRET"),
 				folderToPublish: yield* runtimeEnvironment.getEnv("FOLDER_TO_PUBLISH"),
 				contentRoot: yield* runtimeEnvironment.getEnv("CONFLUENCE_CONTENT_ROOT"),
 				firstHeadingPageTitle:
@@ -200,9 +281,13 @@ function makeEnvironmentProvider(
 function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.ConfigProvider {
 	const options = parseArgumentValues(argv, [
 		{ name: "baseUrl", aliases: ["b"], type: "string" },
+		{ name: "siteUrl", type: "string" },
 		{ name: "parentId", aliases: ["p"], type: "string" },
+		{ name: "authMethod", type: "string" },
 		{ name: "userName", aliases: ["u"], type: "string" },
 		{ name: "apiToken", type: "string" },
+		{ name: "clientId", type: "string" },
+		{ name: "clientSecret", type: "string" },
 		{ name: "enableFolder", aliases: ["f"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
@@ -211,9 +296,13 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 	return ConfigProvider.fromUnknown(
 		compactRecord({
 			confluenceBaseUrl: options["baseUrl"],
+			confluenceSiteUrl: options["siteUrl"],
 			confluenceParentId: options["parentId"],
+			authMethod: options["authMethod"],
 			atlassianUserName: options["userName"],
 			atlassianApiToken: options["apiToken"],
+			atlassianClientId: options["clientId"],
+			atlassianClientSecret: options["clientSecret"],
 			folderToPublish: options["enableFolder"],
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],

--- a/packages/lib/src/TreeConfluence.test.ts
+++ b/packages/lib/src/TreeConfluence.test.ts
@@ -191,9 +191,13 @@ function createRootNode(
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/TreeConfluence.ts
+++ b/packages/lib/src/TreeConfluence.ts
@@ -182,7 +182,7 @@ function createFileStructureInConfluenceEffect(
 			{ concurrency: "unbounded" },
 		);
 
-		const pageUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${spaceKey}/pages/${file.pageId}/`;
+		const pageUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${file.spaceKey}/pages/${file.pageId}/`;
 		return {
 			file: { ...file, pageUrl },
 			version,

--- a/packages/lib/src/TreeConfluence.ts
+++ b/packages/lib/src/TreeConfluence.ts
@@ -14,7 +14,7 @@ import {
 	LocalAdfFile,
 	LocalAdfFileTreeNode,
 } from "./Publisher";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 
 const blankPageAdf: string = JSON.stringify(doc(p("Page not published yet")));
 
@@ -182,7 +182,7 @@ function createFileStructureInConfluenceEffect(
 			{ concurrency: "unbounded" },
 		);
 
-		const pageUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${spaceKey}/pages/${file.pageId}/`;
+		const pageUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${spaceKey}/pages/${file.pageId}/`;
 		return {
 			file: { ...file, pageUrl },
 			version,

--- a/packages/lib/src/TreeLocal.test.ts
+++ b/packages/lib/src/TreeLocal.test.ts
@@ -76,9 +76,13 @@ function createMarkdownFile(filesystemPath: Path, absoluteFilePath: string): Mar
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -35,6 +35,11 @@ import {
 } from "./MarkdownWorkspace";
 import { convertMDtoADF, parseMarkdownToADF, stripMarkdownHtmlComments } from "./MdToADF";
 import {
+	ATLASSIAN_OAUTH_AUDIENCE,
+	ATLASSIAN_OAUTH_TOKEN_URL,
+	fetchOAuthAccessToken,
+} from "./OAuthToken";
+import {
 	Publisher,
 	type ConfluenceAdfFile,
 	type ConfluenceNode,
@@ -54,6 +59,8 @@ import {
 
 export {
 	AlwaysADFProcessingPlugins,
+	ATLASSIAN_OAUTH_AUDIENCE,
+	ATLASSIAN_OAUTH_TOKEN_URL,
 	ConfluencePageConfig,
 	ConfluenceSettingsLive,
 	ConfluenceUploadSettings,
@@ -70,6 +77,7 @@ export {
 	createPublisherFunctions,
 	executeADFProcessingPipeline,
 	executeADFProcessingPipelineEffect,
+	fetchOAuthAccessToken,
 	getMermaidFileName,
 	loadConfluenceSettings,
 	loadConfluenceSettingsEffect,


### PR DESCRIPTION
Adds OAuth 2.0 client-credentials authentication so the CLI can authenticate to Confluence Cloud via service accounts (`client_id` + `client_secret`), alongside the existing Basic Auth. The CLI performs the token exchange itself, so OAuth is available to the CLI, Docker image, and GitHub Action.

Basic Auth remains the default and is unchanged; `authMethod` defaults to `basic`.

**Authentication**

- New settings: `authMethod` (`basic` | `oauth2`), `atlassianClientId`, `atlassianClientSecret`, with env vars (`CONFLUENCE_AUTH_METHOD`, `ATLASSIAN_CLIENT_ID`, `ATLASSIAN_CLIENT_SECRET`) and CLI flags (`--authMethod`, `--clientId`, `--clientSecret`).
- `fetchOAuthAccessToken` performs the client-credentials grant against `https://auth.atlassian.com/oauth/token` (audience `api.atlassian.com`).
- Validation is conditional on `authMethod`: `basic` requires username + API token; `oauth2` requires client id + secret.

**Display/site URL split**

- New `confluenceSiteUrl` setting (env `CONFLUENCE_SITE_URL`, flag `--siteUrl`). When authenticating via OAuth, `confluenceBaseUrl` is typically the API gateway (`https://api.atlassian.com/ex/confluence/{cloudId}`), which can't be used to build browsable links. `confluenceSiteUrl` provides the human-facing site URL; it falls back to `confluenceBaseUrl` when unset (preserving current behavior). Threaded through page URLs, wikilink resolution, and link normalization via a `resolveSiteUrl` helper.
- Validation requires `confluenceSiteUrl` when `confluenceBaseUrl` points at the API gateway.

**Build fix**

The CLI is bundled as ESM but includes CommonJS deps (e.g. `mime-types`) that call `require()` for Node built-ins at runtime, which threw on startup. Adds a `createRequire` banner to the bundle. (Separate commit; pre-existing issue surfaced while running the OAuth CLI.)

**Docs & tests**

- CLI README: new settings table rows + an "OAuth 2.0 Service Account Authentication" section.
- Tests for token exchange, settings validation matrix, and site-URL handling.

`vp check`, `vp test run` (56 passed), `vp run -r build` (all packages) green. Verified end-to-end against a live Confluence Cloud tenant via a service account.

## Out of scope

- The Obsidian plugin keeps its own `MyBaseClient`/settings UI and is intentionally untouched; `authMethod` defaults to `basic`, so it's unaffected.
- Service-account OAuth on Confluence Cloud requires the v1 `/content` REST endpoints that confluence.js uses, which are gone via the OAuth gateway (they return 410, while Basic Auth still works). Publishing therefore needs the content operations on the v2 API. That's tracked separately in #796 for maintainer direction before implementation; this PR is the auth layer only.

---

## Temporary fork for OAuth users

If anyone needs to use OAuth 2.0 publishing before these changes land upstream, I am maintaining a temporary fork with this PR plus the follow-up v2 content adapter and force-publish support merged:

- Fork: <https://github.com/theherk/markdown-confluence>
- Branch: `main`
- Included branches/PRs:
  - `oauth2` (this PR)
  - `v2-content-adapter` (#830)
  - `force-publish-clean` (#831)

```mermaid
gitGraph
    commit id: "upstream/main"
    branch oauth2
    checkout oauth2
    commit id: "OAuth 2.0 auth"
    commit id: "OAuth review fixes"
    branch v2-content-adapter
    checkout v2-content-adapter
    commit id: "ConfluenceV2Client"
    commit id: "v2 wiring + fixes"
    checkout main
    branch force-publish-clean
    checkout force-publish-clean
    commit id: "forcePublish setting"
    checkout main
    merge oauth2
    merge v2-content-adapter
    merge force-publish-clean
```
