### PR TITLE
feat(lib): Add Confluence v2 adapter for content operations

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -108,13 +108,50 @@ The CLI, Docker image, and GitHub Action all read the same global settings. You 
 
 | JSON key | Environment variable | CLI option | Description |
 | --- | --- | --- | --- |
-| `confluenceBaseUrl` | `CONFLUENCE_BASE_URL` | `--baseUrl`, `-b` | Your Confluence site URL. For Confluence Cloud, use the Atlassian site URL without `/wiki`, for example `https://your-domain.atlassian.net`. |
+| `confluenceBaseUrl` | `CONFLUENCE_BASE_URL` | `--baseUrl`, `-b` | Your Confluence site URL. For Confluence Cloud, use the Atlassian site URL without `/wiki`, for example `https://your-domain.atlassian.net`. When authenticating with OAuth 2.0, set this to the API gateway URL `https://api.atlassian.com/ex/confluence/{cloudId}`. |
+| `confluenceSiteUrl` | `CONFLUENCE_SITE_URL` | `--siteUrl` | The browsable Confluence site URL used to build and match display links (for example `https://your-domain.atlassian.net`). Falls back to `confluenceBaseUrl` when unset. Required when `confluenceBaseUrl` points at the API gateway, otherwise published links would be unresolvable. |
 | `confluenceParentId` | `CONFLUENCE_PARENT_ID` | `--parentId`, `-p` | The numeric ID of an existing Confluence parent page. The parent page determines the target space. |
-| `atlassianUserName` | `ATLASSIAN_USERNAME` | `--userName`, `-u` | The Atlassian user name or email address used for publishing. |
-| `atlassianApiToken` | `ATLASSIAN_API_TOKEN` | `--apiToken` | The Atlassian API token. Prefer an environment variable or GitHub secret instead of committing this value to JSON. |
+| `authMethod` | `CONFLUENCE_AUTH_METHOD` | `--authMethod` | Authentication method: `basic` (default) or `oauth2`. |
+| `atlassianUserName` | `ATLASSIAN_USERNAME` | `--userName`, `-u` | The Atlassian user name or email address used for publishing. Required when `authMethod` is `basic`. |
+| `atlassianApiToken` | `ATLASSIAN_API_TOKEN` | `--apiToken` | The Atlassian API token. Required when `authMethod` is `basic`. Prefer an environment variable or GitHub secret instead of committing this value to JSON. |
+| `atlassianClientId` | `ATLASSIAN_CLIENT_ID` | `--clientId` | OAuth 2.0 client ID. Required when `authMethod` is `oauth2`. |
+| `atlassianClientSecret` | `ATLASSIAN_CLIENT_SECRET` | `--clientSecret` | OAuth 2.0 client secret. Required when `authMethod` is `oauth2`. Prefer an environment variable or GitHub secret instead of committing this value to JSON. |
 | `folderToPublish` | `FOLDER_TO_PUBLISH` | `--enableFolder`, `-f` | The folder, relative to `contentRoot`, whose Markdown files default to `connie-publish: true`. Use `.` to publish all Markdown files under `contentRoot`. |
 | `contentRoot` | `CONFLUENCE_CONTENT_ROOT` | `--contentRoot`, `--cr` | The root directory to scan for Markdown files and referenced content. |
 | `firstHeadingPageTitle` | `CONFLUENCE_FIRST_HEADING_PAGE_TITLE` | `--firstHeaderPageTitle`, `--fh` | When `true`, use the first heading as the page title when `connie-title` is not set. |
+
+### OAuth 2.0 Service Account Authentication
+
+By default the CLI authenticates with Basic Auth using `atlassianUserName` and `atlassianApiToken`. You can instead authenticate as a service account using the OAuth 2.0 client-credentials grant. The CLI exchanges the credentials for a short-lived bearer token itself, so this works for the CLI, the Docker image, and the GitHub Action without any pre-steps.
+
+To use OAuth 2.0:
+
+1. Set `authMethod` to `oauth2`.
+2. Supply `atlassianClientId` and `atlassianClientSecret` (prefer environment variables or secrets).
+3. Set `confluenceBaseUrl` to the API gateway URL `https://api.atlassian.com/ex/confluence/{cloudId}`.
+4. Set `confluenceSiteUrl` to your browsable site URL `https://your-domain.atlassian.net` so published links resolve correctly.
+
+`.markdown-confluence.json`:
+
+```json
+{
+  "authMethod": "oauth2",
+  "confluenceBaseUrl": "https://api.atlassian.com/ex/confluence/your-cloud-id",
+  "confluenceSiteUrl": "https://your-domain.atlassian.net",
+  "confluenceParentId": "123456",
+  "folderToPublish": "docs",
+  "contentRoot": "."
+}
+```
+
+```bash
+export ATLASSIAN_CLIENT_ID="YOUR CLIENT ID"
+export ATLASSIAN_CLIENT_SECRET="YOUR CLIENT SECRET"
+```
+
+The CLI exchanges these credentials for a bearer token against the Atlassian token endpoint (`https://auth.atlassian.com/oauth/token`) and uses it for all Confluence API requests.
+
+> **Note:** The bearer token is fetched once at startup and is short-lived. This is sufficient for normal publishes, but a very large publish run could exceed the token lifetime and begin failing partway through. If you hit this, split the publish into smaller runs.
 
 ### `folderToPublish` vs `contentRoot`
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
 	Publisher,
 	MermaidRendererPlugin,
 	RuntimeEnvironmentService,
+	fetchOAuthAccessToken,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { ConfluenceClient } from "confluence.js";
@@ -22,14 +23,11 @@ const program = Effect.gen(function* () {
 
 	const settings = yield* ConfluenceUploadSettings.ConfluenceSettingsService as any;
 
+	const authentication = yield* resolveAuthentication(settings);
+
 	const confluenceClient = new ConfluenceClient({
 		host: settings.confluenceBaseUrl,
-		authentication: {
-			basic: {
-				email: settings.atlassianUserName,
-				apiToken: settings.atlassianApiToken,
-			},
-		},
+		authentication,
 		middlewares: {
 			onError(e) {
 				if ("response" in e && "data" in e.response) {
@@ -85,4 +83,25 @@ NodeRuntime.runMain(
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : JSON.stringify(error);
+}
+
+type ConfluenceClientConfig = ConstructorParameters<typeof ConfluenceClient>[0];
+type ConfluenceAuthentication = ConfluenceClientConfig["authentication"];
+
+function resolveAuthentication(
+	settings: ConfluenceUploadSettings.ConfluenceSettings,
+): Effect.Effect<ConfluenceAuthentication, Error> {
+	if (settings.authMethod === "oauth2") {
+		return fetchOAuthAccessToken(
+			settings.atlassianClientId,
+			settings.atlassianClientSecret,
+		).pipe(Effect.map((accessToken) => ({ oauth2: { accessToken } })));
+	}
+
+	return Effect.succeed({
+		basic: {
+			email: settings.atlassianUserName,
+			apiToken: settings.atlassianApiToken,
+		},
+	});
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,15 +7,17 @@ import { Console, Effect } from "effect";
 import {
 	ConfluenceSettingsLive,
 	ConfluenceUploadSettings,
+	ConfluenceV2Client,
 	MarkdownWorkspaceLive,
 	MarkdownConfluencePlatformLive,
 	Publisher,
 	MermaidRendererPlugin,
 	RuntimeEnvironmentService,
 	fetchOAuthAccessToken,
+	type RequiredConfluenceClient,
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
-import { ConfluenceClient } from "confluence.js";
+import { Api, ConfluenceClient } from "confluence.js";
 
 const program = Effect.gen(function* () {
 	const runtimeEnvironment = yield* RuntimeEnvironmentService as any;
@@ -23,22 +25,7 @@ const program = Effect.gen(function* () {
 
 	const settings = yield* ConfluenceUploadSettings.ConfluenceSettingsService as any;
 
-	const authentication = yield* resolveAuthentication(settings);
-
-	const confluenceClient = new ConfluenceClient({
-		host: settings.confluenceBaseUrl,
-		authentication,
-		middlewares: {
-			onError(e) {
-				if ("response" in e && "data" in e.response) {
-					e.message =
-						typeof e.response.data === "string"
-							? e.response.data
-							: JSON.stringify(e.response.data);
-				}
-			},
-		},
-	});
+	const confluenceClient = yield* buildConfluenceClient(settings);
 
 	const publisher = new Publisher(settings, confluenceClient, [
 		new MermaidRendererPlugin(new PuppeteerMermaidRenderer()),
@@ -88,20 +75,74 @@ function getErrorMessage(error: unknown): string {
 type ConfluenceClientConfig = ConstructorParameters<typeof ConfluenceClient>[0];
 type ConfluenceAuthentication = ConfluenceClientConfig["authentication"];
 
-function resolveAuthentication(
+const onErrorMiddleware: NonNullable<ConfluenceClientConfig["middlewares"]>["onError"] = (e) => {
+	if ("response" in e && "data" in e.response) {
+		e.message =
+			typeof e.response.data === "string" ? e.response.data : JSON.stringify(e.response.data);
+	}
+};
+
+/**
+ * Builds the Confluence client the publisher uses. For Basic auth this is the
+ * stock confluence.js client (v1 REST). For OAuth, the v1 `/content` CRUD
+ * endpoints return 410 via the gateway, so content operations are routed
+ * through {@link ConfluenceV2Client} (v2 API) while attachments, labels, and
+ * users continue to use the v1 client (which works under OAuth).
+ */
+function buildConfluenceClient(
 	settings: ConfluenceUploadSettings.ConfluenceSettings,
-): Effect.Effect<ConfluenceAuthentication, Error> {
+): Effect.Effect<RequiredConfluenceClient, Error> {
 	if (settings.authMethod === "oauth2") {
 		return fetchOAuthAccessToken(
 			settings.atlassianClientId,
 			settings.atlassianClientSecret,
-		).pipe(Effect.map((accessToken) => ({ oauth2: { accessToken } })));
+		).pipe(
+			Effect.map((accessToken) => {
+				const client = makeConfluenceClient(settings.confluenceBaseUrl, {
+					oauth2: { accessToken },
+				});
+				const v2Content = new ConfluenceV2Client(settings.confluenceBaseUrl, accessToken);
+				// Under OAuth the v1 /content reads are gone (410), so route content
+				// CRUD plus the attachment/label *reads* through the v2 adapter. The
+				// attachment upload and label writes still work on v1 and are kept.
+				return {
+					content: v2Content as unknown as Api.Content,
+					space: client.space,
+					contentAttachments: Object.assign(
+						Object.create(client.contentAttachments) as Api.ContentAttachments,
+						{
+							getAttachments: v2Content.getAttachments.bind(v2Content),
+						},
+					),
+					contentLabels: Object.assign(
+						Object.create(client.contentLabels) as Api.ContentLabels,
+						{
+							getLabelsForContent: v2Content.getLabelsForContent.bind(v2Content),
+						},
+					),
+					users: client.users,
+				};
+			}),
+		);
 	}
 
-	return Effect.succeed({
-		basic: {
-			email: settings.atlassianUserName,
-			apiToken: settings.atlassianApiToken,
-		},
+	return Effect.succeed(
+		makeConfluenceClient(settings.confluenceBaseUrl, {
+			basic: {
+				email: settings.atlassianUserName,
+				apiToken: settings.atlassianApiToken,
+			},
+		}),
+	);
+}
+
+function makeConfluenceClient(
+	host: string,
+	authentication: ConfluenceAuthentication,
+): ConfluenceClient {
+	return new ConfluenceClient({
+		host,
+		authentication,
+		middlewares: { onError: onErrorMiddleware },
 	});
 }

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -5,6 +5,14 @@ import { Effect, Layer } from "effect";
 import { defineConfig, type Plugin } from "vite-plus";
 import { generatedBanner, isNodeBuiltin } from "../../vite.package-build.ts";
 
+// The CLI is bundled as ESM but pulls in CommonJS dependencies (for example
+// `mime-types`) that call `require(...)` for Node built-ins at runtime.
+// ESM modules have no `require` in scope, so rolldown's CJS interop shim throws.
+// Provide a real `require` via `createRequire` so those calls resolve natively.
+const cliBanner = `${generatedBanner}import { createRequire as __createRequire } from "node:module";
+const require = __createRequire(import.meta.url);
+`;
+
 const NodePlatformLive = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
 
 function runNodePlatform<A>(effect: Effect.Effect<A, unknown, FileSystem | Path>) {
@@ -45,7 +53,7 @@ export default defineConfig({
 		rollupOptions: {
 			external: isNodeBuiltin,
 			output: {
-				banner: generatedBanner,
+				banner: cliBanner,
 				codeSplitting: false,
 			},
 		},

--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -90,9 +90,13 @@ function createNode(file: Partial<ConfluenceAdfFile>): ConfluenceNode {
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "1",
+	authMethod: "basic",
 	atlassianUserName: "test@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/AdfProcessing.ts
+++ b/packages/lib/src/AdfProcessing.ts
@@ -1,7 +1,7 @@
 import { traverse } from "@atlaskit/adf-utils/traverse";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { ConfluenceAdfFile, ConfluenceNode } from "./Publisher";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 import { adfEqual, marksEqual } from "./AdfEqual";
 import { ADFEntity } from "@atlaskit/adf-utils/types";
 import { heading, li, ol, p, text } from "@atlaskit/adf-utils/builders";
@@ -583,7 +583,7 @@ function processWikilinkToActualLink(
 					const linkPage = fileToPageIdMap[pagename];
 
 					if (linkPage) {
-						const confluenceUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${linkPage.spaceKey}/pages/${linkPage.pageId}${wikilinkUrl.hash}`;
+						const confluenceUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${linkPage.spaceKey}/pages/${linkPage.pageId}${wikilinkUrl.hash}`;
 						node.marks[0].attrs["href"] = confluenceUrl;
 						if (
 							node.text === `${pathName}${wikilinkUrl.hash}` ||

--- a/packages/lib/src/Attachments.test.ts
+++ b/packages/lib/src/Attachments.test.ts
@@ -60,6 +60,37 @@ test("derives upload buffer content type from the filename", async () => {
 	expect(getUploadedAttachment(uploadRequests).contentType).toBe("text/plain");
 });
 
+test("extracts SVG dimensions when image-size cannot detect them", async () => {
+	const uploadRequests: unknown[] = [];
+	const svgBytes = Buffer.from(
+		'<svg xmlns="http://www.w3.org/2000/svg" width="1911px" height="1391px" viewBox="0 0 1911 1391"></svg>',
+	);
+	const workspace = new TestMarkdownWorkspace((searchPath) =>
+		searchPath === "diagram.svg"
+			? {
+					filename: "diagram.svg",
+					filePath: "img/diagram.svg",
+					mimeType: "image/svg+xml",
+					contents: svgBytes,
+				}
+			: false,
+	);
+
+	const result = await Effect.runPromise(
+		uploadFileEffect(
+			makeConfluenceClient(uploadRequests),
+			"page-id",
+			"page.md",
+			"diagram.svg",
+			{},
+		).pipe(Effect.provideService(MarkdownWorkspaceService, workspace)),
+	);
+
+	expect(result?.width).toBe(1911);
+	expect(result?.height).toBe(1391);
+	expect(getUploadedAttachment(uploadRequests).contentType).toBe("image/svg+xml");
+});
+
 class TestMarkdownWorkspace implements MarkdownWorkspace {
 	readonly getMarkdownFilesToUpload: Effect.Effect<FilesToUpload, Error> = Effect.succeed([]);
 

--- a/packages/lib/src/Attachments.test.ts
+++ b/packages/lib/src/Attachments.test.ts
@@ -63,7 +63,7 @@ test("derives upload buffer content type from the filename", async () => {
 test("extracts SVG dimensions when image-size cannot detect them", async () => {
 	const uploadRequests: unknown[] = [];
 	const svgBytes = Buffer.from(
-		'<svg xmlns="http://www.w3.org/2000/svg" width="1911px" height="1391px" viewBox="0 0 1911 1391"></svg>',
+		'<?xml version="1.0"?><!----><svg xmlns="http://www.w3.org/2000/svg" width="1911px" height="1391px" viewBox="0 0 1911 1391"></svg>',
 	);
 	const workspace = new TestMarkdownWorkspace((searchPath) =>
 		searchPath === "diagram.svg"

--- a/packages/lib/src/Attachments.ts
+++ b/packages/lib/src/Attachments.ts
@@ -232,17 +232,19 @@ function getImageSize(buffer: Buffer): { width?: number; height?: number } {
 
 function getSvgImageSize(buffer: Buffer): { width?: number; height?: number } | undefined {
 	const svg = buffer.toString("utf-8", 0, Math.min(buffer.length, 4096));
-	if (!svg.trimStart().startsWith("<svg")) {
+	const svgTagStart = svg.indexOf("<svg");
+	if (svgTagStart === -1) {
 		return undefined;
 	}
+	const svgTag = svg.slice(svgTagStart);
 
-	const width = parseSvgLength(svg.match(/\swidth="([^"]+)"/)?.[1]);
-	const height = parseSvgLength(svg.match(/\sheight="([^"]+)"/)?.[1]);
+	const width = parseSvgLength(svgTag.match(/\swidth="([^"]+)"/)?.[1]);
+	const height = parseSvgLength(svgTag.match(/\sheight="([^"]+)"/)?.[1]);
 	if (width && height) {
 		return { width, height };
 	}
 
-	const viewBox = svg.match(/\sviewBox="([^"]+)"/)?.[1];
+	const viewBox = svgTag.match(/\sviewBox="([^"]+)"/)?.[1];
 	if (viewBox) {
 		const [, , viewBoxWidth, viewBoxHeight] = viewBox
 			.trim()

--- a/packages/lib/src/Attachments.ts
+++ b/packages/lib/src/Attachments.ts
@@ -226,8 +226,42 @@ function getImageSize(buffer: Buffer): { width?: number; height?: number } {
 	try {
 		return sizeOf(buffer);
 	} catch {
-		return {};
+		return getSvgImageSize(buffer) ?? {};
 	}
+}
+
+function getSvgImageSize(buffer: Buffer): { width?: number; height?: number } | undefined {
+	const svg = buffer.toString("utf-8", 0, Math.min(buffer.length, 4096));
+	if (!svg.trimStart().startsWith("<svg")) {
+		return undefined;
+	}
+
+	const width = parseSvgLength(svg.match(/\swidth="([^"]+)"/)?.[1]);
+	const height = parseSvgLength(svg.match(/\sheight="([^"]+)"/)?.[1]);
+	if (width && height) {
+		return { width, height };
+	}
+
+	const viewBox = svg.match(/\sviewBox="([^"]+)"/)?.[1];
+	if (viewBox) {
+		const [, , viewBoxWidth, viewBoxHeight] = viewBox
+			.trim()
+			.split(/[\s,]+/)
+			.map((value) => Number(value));
+		if (viewBoxWidth && viewBoxHeight) {
+			return { width: viewBoxWidth, height: viewBoxHeight };
+		}
+	}
+
+	return undefined;
+}
+
+function parseSvgLength(value: string | undefined): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+	const parsed = Number.parseFloat(value);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function resolveContentType(uploadFilename: string, contentType: string | undefined): string {

--- a/packages/lib/src/ConfluenceUrlParser.ts
+++ b/packages/lib/src/ConfluenceUrlParser.ts
@@ -1,4 +1,4 @@
-export function cleanUpUrlIfConfluence(input: string, confluenceBaseUrl: string): string {
+export function cleanUpUrlIfConfluence(input: string, siteUrl: string): string {
 	let url: URL;
 
 	// Check if the input is a valid URL
@@ -8,7 +8,7 @@ export function cleanUpUrlIfConfluence(input: string, confluenceBaseUrl: string)
 		return "#";
 	}
 
-	const confluenceUrl = new URL(confluenceBaseUrl);
+	const confluenceUrl = new URL(siteUrl);
 	if (url.hostname !== confluenceUrl.hostname) {
 		return input;
 	}

--- a/packages/lib/src/ConfluenceV2Client.test.ts
+++ b/packages/lib/src/ConfluenceV2Client.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, expect, test, vi } from "@effect/vitest";
+import { ConfluenceV2Client, ConfluenceV2Error } from "./ConfluenceV2Client";
+
+const BASE = "https://api.atlassian.com/ex/confluence/cloud-id";
+const TOKEN = "test-token";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+/**
+ * Builds a fetch mock that dispatches by URL substring, so tests can describe
+ * the v2 endpoints they expect to be called.
+ */
+function routedFetch(routes: Array<{ match: string; response: () => Response }>) {
+	return vi.fn(async (input: string | URL) => {
+		const url = String(input);
+		const route = routes.find((r) => url.includes(r.match));
+		if (!route) {
+			throw new Error(`Unexpected fetch to ${url}`);
+		}
+		return route.response();
+	});
+}
+
+const PAGE = {
+	id: "123",
+	status: "current",
+	title: "My Page",
+	spaceId: "900",
+	parentId: "100",
+	version: { number: 3, authorId: "acc-1" },
+	body: { atlas_doc_format: { value: '{"type":"doc"}', representation: "atlas_doc_format" } },
+};
+
+test("getContentById fetches the v2 page and adapts it to v1 shape", async () => {
+	const fetchMock = routedFetch([
+		{ match: "/wiki/api/v2/pages/123", response: () => jsonResponse(PAGE) },
+		{
+			match: "/wiki/api/v2/spaces/900",
+			response: () => jsonResponse({ id: "900", key: "PCBF", name: "PCBF" }),
+		},
+	]);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	const content = await client.getContentById({ id: "123", expand: ["space"] });
+
+	expect(content.id).toBe("123");
+	expect(content.type).toBe("page");
+	expect(content.title).toBe("My Page");
+	expect(content.space?.key).toBe("PCBF");
+	expect(content.version?.number).toBe(3);
+	expect(content.version?.by?.accountId).toBe("acc-1");
+	expect(content.body?.atlas_doc_format?.value).toBe('{"type":"doc"}');
+	// No ancestors expansion requested -> ancestors endpoint not called.
+	expect(fetchMock.mock.calls.some(([u]) => String(u).includes("/ancestors"))).toBe(false);
+});
+
+test("getContentById fetches ancestors when expand includes ancestors", async () => {
+	const fetchMock = routedFetch([
+		{
+			match: "/wiki/api/v2/pages/123/ancestors",
+			response: () => jsonResponse({ results: [{ id: "100", type: "page" }] }),
+		},
+		{ match: "/wiki/api/v2/pages/123", response: () => jsonResponse(PAGE) },
+		{
+			match: "/wiki/api/v2/spaces/900",
+			response: () => jsonResponse({ id: "900", key: "PCBF" }),
+		},
+	]);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	const content = await client.getContentById({
+		id: "123",
+		expand: ["ancestors", "space"],
+	});
+
+	expect(content.ancestors).toEqual([{ id: "100" }]);
+});
+
+test("getContent resolves the space key to an id and queries by title", async () => {
+	const fetchMock = routedFetch([
+		{
+			match: "/wiki/api/v2/spaces?keys=PCBF",
+			response: () => jsonResponse({ results: [{ id: "900", key: "PCBF" }] }),
+		},
+		{
+			match: "/wiki/api/v2/spaces/900/pages",
+			response: () => jsonResponse({ results: [PAGE] }),
+		},
+	]);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	const result = await client.getContent({
+		type: "page",
+		spaceKey: "PCBF",
+		title: "My Page",
+		expand: ["version"],
+	});
+
+	expect(result.size).toBe(1);
+	expect(result.results[0]?.id).toBe("123");
+	expect(result.results[0]?.space?.key).toBe("PCBF");
+	const pagesCall = fetchMock.mock.calls.find(([u]) => String(u).includes("/spaces/900/pages"));
+	expect(String(pagesCall?.[0])).toContain("title=My+Page");
+	expect(String(pagesCall?.[0])).toContain("body-format=atlas_doc_format");
+});
+
+test("createContent posts a v2 page with spaceId, parentId, and adf body", async () => {
+	const fetchMock = routedFetch([
+		{
+			match: "/wiki/api/v2/spaces?keys=PCBF",
+			response: () => jsonResponse({ results: [{ id: "900", key: "PCBF" }] }),
+		},
+		{ match: "/wiki/api/v2/pages", response: () => jsonResponse(PAGE) },
+	]);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	const content = await client.createContent({
+		space: { key: "PCBF" },
+		title: "My Page",
+		type: "page",
+		ancestors: [{ id: "100" }],
+		body: { atlas_doc_format: { value: '{"type":"doc"}', representation: "atlas_doc_format" } },
+	});
+
+	expect(content.id).toBe("123");
+	const postCall = fetchMock.mock.calls.find(
+		([u, init]) =>
+			String(u).endsWith("/wiki/api/v2/pages") && (init as RequestInit)?.method === "POST",
+	);
+	expect(postCall).toBeDefined();
+	const body = JSON.parse(String((postCall![1] as RequestInit).body));
+	expect(body).toMatchObject({
+		spaceId: "900",
+		status: "current",
+		title: "My Page",
+		parentId: "100",
+		body: { representation: "atlas_doc_format", value: '{"type":"doc"}' },
+	});
+});
+
+test("updateContent puts a v2 page with the new version number", async () => {
+	const fetchMock = routedFetch([
+		{
+			match: "/wiki/api/v2/spaces/900",
+			response: () => jsonResponse({ id: "900", key: "PCBF" }),
+		},
+		{ match: "/wiki/api/v2/pages/123", response: () => jsonResponse(PAGE) },
+	]);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	await client.updateContent({
+		id: "123",
+		title: "My Page",
+		type: "page",
+		version: { number: 4 },
+		body: {
+			atlas_doc_format: { value: '{"type":"doc2"}', representation: "atlas_doc_format" },
+		},
+	});
+
+	const putCall = fetchMock.mock.calls.find(
+		([u, init]) =>
+			String(u).includes("/wiki/api/v2/pages/123") && (init as RequestInit)?.method === "PUT",
+	);
+	expect(putCall).toBeDefined();
+	const body = JSON.parse(String((putCall![1] as RequestInit).body));
+	expect(body).toMatchObject({
+		id: "123",
+		status: "current",
+		title: "My Page",
+		version: { number: 4 },
+		body: { representation: "atlas_doc_format", value: '{"type":"doc2"}' },
+	});
+});
+
+test("space key resolution is cached across calls within an invocation", async () => {
+	const fetchMock = routedFetch([
+		{
+			match: "/wiki/api/v2/spaces?keys=PCBF",
+			response: () => jsonResponse({ results: [{ id: "900", key: "PCBF" }] }),
+		},
+		{
+			match: "/wiki/api/v2/spaces/900/pages",
+			response: () => jsonResponse({ results: [PAGE] }),
+		},
+	]);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	await client.getContent({ type: "page", spaceKey: "PCBF", title: "A" });
+	await client.getContent({ type: "page", spaceKey: "PCBF", title: "B" });
+
+	const keyLookups = fetchMock.mock.calls.filter(([u]) =>
+		String(u).includes("/wiki/api/v2/spaces?keys=PCBF"),
+	);
+	expect(keyLookups).toHaveLength(1);
+});
+
+test("rejects blog posts", async () => {
+	globalThis.fetch = vi.fn() as unknown as typeof fetch;
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+
+	await expect(
+		client.getContent({ type: "blogpost", spaceKey: "PCBF", title: "X" }),
+	).rejects.toThrow(/does not support blog posts/);
+});
+
+test("wraps non-2xx responses in ConfluenceV2Error with status and body", async () => {
+	globalThis.fetch = routedFetch([
+		{
+			match: "/wiki/api/v2/pages/123",
+			response: () => jsonResponse({ errors: [{ status: 404, title: "Not Found" }] }, 404),
+		},
+	]) as unknown as typeof fetch;
+
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	const error = await client.getContentById({ id: "123" }).catch((e: unknown) => e);
+
+	expect(error).toBeInstanceOf(ConfluenceV2Error);
+	expect((error as ConfluenceV2Error).response.status).toBe(404);
+});
+
+test("unsupported methods throw not-implemented errors", async () => {
+	const client = new ConfluenceV2Client(BASE, TOKEN);
+	expect(() => client.searchContentByCQL()).toThrow(/not implemented/);
+	expect(() => client.deleteContent()).toThrow(/not implemented/);
+});

--- a/packages/lib/src/ConfluenceV2Client.ts
+++ b/packages/lib/src/ConfluenceV2Client.ts
@@ -266,7 +266,7 @@ export class ConfluenceV2Client {
 			);
 		}
 		const spaceId = await this.spaces.resolveKeyToId(spaceKey);
-		const parentId = parameters?.ancestors?.[0]?.id;
+		const parentId = parameters?.ancestors?.at(-1)?.id;
 
 		const requestBody: V2CreatePageBody = {
 			spaceId,
@@ -297,7 +297,7 @@ export class ConfluenceV2Client {
 	): Promise<T> {
 		void callback;
 
-		const parentId = parameters.ancestors?.[0]?.id;
+		const parentId = parameters.ancestors?.at(-1)?.id;
 		const requestBody: V2UpdatePageBody = {
 			id: parameters.id,
 			status: "current",

--- a/packages/lib/src/ConfluenceV2Client.ts
+++ b/packages/lib/src/ConfluenceV2Client.ts
@@ -1,0 +1,518 @@
+import type { Models, Parameters } from "confluence.js";
+import type {
+	V2Ancestor,
+	V2Attachment,
+	V2CreatePageBody,
+	V2Label,
+	V2MultiEntityResult,
+	V2Page,
+	V2Space,
+	V2UpdatePageBody,
+} from "./ConfluenceV2Types";
+
+/**
+ * Default representation used for page bodies. The publisher always works in
+ * Atlassian Document Format.
+ */
+const ATLAS_DOC_FORMAT = "atlas_doc_format";
+
+/**
+ * Error thrown when a v2 request fails. Mirrors the shape that `confluence.js`
+ * surfaces (a `message` plus a `response.data` payload) so that the publisher's
+ * existing error handling continues to work unchanged.
+ */
+export class ConfluenceV2Error extends Error {
+	readonly response: { status: number; data: unknown };
+
+	constructor(message: string, status: number, data: unknown) {
+		super(message);
+		this.name = "ConfluenceV2Error";
+		this.response = { status, data };
+	}
+}
+
+/**
+ * Resolves and caches Confluence space key <-> id mappings for the lifetime of
+ * a single invocation. The v2 API addresses spaces by numeric id, while the
+ * publisher works in terms of space keys, so both directions are needed.
+ */
+class SpaceKeyCache {
+	private readonly keyToId = new Map<string, string>();
+	private readonly idToKey = new Map<string, string>();
+
+	constructor(
+		private readonly baseUrl: string,
+		private readonly accessToken: string,
+	) {}
+
+	record(key: string, id: string): void {
+		this.keyToId.set(key, id);
+		this.idToKey.set(id, key);
+	}
+
+	async resolveKeyToId(key: string): Promise<string> {
+		const cached = this.keyToId.get(key);
+		if (cached) {
+			return cached;
+		}
+
+		const result = await requestV2<V2MultiEntityResult<V2Space>>(
+			this.baseUrl,
+			this.accessToken,
+			"GET",
+			`/spaces?keys=${encodeURIComponent(key)}&limit=1`,
+		);
+		const space = result.results[0];
+		if (!space) {
+			throw new ConfluenceV2Error(`Confluence space not found for key "${key}"`, 404, result);
+		}
+		this.record(space.key, space.id);
+		return space.id;
+	}
+
+	async resolveIdToKey(id: string): Promise<string> {
+		const cached = this.idToKey.get(id);
+		if (cached) {
+			return cached;
+		}
+
+		const space = await requestV2<V2Space>(
+			this.baseUrl,
+			this.accessToken,
+			"GET",
+			`/spaces/${encodeURIComponent(id)}`,
+		);
+		this.record(space.key, space.id);
+		return space.key;
+	}
+}
+
+/**
+ * Performs a Confluence REST API v2 request and parses the JSON response,
+ * wrapping failures in {@link ConfluenceV2Error}.
+ *
+ * @param baseUrl - The Confluence base URL, typically the OAuth API gateway
+ *   (`https://api.atlassian.com/ex/confluence/{cloudId}`).
+ * @param path - The v2 path beginning with `/` (e.g. `/pages/123`), appended
+ *   after `/wiki/api/v2`.
+ */
+async function requestV2<T>(
+	baseUrl: string,
+	accessToken: string,
+	method: string,
+	path: string,
+	body?: unknown,
+): Promise<T> {
+	const url = `${baseUrl.replace(/\/$/, "")}/wiki/api/v2${path}`;
+
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method,
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				Accept: "application/json",
+				...(body === undefined ? {} : { "Content-Type": "application/json" }),
+			},
+			...(body === undefined ? {} : { body: JSON.stringify(body) }),
+		});
+	} catch (error) {
+		throw new ConfluenceV2Error(
+			`Failed to reach the Confluence v2 API (${method} ${path}): ${getErrorMessage(error)}`,
+			0,
+			undefined,
+		);
+	}
+
+	if (!response.ok) {
+		const data = await readJsonSafe(response);
+		throw new ConfluenceV2Error(
+			`Confluence v2 request failed (${method} ${path}) with status ${response.status} ${response.statusText}`,
+			response.status,
+			data,
+		);
+	}
+
+	if (response.status === 204) {
+		return undefined as T;
+	}
+
+	return (await response.json()) as T;
+}
+
+async function readJsonSafe(response: Response): Promise<unknown> {
+	try {
+		return await response.json();
+	} catch {
+		return undefined;
+	}
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function notImplemented(method: string): never {
+	throw new ConfluenceV2Error(
+		`${method} is not implemented by ConfluenceV2Client; only getContent, getContentById, createContent, and updateContent are supported`,
+		501,
+		undefined,
+	);
+}
+
+/**
+ * A v2-backed implementation of the subset of `confluence.js`'s `Api.Content`
+ * surface that the publisher uses. It exists because the legacy v1 `/content`
+ * CRUD endpoints return `410 Gone` when accessed via OAuth on Confluence Cloud,
+ * while the equivalent v2 (`/wiki/api/v2/pages`) endpoints work.
+ *
+ * Responses are adapted back into the v1 `Models.Content` / `Models.ContentArray`
+ * shapes the publisher expects, so downstream code requires no changes.
+ *
+ * Only pages are supported; blog posts are intentionally out of scope and will
+ * throw if requested.
+ *
+ * This implements the subset of `Api.Content` the publisher invokes. It is not
+ * declared `implements Api.Content` because that interface exposes
+ * callback-style overloads the publisher never uses; callers wire it in as the
+ * `content` member of {@link RequiredConfluenceClient} via a cast.
+ */
+export class ConfluenceV2Client {
+	private readonly spaces: SpaceKeyCache;
+
+	constructor(
+		private readonly baseUrl: string,
+		private readonly accessToken: string,
+	) {
+		this.spaces = new SpaceKeyCache(baseUrl, accessToken);
+	}
+
+	async getContent<T = Models.ContentArray>(
+		parameters?: Parameters.GetContent,
+		callback?: never,
+	): Promise<T> {
+		void callback;
+		assertNotBlogpost(parameters?.type);
+
+		const spaceKey = parameters?.spaceKey;
+		if (!spaceKey) {
+			throw new ConfluenceV2Error(
+				"getContent requires a spaceKey when using the v2 client",
+				400,
+				undefined,
+			);
+		}
+
+		const spaceId = await this.spaces.resolveKeyToId(spaceKey);
+		const query = new URLSearchParams({ "body-format": ATLAS_DOC_FORMAT, limit: "1" });
+		if (parameters?.title) {
+			query.set("title", parameters.title);
+		}
+
+		const result = await requestV2<V2MultiEntityResult<V2Page>>(
+			this.baseUrl,
+			this.accessToken,
+			"GET",
+			`/spaces/${encodeURIComponent(spaceId)}/pages?${query.toString()}`,
+		);
+
+		const wantsAncestors = expandIncludes(parameters?.expand, "ancestors");
+		const contents = await Promise.all(
+			result.results.map((page) => this.adaptPage(page, spaceKey, wantsAncestors)),
+		);
+
+		const contentArray: Models.ContentArray = {
+			results: contents,
+			start: 0,
+			limit: 1,
+			size: contents.length,
+			_links: { self: "" },
+		};
+		return contentArray as T;
+	}
+
+	async getContentById<T = Models.Content>(
+		parameters: Parameters.GetContentById,
+		callback?: never,
+	): Promise<T> {
+		void callback;
+
+		const page = await requestV2<V2Page>(
+			this.baseUrl,
+			this.accessToken,
+			"GET",
+			`/pages/${encodeURIComponent(parameters.id)}?body-format=${ATLAS_DOC_FORMAT}`,
+		);
+
+		const spaceKey = await this.spaces.resolveIdToKey(page.spaceId);
+		const wantsAncestors = expandIncludes(parameters.expand, "ancestors");
+		const content = await this.adaptPage(page, spaceKey, wantsAncestors);
+		return content as T;
+	}
+
+	async createContent<T = Models.Content>(
+		parameters?: Parameters.CreateContent,
+		callback?: never,
+	): Promise<T> {
+		void callback;
+		assertNotBlogpost(parameters?.type);
+
+		const spaceKey = parameters?.space?.key;
+		if (!spaceKey) {
+			throw new ConfluenceV2Error(
+				"createContent requires space.key when using the v2 client",
+				400,
+				undefined,
+			);
+		}
+		const spaceId = await this.spaces.resolveKeyToId(spaceKey);
+		const parentId = parameters?.ancestors?.[0]?.id;
+
+		const requestBody: V2CreatePageBody = {
+			spaceId,
+			status: "current",
+			title: parameters?.title ?? "",
+			...(parentId ? { parentId } : {}),
+			body: {
+				representation: ATLAS_DOC_FORMAT,
+				value: parameters?.body?.atlas_doc_format?.value ?? "",
+			},
+		};
+
+		const page = await requestV2<V2Page>(
+			this.baseUrl,
+			this.accessToken,
+			"POST",
+			"/pages",
+			requestBody,
+		);
+
+		const content = await this.adaptPage(page, spaceKey, false);
+		return content as T;
+	}
+
+	async updateContent<T = Models.Content>(
+		parameters: Parameters.UpdateContent,
+		callback?: never,
+	): Promise<T> {
+		void callback;
+
+		const parentId = parameters.ancestors?.[0]?.id;
+		const requestBody: V2UpdatePageBody = {
+			id: parameters.id,
+			status: "current",
+			title: parameters.title,
+			...(parentId ? { parentId } : {}),
+			body: {
+				representation: ATLAS_DOC_FORMAT,
+				value: parameters.body?.atlas_doc_format?.value ?? "",
+			},
+			version: {
+				number: parameters.version.number,
+				message: parameters.version.message ?? "",
+			},
+		};
+
+		const page = await requestV2<V2Page>(
+			this.baseUrl,
+			this.accessToken,
+			"PUT",
+			`/pages/${encodeURIComponent(parameters.id)}`,
+			requestBody,
+		);
+
+		const spaceKey = await this.spaces.resolveIdToKey(page.spaceId);
+		const content = await this.adaptPage(page, spaceKey, false);
+		return content as T;
+	}
+
+	/**
+	 * Lists a page's attachments via v2 (`GET /wiki/api/v2/pages/{id}/attachments`)
+	 * and adapts them to the v1 `getAttachments` shape the publisher consumes.
+	 *
+	 * v2 does not return a media `collectionName`, but Confluence derives it
+	 * deterministically as `contentId-{pageId}` (the same value the v1 upload
+	 * path computes), so it is reconstructed here to preserve the publisher's
+	 * skip-unchanged-attachment optimization.
+	 */
+	async getAttachments<T = Models.ContentArray>(
+		parameters: Parameters.GetAttachments,
+		callback?: never,
+	): Promise<T> {
+		void callback;
+
+		const pageId = parameters.id;
+		const result = await requestV2<V2MultiEntityResult<V2Attachment>>(
+			this.baseUrl,
+			this.accessToken,
+			"GET",
+			`/pages/${encodeURIComponent(pageId)}/attachments?limit=250`,
+		);
+
+		const collectionName = `contentId-${pageId}`;
+		const results = result.results.map((attachment) => ({
+			title: attachment.title,
+			metadata: { comment: attachment.comment ?? "" },
+			extensions: { fileId: attachment.fileId ?? "", collectionName },
+		}));
+
+		const contentArray = {
+			results,
+			start: 0,
+			limit: results.length,
+			size: results.length,
+			_links: { self: "" },
+		};
+		return contentArray as unknown as T;
+	}
+
+	/**
+	 * Lists a page's labels via v2 (`GET /wiki/api/v2/pages/{id}/labels`) and
+	 * adapts them to the v1 `getLabelsForContent` shape (results with `name` and
+	 * `label`). The v1 label endpoint is gone under OAuth, but v2 labels read
+	 * works with the granted scopes.
+	 */
+	async getLabelsForContent<T = Models.LabelArray>(
+		parameters: Parameters.GetLabelsForContent,
+		callback?: never,
+	): Promise<T> {
+		void callback;
+
+		const result = await requestV2<V2MultiEntityResult<V2Label>>(
+			this.baseUrl,
+			this.accessToken,
+			"GET",
+			`/pages/${encodeURIComponent(parameters.id)}/labels?limit=250`,
+		);
+
+		const labels = result.results.map((label) => ({
+			prefix: label.prefix ?? "global",
+			name: label.name,
+			id: label.id,
+			label: label.name,
+		}));
+
+		const labelArray = {
+			results: labels,
+			start: 0,
+			limit: labels.length,
+			size: labels.length,
+			_links: { self: "" },
+		};
+		return labelArray as unknown as T;
+	}
+
+	/** Adapts a v2 page into the v1 `Models.Content` shape the publisher expects. */
+	private async adaptPage(
+		page: V2Page,
+		spaceKey: string,
+		includeAncestors: boolean,
+	): Promise<Models.Content> {
+		const ancestors = includeAncestors ? await this.fetchAncestors(page) : [];
+		const adfValue = page.body?.atlas_doc_format?.value;
+
+		const content = {
+			id: page.id,
+			type: "page",
+			status: page.status,
+			title: page.title,
+			space: { key: spaceKey },
+			version: {
+				number: page.version?.number ?? 1,
+				by: { accountId: page.version?.authorId ?? "" },
+			},
+			ancestors: ancestors.map((ancestor) => ({ id: ancestor.id })),
+			body: {
+				atlas_doc_format:
+					adfValue === undefined
+						? undefined
+						: { value: adfValue, representation: ATLAS_DOC_FORMAT },
+			},
+		};
+
+		return content as unknown as Models.Content;
+	}
+
+	/**
+	 * Fetches the full ancestor chain for a page. The v2 ancestors endpoint
+	 * requires the `read:content.metadata:confluence` scope; when that scope is
+	 * not granted (401/403), this degrades gracefully to the page's immediate
+	 * parent (from `parentId`) so publishing still works. Note the deep-nesting
+	 * tree-membership check in the publisher is weaker without the full chain.
+	 */
+	private async fetchAncestors(page: V2Page): Promise<V2Ancestor[]> {
+		try {
+			const result = await requestV2<V2MultiEntityResult<V2Ancestor>>(
+				this.baseUrl,
+				this.accessToken,
+				"GET",
+				`/pages/${encodeURIComponent(page.id)}/ancestors`,
+			);
+			return result.results;
+		} catch (error) {
+			if (
+				error instanceof ConfluenceV2Error &&
+				(error.response.status === 401 || error.response.status === 403)
+			) {
+				return page.parentId ? [{ id: page.parentId, type: "page" }] : [];
+			}
+			throw error;
+		}
+	}
+
+	// --- Unsupported Api.Content methods (not used by the publisher) ---
+	// These mirror confluence.js method names so the adapter can stand in for
+	// Api.Content; the names are dictated by that API surface.
+
+	archivePages(): never {
+		notImplemented("archivePages");
+	}
+
+	// oxlint-disable-next-line descriptive/no-vague-names -- confluence.js API method name
+	publishLegacyDraft(): never {
+		notImplemented("publishLegacyDraft");
+	}
+
+	// oxlint-disable-next-line descriptive/no-vague-names -- confluence.js API method name
+	publishSharedDraft(): never {
+		notImplemented("publishSharedDraft");
+	}
+
+	searchContentByCQL(): never {
+		notImplemented("searchContentByCQL");
+	}
+
+	deleteContent(): never {
+		notImplemented("deleteContent");
+	}
+
+	getHistoryForContent(): never {
+		notImplemented("getHistoryForContent");
+	}
+}
+
+function assertNotBlogpost(type: string | undefined): void {
+	if (type === "blogpost") {
+		throw new ConfluenceV2Error(
+			"The v2 client does not support blog posts yet; only pages are supported",
+			400,
+			undefined,
+		);
+	}
+}
+
+function expandIncludes(
+	expand: Parameters.GetContent["expand"] | Parameters.GetContentById["expand"],
+	field: string,
+): boolean {
+	if (!expand) {
+		return false;
+	}
+	if (Array.isArray(expand)) {
+		return expand.includes(field);
+	}
+	return String(expand)
+		.split(",")
+		.map((part) => part.trim())
+		.includes(field);
+}

--- a/packages/lib/src/ConfluenceV2Client.ts
+++ b/packages/lib/src/ConfluenceV2Client.ts
@@ -16,6 +16,9 @@ import type {
  */
 const ATLAS_DOC_FORMAT = "atlas_doc_format";
 
+/** Maximum time to wait for each Confluence v2 API request. */
+const CONFLUENCE_V2_TIMEOUT_MS = 15_000;
+
 /**
  * Error thrown when a v2 request fails. Mirrors the shape that `confluence.js`
  * surfaces (a `message` plus a `response.data` payload) so that the publisher's
@@ -114,6 +117,7 @@ async function requestV2<T>(
 				Accept: "application/json",
 				...(body === undefined ? {} : { "Content-Type": "application/json" }),
 			},
+			signal: AbortSignal.timeout(CONFLUENCE_V2_TIMEOUT_MS),
 			...(body === undefined ? {} : { body: JSON.stringify(body) }),
 		});
 	} catch (error) {
@@ -296,6 +300,7 @@ export class ConfluenceV2Client {
 		callback?: never,
 	): Promise<T> {
 		void callback;
+		assertNotBlogpost(parameters.type);
 
 		const parentId = parameters.ancestors?.at(-1)?.id;
 		const requestBody: V2UpdatePageBody = {

--- a/packages/lib/src/ConfluenceV2Types.ts
+++ b/packages/lib/src/ConfluenceV2Types.ts
@@ -1,0 +1,109 @@
+/**
+ * Minimal type definitions for the Confluence Cloud REST API v2 responses and
+ * request bodies used by {@link ConfluenceV2Client}. These cover only the
+ * fields the publisher relies on; the full v2 schema is much larger.
+ *
+ * @see https://developer.atlassian.com/cloud/confluence/rest/v2/
+ */
+
+/** A v2 page version block. */
+export type V2Version = {
+	number: number;
+	authorId?: string;
+	message?: string;
+	createdAt?: string;
+};
+
+/** A v2 body representation block (e.g. `atlas_doc_format`). */
+export type V2BodyRepresentation = {
+	value?: string;
+	representation?: string;
+};
+
+/** The `body` block returned by v2 page endpoints. */
+export type V2PageBody = {
+	storage?: V2BodyRepresentation;
+	atlas_doc_format?: V2BodyRepresentation;
+	view?: V2BodyRepresentation;
+};
+
+/** A v2 page object (subset of fields). */
+export type V2Page = {
+	id: string;
+	status: string;
+	title: string;
+	spaceId: string;
+	parentId?: string | null;
+	parentType?: string | null;
+	authorId?: string;
+	ownerId?: string;
+	version?: V2Version;
+	body?: V2PageBody;
+};
+
+/** A v2 multi-entity result wrapper. */
+export type V2MultiEntityResult<T> = {
+	results: T[];
+	_links?: {
+		next?: string;
+		base?: string;
+	};
+};
+
+/** A v2 ancestor entry (minimal shape returned by the ancestors endpoint). */
+export type V2Ancestor = {
+	id: string;
+	type: string;
+};
+
+/** A v2 space object (subset of fields). */
+export type V2Space = {
+	id: string;
+	key: string;
+	name?: string;
+};
+
+/** Request body for `POST /wiki/api/v2/pages`. */
+export type V2CreatePageBody = {
+	spaceId: string;
+	status: string;
+	title: string;
+	parentId?: string;
+	body: {
+		representation: string;
+		value: string;
+	};
+};
+
+/** Request body for `PUT /wiki/api/v2/pages/{id}`. */
+export type V2UpdatePageBody = {
+	id: string;
+	status: string;
+	title: string;
+	parentId?: string;
+	body: {
+		representation: string;
+		value: string;
+	};
+	version: {
+		number: number;
+		message?: string;
+	};
+};
+
+/** A v2 attachment object (subset of fields). */
+export type V2Attachment = {
+	id: string;
+	title: string;
+	mediaType?: string;
+	comment?: string;
+	fileId?: string;
+	fileSize?: number;
+};
+
+/** A v2 label object (subset of fields). */
+export type V2Label = {
+	id: string;
+	name: string;
+	prefix?: string;
+};

--- a/packages/lib/src/ConniePageConfig.ts
+++ b/packages/lib/src/ConniePageConfig.ts
@@ -1,5 +1,5 @@
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 import { MarkdownFile } from "./MarkdownWorkspace";
 import { parseMarkdownToADF } from "./MdToADF";
 
@@ -143,7 +143,7 @@ export const conniePerPageConfig: ConfluencePerPageConfig = {
 					}
 				}
 
-				const newADF = parseMarkdownToADF(frontmatterHeader, settings.confluenceBaseUrl);
+				const newADF = parseMarkdownToADF(frontmatterHeader, resolveSiteUrl(settings));
 
 				adfContent.content = [...newADF.content, ...adfContent.content];
 			}

--- a/packages/lib/src/MarkdownWorkspace.test.ts
+++ b/packages/lib/src/MarkdownWorkspace.test.ts
@@ -136,9 +136,13 @@ test("updates markdown values for an absolute file path inside contentRoot", asy
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -248,9 +248,13 @@ const markdownTestCases: MarkdownFile[] = [
 test.each(markdownTestCases)("parses $fileName", (markdown: MarkdownFile) => {
 	const settings: ConfluenceSettings = {
 		confluenceBaseUrl: "https://example.com",
+		confluenceSiteUrl: "",
 		confluenceParentId: "asdf",
+		authMethod: "basic",
 		atlassianUserName: "asdf@asdf.com",
 		atlassianApiToken: "asdfasdf",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
 		folderToPublish: ".",
 		contentRoot: "./",
 		firstHeadingPageTitle: false,
@@ -279,9 +283,13 @@ test("parses callout with adjacent wikilink image", () => {
 	};
 	const settings: ConfluenceSettings = {
 		confluenceBaseUrl: "https://example.com",
+		confluenceSiteUrl: "",
 		confluenceParentId: "asdf",
+		authMethod: "basic",
 		atlassianUserName: "asdf@asdf.com",
 		atlassianApiToken: "asdfasdf",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
 		folderToPublish: ".",
 		contentRoot: "./",
 		firstHeadingPageTitle: false,
@@ -291,4 +299,70 @@ test("parses callout with adjacent wikilink image", () => {
 
 	expect(adfFile.contents.content?.[0]?.type).toBe("panel");
 	expect(JSON.stringify(adfFile.contents)).toContain("file://Pasted image 20231006155212.png");
+});
+
+test("matches bare Confluence links against confluenceSiteUrl, not the API gateway base", () => {
+	const pageLink =
+		"https://site.example.atlassian.net/wiki/spaces/TEAM/pages/12345/Some+Page+Title";
+	const markdown: MarkdownFile = {
+		folderName: "links",
+		absoluteFilePath: "/path/to/links.md",
+		fileName: "links.md",
+		contents: pageLink,
+		pageTitle: "Links",
+		frontmatter: {},
+	};
+	const settings: ConfluenceSettings = {
+		confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+		confluenceSiteUrl: "https://site.example.atlassian.net",
+		confluenceParentId: "asdf",
+		authMethod: "oauth2",
+		atlassianUserName: "",
+		atlassianApiToken: "",
+		atlassianClientId: "client-id",
+		atlassianClientSecret: "client-secret",
+		folderToPublish: ".",
+		contentRoot: "./",
+		firstHeadingPageTitle: false,
+	};
+
+	const adfFile = convertMDtoADF(markdown, settings);
+	const serialized = JSON.stringify(adfFile.contents);
+
+	expect(serialized).toContain('"type":"inlineCard"');
+	// The trailing slug is stripped because the host matches confluenceSiteUrl.
+	expect(serialized).toContain("https://site.example.atlassian.net/wiki/spaces/TEAM/pages/12345");
+	expect(serialized).not.toContain("Some+Page+Title");
+});
+
+test("falls back to confluenceBaseUrl for link matching when confluenceSiteUrl is empty", () => {
+	const pageLink =
+		"https://site.example.atlassian.net/wiki/spaces/TEAM/pages/12345/Some+Page+Title";
+	const markdown: MarkdownFile = {
+		folderName: "links",
+		absoluteFilePath: "/path/to/links-fallback.md",
+		fileName: "links-fallback.md",
+		contents: pageLink,
+		pageTitle: "Links Fallback",
+		frontmatter: {},
+	};
+	const settings: ConfluenceSettings = {
+		confluenceBaseUrl: "https://site.example.atlassian.net",
+		confluenceSiteUrl: "",
+		confluenceParentId: "asdf",
+		authMethod: "basic",
+		atlassianUserName: "user@example.com",
+		atlassianApiToken: "token",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
+		folderToPublish: ".",
+		contentRoot: "./",
+		firstHeadingPageTitle: false,
+	};
+
+	const adfFile = convertMDtoADF(markdown, settings);
+	const serialized = JSON.stringify(adfFile.contents);
+
+	expect(serialized).toContain('"type":"inlineCard"');
+	expect(serialized).not.toContain("Some+Page+Title");
 });

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -7,7 +7,7 @@ import { processConniePerPageConfig } from "./ConniePageConfig";
 import { p } from "@atlaskit/adf-utils/builders";
 import { MarkdownToConfluenceCodeBlockLanguageMap } from "./CodeBlockLanguageMap";
 import { isSafeUrl } from "@atlaskit/adf-schema";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 import { cleanUpUrlIfConfluence } from "./ConfluenceUrlParser";
 
 const frontmatterRegex = /^\s*?---\n([\s\S]*?)\n---\s*/g;
@@ -100,14 +100,14 @@ function countBacktickRun(line: string, position: number): number {
 	return count;
 }
 
-export function parseMarkdownToADF(markdown: string, confluenceBaseUrl: string) {
+export function parseMarkdownToADF(markdown: string, confluenceSiteUrl: string) {
 	const prosenodes = transformer.parse(stripMarkdownHtmlComments(markdown));
 	const adfNodes = serializer.encode(prosenodes);
-	const nodes = processADF(adfNodes, confluenceBaseUrl);
+	const nodes = processADF(adfNodes, confluenceSiteUrl);
 	return nodes;
 }
 
-function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
+function processADF(adf: JSONDocNode, confluenceSiteUrl: string): JSONDocNode {
 	const olivia = traverse(adf, {
 		text: (node, _parent) => {
 			if (_parent.parent?.node?.type == "listItem" && node.text) {
@@ -141,7 +141,7 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 			if (node.marks[0].attrs["href"] === node.text) {
 				const cleanedUrl = cleanUpUrlIfConfluence(
 					node.marks[0].attrs["href"],
-					confluenceBaseUrl,
+					confluenceSiteUrl,
 				);
 				node.type = "inlineCard";
 				node.attrs = { url: cleanedUrl };
@@ -223,7 +223,7 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 export function convertMDtoADF(file: MarkdownFile, settings: ConfluenceSettings): LocalAdfFile {
 	file.contents = file.contents.replace(frontmatterRegex, "");
 
-	const adfContent = parseMarkdownToADF(file.contents, settings.confluenceBaseUrl);
+	const adfContent = parseMarkdownToADF(file.contents, resolveSiteUrl(settings));
 
 	const results = processConniePerPageConfig(file, settings, adfContent);
 

--- a/packages/lib/src/OAuthToken.test.ts
+++ b/packages/lib/src/OAuthToken.test.ts
@@ -26,6 +26,7 @@ test("returns the access token on a successful response", async () => {
 	const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 	expect(url).toBe(ATLASSIAN_OAUTH_TOKEN_URL);
 	expect(init.method).toBe("POST");
+	expect(init.signal).toBeInstanceOf(AbortSignal);
 	const body = JSON.parse(String(init.body));
 	expect(body).toMatchObject({
 		grant_type: "client_credentials",

--- a/packages/lib/src/OAuthToken.test.ts
+++ b/packages/lib/src/OAuthToken.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, expect, test, vi } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+import { ATLASSIAN_OAUTH_TOKEN_URL, fetchOAuthAccessToken } from "./OAuthToken";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+test("returns the access token on a successful response", async () => {
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(JSON.stringify({ access_token: "token-123" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+	);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+	const token = await Effect.runPromise(fetchOAuthAccessToken("client-id", "client-secret"));
+
+	expect(token).toBe("token-123");
+	expect(fetchMock).toHaveBeenCalledTimes(1);
+	const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+	expect(url).toBe(ATLASSIAN_OAUTH_TOKEN_URL);
+	expect(init.method).toBe("POST");
+	const body = JSON.parse(String(init.body));
+	expect(body).toMatchObject({
+		grant_type: "client_credentials",
+		client_id: "client-id",
+		client_secret: "client-secret",
+		audience: "api.atlassian.com",
+	});
+});
+
+test("fails with a clear message on a non-2xx response", async () => {
+	globalThis.fetch = vi.fn(
+		async () => new Response("invalid_client", { status: 401, statusText: "Unauthorized" }),
+	) as unknown as typeof fetch;
+
+	const exit = await Effect.runPromiseExit(fetchOAuthAccessToken("client-id", "bad-secret"));
+
+	expect(Exit.isFailure(exit)).toBe(true);
+	const message = Exit.isFailure(exit) ? String(exit.cause) : "";
+	expect(message).toContain("401");
+	expect(message).toContain("invalid_client");
+});
+
+test("fails with a clear message on a network error", async () => {
+	globalThis.fetch = vi.fn(async () => {
+		throw new Error("connection refused");
+	}) as unknown as typeof fetch;
+
+	const exit = await Effect.runPromiseExit(fetchOAuthAccessToken("client-id", "client-secret"));
+
+	expect(Exit.isFailure(exit)).toBe(true);
+	const message = Exit.isFailure(exit) ? String(exit.cause) : "";
+	expect(message).toContain("Failed to reach the Atlassian OAuth token endpoint");
+	expect(message).toContain("connection refused");
+});
+
+test("fails when the response is missing an access token", async () => {
+	globalThis.fetch = vi.fn(
+		async () =>
+			new Response(JSON.stringify({ token_type: "Bearer" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+	) as unknown as typeof fetch;
+
+	const exit = await Effect.runPromiseExit(fetchOAuthAccessToken("client-id", "client-secret"));
+
+	expect(Exit.isFailure(exit)).toBe(true);
+	const message = Exit.isFailure(exit) ? String(exit.cause) : "";
+	expect(message).toContain("did not include an access_token");
+});

--- a/packages/lib/src/OAuthToken.ts
+++ b/packages/lib/src/OAuthToken.ts
@@ -1,0 +1,87 @@
+import { Effect } from "effect";
+
+/**
+ * Atlassian OAuth 2.0 token endpoint used for the client-credentials grant.
+ */
+export const ATLASSIAN_OAUTH_TOKEN_URL = "https://auth.atlassian.com/oauth/token";
+
+/**
+ * Audience required by Atlassian for service-account access tokens.
+ */
+export const ATLASSIAN_OAUTH_AUDIENCE = "api.atlassian.com";
+
+type OAuthTokenResponse = {
+	access_token?: unknown;
+};
+
+/**
+ * Exchanges an Atlassian service-account client ID and secret for a short-lived
+ * OAuth 2.0 bearer access token using the client-credentials grant.
+ *
+ * The returned token is suitable for the `confluence.js` client via
+ * `authentication: { oauth2: { accessToken } }`, which sends it as
+ * `Authorization: Bearer <token>`.
+ *
+ * Note: the token is short-lived. Callers that hold it for the duration of a
+ * long-running operation may need to re-fetch it if it expires; this function
+ * performs a single exchange and does not refresh.
+ */
+export function fetchOAuthAccessToken(
+	clientId: string,
+	clientSecret: string,
+): Effect.Effect<string, Error> {
+	return Effect.gen(function* () {
+		const response = yield* Effect.tryPromise({
+			try: () =>
+				fetch(ATLASSIAN_OAUTH_TOKEN_URL, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						grant_type: "client_credentials",
+						client_id: clientId,
+						client_secret: clientSecret,
+						audience: ATLASSIAN_OAUTH_AUDIENCE,
+					}),
+				}),
+			catch: (error) =>
+				new Error(
+					`Failed to reach the Atlassian OAuth token endpoint: ${getErrorMessage(error)}`,
+				),
+		});
+
+		if (!response.ok) {
+			const detail = yield* Effect.tryPromise({
+				try: () => response.text(),
+				catch: () => new Error(""),
+			}).pipe(Effect.orElseSucceed(() => ""));
+
+			return yield* Effect.fail(
+				new Error(
+					`Atlassian OAuth token request failed with status ${response.status} ${response.statusText}${
+						detail ? `: ${detail}` : ""
+					}`,
+				),
+			);
+		}
+
+		const payload = yield* Effect.tryPromise({
+			try: () => response.json() as Promise<OAuthTokenResponse>,
+			catch: (error) =>
+				new Error(
+					`Failed to parse the Atlassian OAuth token response: ${getErrorMessage(error)}`,
+				),
+		});
+
+		if (typeof payload.access_token !== "string" || payload.access_token.length === 0) {
+			return yield* Effect.fail(
+				new Error("Atlassian OAuth token response did not include an access_token"),
+			);
+		}
+
+		return payload.access_token;
+	});
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/lib/src/OAuthToken.ts
+++ b/packages/lib/src/OAuthToken.ts
@@ -10,6 +10,12 @@ export const ATLASSIAN_OAUTH_TOKEN_URL = "https://auth.atlassian.com/oauth/token
  */
 export const ATLASSIAN_OAUTH_AUDIENCE = "api.atlassian.com";
 
+/**
+ * Maximum time to wait for the Atlassian OAuth token endpoint before aborting,
+ * so a stalled network path can't hang CLI startup indefinitely.
+ */
+const ATLASSIAN_OAUTH_TIMEOUT_MS = 15_000;
+
 type OAuthTokenResponse = {
 	access_token?: unknown;
 };
@@ -36,6 +42,7 @@ export function fetchOAuthAccessToken(
 				fetch(ATLASSIAN_OAUTH_TOKEN_URL, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
+					signal: AbortSignal.timeout(ATLASSIAN_OAUTH_TIMEOUT_MS),
 					body: JSON.stringify({
 						grant_type: "client_credentials",
 						client_id: clientId,

--- a/packages/lib/src/PublisherErrors.test.ts
+++ b/packages/lib/src/PublisherErrors.test.ts
@@ -29,9 +29,13 @@ function createConfluenceClientWithoutParentSpace(): RequiredConfluenceClient {
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -1,10 +1,16 @@
 import { Context } from "effect";
 
+export type ConfluenceAuthMethod = "basic" | "oauth2";
+
 export type ConfluenceSettings = {
 	confluenceBaseUrl: string;
+	confluenceSiteUrl: string;
 	confluenceParentId: string;
+	authMethod: ConfluenceAuthMethod;
 	atlassianUserName: string;
 	atlassianApiToken: string;
+	atlassianClientId: string;
+	atlassianClientSecret: string;
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
@@ -12,13 +18,28 @@ export type ConfluenceSettings = {
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	confluenceBaseUrl: "",
+	confluenceSiteUrl: "",
 	confluenceParentId: "",
+	authMethod: "basic",
 	atlassianUserName: "",
 	atlassianApiToken: "",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
 };
+
+/**
+ * The human-facing Atlassian site URL used to build and match browser-facing
+ * links (e.g. https://your-site.atlassian.net). Falls back to
+ * `confluenceBaseUrl` when `confluenceSiteUrl` is unset, preserving existing
+ * behaviour for deployments that talk directly to the site rather than the
+ * API gateway (https://api.atlassian.com/ex/confluence/{cloudId}).
+ */
+export function resolveSiteUrl(settings: ConfluenceSettings): string {
+	return settings.confluenceSiteUrl || settings.confluenceBaseUrl;
+}
 
 export class ConfluenceSettingsService extends Context.Service<
 	ConfluenceSettingsService,

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -85,9 +85,13 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 
 	expect(settings).toEqual({
 		confluenceBaseUrl: "https://env.example.atlassian.net",
+		confluenceSiteUrl: "",
 		confluenceParentId: "cli-parent",
+		authMethod: "basic",
 		atlassianUserName: "env-user@example.com",
 		atlassianApiToken: "cli-token",
+		atlassianClientId: "",
+		atlassianClientSecret: "",
 		folderToPublish: "env-folder",
 		contentRoot: expectedCliContentRoot,
 		firstHeadingPageTitle: true,
@@ -168,6 +172,146 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 
 	expect(settings.firstHeadingPageTitle).toBe(false);
 	expect(settings.contentRoot).toBe(expectedContentRoot);
+});
+
+test("loads OAuth client-credentials settings and leaves basic credentials optional", async () => {
+	const settings = await runEffect(
+		parseConfluenceSettingsEffect(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+				confluenceSiteUrl: "https://site.example.atlassian.net",
+				confluenceParentId: "parent",
+				authMethod: "oauth2",
+				atlassianClientId: "client-id",
+				atlassianClientSecret: "client-secret",
+				folderToPublish: "docs",
+				contentRoot: "docs",
+				firstHeadingPageTitle: false,
+			}),
+		),
+	);
+
+	expect(settings.authMethod).toBe("oauth2");
+	expect(settings.atlassianClientId).toBe("client-id");
+	expect(settings.atlassianClientSecret).toBe("client-secret");
+	expect(settings.confluenceSiteUrl).toBe("https://site.example.atlassian.net");
+	expect(settings.atlassianUserName).toBe("");
+	expect(settings.atlassianApiToken).toBe("");
+});
+
+test("defaults authMethod to basic and confluenceSiteUrl to empty string", async () => {
+	const settings = await runEffect(
+		parseConfluenceSettingsEffect(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: "https://site.example.atlassian.net",
+				confluenceParentId: "parent",
+				atlassianUserName: "user@example.com",
+				atlassianApiToken: "token",
+				folderToPublish: "docs",
+				contentRoot: "docs",
+				firstHeadingPageTitle: false,
+			}),
+		),
+	);
+
+	expect(settings.authMethod).toBe("basic");
+	expect(settings.confluenceSiteUrl).toBe("");
+});
+
+test("fails when basic auth is missing the API token", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://site.example.atlassian.net",
+					confluenceParentId: "parent",
+					authMethod: "basic",
+					atlassianUserName: "user@example.com",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(/Atlassian API token is required when authMethod is basic/);
+});
+
+test("fails when oauth2 auth is missing the client secret", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+					confluenceParentId: "parent",
+					authMethod: "oauth2",
+					atlassianClientId: "client-id",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(/Atlassian client secret is required when authMethod is oauth2/);
+});
+
+test("requires confluenceSiteUrl when confluenceBaseUrl is the Atlassian API gateway", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+					confluenceParentId: "parent",
+					authMethod: "oauth2",
+					atlassianClientId: "client-id",
+					atlassianClientSecret: "client-secret",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(
+		/Confluence site URL is required when confluenceBaseUrl points at the Atlassian API gateway/,
+	);
+});
+
+test("accepts the Atlassian API gateway base URL when confluenceSiteUrl is provided", async () => {
+	const settings = await runEffect(
+		parseConfluenceSettingsEffect(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-id",
+				confluenceSiteUrl: "https://site.example.atlassian.net",
+				confluenceParentId: "parent",
+				authMethod: "oauth2",
+				atlassianClientId: "client-id",
+				atlassianClientSecret: "client-secret",
+				folderToPublish: "docs",
+				contentRoot: "docs",
+				firstHeadingPageTitle: false,
+			}),
+		),
+	);
+
+	expect(settings.confluenceSiteUrl).toBe("https://site.example.atlassian.net");
+});
+
+test("rejects an unsupported authMethod value", async () => {
+	await expect(
+		runEffect(
+			parseConfluenceSettingsEffect(
+				ConfigProvider.fromUnknown({
+					confluenceBaseUrl: "https://site.example.atlassian.net",
+					confluenceParentId: "parent",
+					authMethod: "saml",
+					atlassianUserName: "user@example.com",
+					atlassianApiToken: "token",
+					folderToPublish: "docs",
+					contentRoot: "docs",
+					firstHeadingPageTitle: false,
+				}),
+			),
+		),
+	).rejects.toThrow(/Unsupported authMethod "saml"/);
 });
 
 function makeRuntimeEnvironment({

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -7,7 +7,12 @@ import {
 	RuntimeEnvironment,
 	RuntimeEnvironmentService,
 } from "./effects";
-import { ConfluenceSettings, ConfluenceSettingsService, DEFAULT_SETTINGS } from "./Settings";
+import {
+	ConfluenceAuthMethod,
+	ConfluenceSettings,
+	ConfluenceSettingsService,
+	DEFAULT_SETTINGS,
+} from "./Settings";
 
 const CONFLUENCE_SETTINGS_KEYS = Object.keys(DEFAULT_SETTINGS) as (keyof ConfluenceSettings)[];
 
@@ -21,9 +26,23 @@ type ArgumentValue = boolean | string | undefined;
 
 export const confluenceSettingsConfig = Config.all({
 	confluenceBaseUrl: Config.string("confluenceBaseUrl"),
+	confluenceSiteUrl: Config.string("confluenceSiteUrl").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.confluenceSiteUrl),
+	),
 	confluenceParentId: Config.string("confluenceParentId"),
-	atlassianUserName: Config.string("atlassianUserName"),
-	atlassianApiToken: Config.string("atlassianApiToken"),
+	authMethod: Config.string("authMethod").pipe(Config.withDefault(DEFAULT_SETTINGS.authMethod)),
+	atlassianUserName: Config.string("atlassianUserName").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianUserName),
+	),
+	atlassianApiToken: Config.string("atlassianApiToken").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianApiToken),
+	),
+	atlassianClientId: Config.string("atlassianClientId").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianClientId),
+	),
+	atlassianClientSecret: Config.string("atlassianClientSecret").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.atlassianClientSecret),
+	),
 	folderToPublish: Config.string("folderToPublish"),
 	contentRoot: Config.string("contentRoot"),
 	firstHeadingPageTitle: Config.boolean("firstHeadingPageTitle"),
@@ -95,8 +114,12 @@ export function makeConfluenceSettingsConfigProvider(): Effect.Effect<
 	});
 }
 
+type ParsedConfluenceSettings = Omit<ConfluenceSettings, "authMethod"> & {
+	authMethod: string;
+};
+
 function validateConfluenceSettingsEffect(
-	settings: ConfluenceSettings,
+	settings: ParsedConfluenceSettings,
 ): Effect.Effect<ConfluenceSettings, Error, Path> {
 	return Effect.gen(function* () {
 		const path = yield* Path;
@@ -109,12 +132,40 @@ function validateConfluenceSettingsEffect(
 			return yield* Effect.fail(new Error("Confluence parent ID is required"));
 		}
 
-		if (!settings.atlassianUserName) {
-			return yield* Effect.fail(new Error("Atlassian user name is required"));
+		const authMethod = yield* validateAuthMethod(settings.authMethod);
+
+		if (authMethod === "oauth2") {
+			if (!settings.atlassianClientId) {
+				return yield* Effect.fail(
+					new Error("Atlassian client ID is required when authMethod is oauth2"),
+				);
+			}
+
+			if (!settings.atlassianClientSecret) {
+				return yield* Effect.fail(
+					new Error("Atlassian client secret is required when authMethod is oauth2"),
+				);
+			}
+		} else {
+			if (!settings.atlassianUserName) {
+				return yield* Effect.fail(
+					new Error("Atlassian user name is required when authMethod is basic"),
+				);
+			}
+
+			if (!settings.atlassianApiToken) {
+				return yield* Effect.fail(
+					new Error("Atlassian API token is required when authMethod is basic"),
+				);
+			}
 		}
 
-		if (!settings.atlassianApiToken) {
-			return yield* Effect.fail(new Error("Atlassian API token is required"));
+		if (isAtlassianApiGatewayUrl(settings.confluenceBaseUrl) && !settings.confluenceSiteUrl) {
+			return yield* Effect.fail(
+				new Error(
+					"Confluence site URL is required when confluenceBaseUrl points at the Atlassian API gateway",
+				),
+			);
 		}
 
 		if (!settings.folderToPublish) {
@@ -127,11 +178,37 @@ function validateConfluenceSettingsEffect(
 
 		return {
 			...settings,
+			authMethod,
 			contentRoot: settings.contentRoot.endsWith(path.sep)
 				? settings.contentRoot
 				: `${settings.contentRoot}${path.sep}`,
 		};
 	});
+}
+
+function validateAuthMethod(value: string): Effect.Effect<ConfluenceAuthMethod, Error> {
+	if (value === "basic" || value === "oauth2") {
+		return Effect.succeed(value);
+	}
+
+	return Effect.fail(
+		new Error(`Unsupported authMethod "${value}". Expected "basic" or "oauth2".`),
+	);
+}
+
+/**
+ * Detects the Atlassian API gateway base URL
+ * (https://api.atlassian.com/ex/confluence/{cloudId}). When the base URL points
+ * at the gateway, browser-facing links cannot be derived from it, so a separate
+ * `confluenceSiteUrl` must be supplied.
+ */
+function isAtlassianApiGatewayUrl(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return url.hostname === "api.atlassian.com" && url.pathname.startsWith("/ex/confluence/");
+	} catch {
+		return false;
+	}
 }
 
 function getConfigPath(
@@ -185,9 +262,13 @@ function makeEnvironmentProvider(
 		return ConfigProvider.fromEnv({
 			env: compactRecord({
 				confluenceBaseUrl: yield* runtimeEnvironment.getEnv("CONFLUENCE_BASE_URL"),
+				confluenceSiteUrl: yield* runtimeEnvironment.getEnv("CONFLUENCE_SITE_URL"),
 				confluenceParentId: yield* runtimeEnvironment.getEnv("CONFLUENCE_PARENT_ID"),
+				authMethod: yield* runtimeEnvironment.getEnv("CONFLUENCE_AUTH_METHOD"),
 				atlassianUserName: yield* runtimeEnvironment.getEnv("ATLASSIAN_USERNAME"),
 				atlassianApiToken: yield* runtimeEnvironment.getEnv("ATLASSIAN_API_TOKEN"),
+				atlassianClientId: yield* runtimeEnvironment.getEnv("ATLASSIAN_CLIENT_ID"),
+				atlassianClientSecret: yield* runtimeEnvironment.getEnv("ATLASSIAN_CLIENT_SECRET"),
 				folderToPublish: yield* runtimeEnvironment.getEnv("FOLDER_TO_PUBLISH"),
 				contentRoot: yield* runtimeEnvironment.getEnv("CONFLUENCE_CONTENT_ROOT"),
 				firstHeadingPageTitle:
@@ -200,9 +281,13 @@ function makeEnvironmentProvider(
 function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.ConfigProvider {
 	const options = parseArgumentValues(argv, [
 		{ name: "baseUrl", aliases: ["b"], type: "string" },
+		{ name: "siteUrl", type: "string" },
 		{ name: "parentId", aliases: ["p"], type: "string" },
+		{ name: "authMethod", type: "string" },
 		{ name: "userName", aliases: ["u"], type: "string" },
 		{ name: "apiToken", type: "string" },
+		{ name: "clientId", type: "string" },
+		{ name: "clientSecret", type: "string" },
 		{ name: "enableFolder", aliases: ["f"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
@@ -211,9 +296,13 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 	return ConfigProvider.fromUnknown(
 		compactRecord({
 			confluenceBaseUrl: options["baseUrl"],
+			confluenceSiteUrl: options["siteUrl"],
 			confluenceParentId: options["parentId"],
+			authMethod: options["authMethod"],
 			atlassianUserName: options["userName"],
 			atlassianApiToken: options["apiToken"],
+			atlassianClientId: options["clientId"],
+			atlassianClientSecret: options["clientSecret"],
 			folderToPublish: options["enableFolder"],
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],

--- a/packages/lib/src/TreeConfluence.test.ts
+++ b/packages/lib/src/TreeConfluence.test.ts
@@ -191,9 +191,13 @@ function createRootNode(
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/TreeConfluence.ts
+++ b/packages/lib/src/TreeConfluence.ts
@@ -182,7 +182,7 @@ function createFileStructureInConfluenceEffect(
 			{ concurrency: "unbounded" },
 		);
 
-		const pageUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${spaceKey}/pages/${file.pageId}/`;
+		const pageUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${file.spaceKey}/pages/${file.pageId}/`;
 		return {
 			file: { ...file, pageUrl },
 			version,

--- a/packages/lib/src/TreeConfluence.ts
+++ b/packages/lib/src/TreeConfluence.ts
@@ -14,7 +14,7 @@ import {
 	LocalAdfFile,
 	LocalAdfFileTreeNode,
 } from "./Publisher";
-import { ConfluenceSettings } from "./Settings";
+import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 
 const blankPageAdf: string = JSON.stringify(doc(p("Page not published yet")));
 
@@ -182,7 +182,7 @@ function createFileStructureInConfluenceEffect(
 			{ concurrency: "unbounded" },
 		);
 
-		const pageUrl = `${settings.confluenceBaseUrl}/wiki/spaces/${spaceKey}/pages/${file.pageId}/`;
+		const pageUrl = `${resolveSiteUrl(settings)}/wiki/spaces/${spaceKey}/pages/${file.pageId}/`;
 		return {
 			file: { ...file, pageUrl },
 			version,

--- a/packages/lib/src/TreeLocal.test.ts
+++ b/packages/lib/src/TreeLocal.test.ts
@@ -76,9 +76,13 @@ function createMarkdownFile(filesystemPath: Path, absoluteFilePath: string): Mar
 
 const testSettings: ConfluenceSettings = {
 	confluenceBaseUrl: "https://example.atlassian.net",
+	confluenceSiteUrl: "",
 	confluenceParentId: "123456",
+	authMethod: "basic",
 	atlassianUserName: "user@example.com",
 	atlassianApiToken: "token",
+	atlassianClientId: "",
+	atlassianClientSecret: "",
 	folderToPublish: ".",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -35,6 +35,11 @@ import {
 } from "./MarkdownWorkspace";
 import { convertMDtoADF, parseMarkdownToADF, stripMarkdownHtmlComments } from "./MdToADF";
 import {
+	ATLASSIAN_OAUTH_AUDIENCE,
+	ATLASSIAN_OAUTH_TOKEN_URL,
+	fetchOAuthAccessToken,
+} from "./OAuthToken";
+import {
 	Publisher,
 	type ConfluenceAdfFile,
 	type ConfluenceNode,
@@ -54,6 +59,8 @@ import {
 
 export {
 	AlwaysADFProcessingPlugins,
+	ATLASSIAN_OAUTH_AUDIENCE,
+	ATLASSIAN_OAUTH_TOKEN_URL,
 	ConfluencePageConfig,
 	ConfluenceSettingsLive,
 	ConfluenceUploadSettings,
@@ -70,6 +77,7 @@ export {
 	createPublisherFunctions,
 	executeADFProcessingPipeline,
 	executeADFProcessingPipelineEffect,
+	fetchOAuthAccessToken,
 	getMermaidFileName,
 	loadConfluenceSettings,
 	loadConfluenceSettingsEffect,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -34,6 +34,7 @@ import {
 	type MarkdownWorkspace,
 } from "./MarkdownWorkspace";
 import { convertMDtoADF, parseMarkdownToADF, stripMarkdownHtmlComments } from "./MdToADF";
+import { ConfluenceV2Client, ConfluenceV2Error } from "./ConfluenceV2Client";
 import {
 	ATLASSIAN_OAUTH_AUDIENCE,
 	ATLASSIAN_OAUTH_TOKEN_URL,
@@ -64,6 +65,8 @@ export {
 	ConfluencePageConfig,
 	ConfluenceSettingsLive,
 	ConfluenceUploadSettings,
+	ConfluenceV2Client,
+	ConfluenceV2Error,
 	MarkdownConfluencePlatformLive,
 	MarkdownConfluenceRuntime,
 	MarkdownWorkspaceLive,


### PR DESCRIPTION
Builds on #795

Implements a v2-backed content client in `packages/lib` for the Confluence content operations that fail under OAuth. Under OAuth 2.0 client credentials, the v1 `/wiki/rest/api/content` CRUD endpoints return `410 Gone`, while the v2 `/wiki/api/v2/pages` endpoints work.

This shim keeps `Publisher` and `TreeConfluence` unchanged by adapting v2 responses back to the v1-shaped objects the existing code expects.

## What changes

- Adds `ConfluenceV2Client` and minimal v2 response types.
- Routes these content methods through v2:
  - `getContent`
  - `getContentById`
  - `createContent`
  - `updateContent`
  - `getAttachments`
  - `getLabelsForContent`
- Keeps these on v1 because they still work under OAuth:
  - `users.getCurrentUser`
  - attachment upload (`createOrUpdateAttachments`)
  - label writes (`addLabelsToContent`, `removeLabelFromContentUsingQueryParameter`)
- Resolves and caches space key/id mappings per invocation.
- Maps v2 page responses to v1 content shape (`space.key`, `version.by.accountId`, `body.atlas_doc_format`, ancestors).
- Uses the immediate parent (`ancestors.at(-1)`) when passing `parentId` to v2, preserving nested page trees.
- Reconstructs attachment `collectionName` as `contentId-{pageId}`, matching the existing upload path.
- Parses SVG dimensions when `image-size` cannot, avoiding 0x0 media nodes for draw.io SVGs.

## Scope intentionally deferred

- Blog posts are not implemented yet; the adapter throws a clear error for `blogpost`.
- This is a shim until either this project or `confluence.js` has a fuller v2 client.

## Validation

- Unit tests cover v2 URL construction, response adaptation, space cache, error wrapping, unsupported methods, and SVG dimensions.
- Verified against a sandbox and two production spaces.
- Confirmed content updates, nested page structure, attachments, labels, and SVG media rendering.

---

## Temporary fork for OAuth users

If anyone needs to use OAuth 2.0 publishing before these changes land upstream, I am maintaining a temporary fork with the OAuth PR, this v2 content adapter, and force-publish support merged:

- Fork: <https://github.com/theherk/markdown-confluence>
- Branch: `main`
- Included branches/PRs:
  - `oauth2` (#795)
  - `v2-content-adapter` (this PR)
  - `force-publish-clean` (#831)

```mermaid
gitGraph
    commit id: "upstream/main"
    branch oauth2
    checkout oauth2
    commit id: "OAuth 2.0 auth"
    commit id: "OAuth review fixes"
    branch v2-content-adapter
    checkout v2-content-adapter
    commit id: "ConfluenceV2Client"
    commit id: "v2 wiring + fixes"
    checkout main
    branch force-publish-clean
    checkout force-publish-clean
    commit id: "forcePublish setting"
    checkout main
    merge oauth2
    merge v2-content-adapter
    merge force-publish-clean
```
