### PR TITLE
feat(lib): Add forcePublish setting for seeding runs

### DIFF
--- a/packages/lib/src/Publisher.ts
+++ b/packages/lib/src/Publisher.ts
@@ -232,9 +232,10 @@ export class Publisher {
 		const confluenceClient = this.confluenceClient;
 		const adfProcessingPlugins = this.adfProcessingPlugins;
 		const getMyAccountId = () => this.myAccountId;
+		const forcePublish = this.settings.forcePublish;
 
 		return Effect.gen(function* () {
-			if (lastUpdatedBy !== getMyAccountId()) {
+			if (!forcePublish && lastUpdatedBy !== getMyAccountId()) {
 				return yield* Effect.fail(
 					new Error(
 						`Page last updated by another user. Won't publish over their changes. MyAccountId: ${getMyAccountId()}, Last Updated By: ${lastUpdatedBy}`,

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -8,6 +8,7 @@ export type ConfluenceSettings = {
 	folderToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
+	forcePublish: boolean;
 };
 
 export const DEFAULT_SETTINGS: ConfluenceSettings = {
@@ -18,6 +19,7 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	folderToPublish: "Confluence Pages",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
+	forcePublish: false,
 };
 
 export class ConfluenceSettingsService extends Context.Service<

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -91,6 +91,7 @@ test("loads settings from Effect ConfigProviders with CLI, env, file, default pr
 		folderToPublish: "env-folder",
 		contentRoot: expectedCliContentRoot,
 		firstHeadingPageTitle: true,
+		forcePublish: false,
 	});
 });
 

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -27,6 +27,9 @@ export const confluenceSettingsConfig = Config.all({
 	folderToPublish: Config.string("folderToPublish"),
 	contentRoot: Config.string("contentRoot"),
 	firstHeadingPageTitle: Config.boolean("firstHeadingPageTitle"),
+	forcePublish: Config.boolean("forcePublish").pipe(
+		Config.withDefault(DEFAULT_SETTINGS.forcePublish),
+	),
 });
 
 export const ConfluenceSettingsLive: Layer.Layer<
@@ -181,6 +184,7 @@ function makeEnvironmentProvider(
 		const firstHeadingPageTitle = yield* runtimeEnvironment.getEnv(
 			"CONFLUENCE_FIRST_HEADING_PAGE_TITLE",
 		);
+		const forcePublish = yield* runtimeEnvironment.getEnv("CONFLUENCE_FORCE_PUBLISH");
 
 		return ConfigProvider.fromEnv({
 			env: compactRecord({
@@ -192,6 +196,7 @@ function makeEnvironmentProvider(
 				contentRoot: yield* runtimeEnvironment.getEnv("CONFLUENCE_CONTENT_ROOT"),
 				firstHeadingPageTitle:
 					firstHeadingPageTitle === "true" ? firstHeadingPageTitle : undefined,
+				forcePublish: forcePublish === "true" ? forcePublish : undefined,
 			}),
 		});
 	});
@@ -206,6 +211,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "enableFolder", aliases: ["f"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
+		{ name: "forcePublish", type: "boolean" },
 	]);
 
 	return ConfigProvider.fromUnknown(
@@ -217,6 +223,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			folderToPublish: options["enableFolder"],
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],
+			forcePublish: options["forcePublish"],
 		}),
 	);
 }


### PR DESCRIPTION
Adds a `forcePublish` setting that bypasses the "page last updated by another user" guard.

This is useful when migrating publishing from one account to another (for example Basic auth bot -> OAuth service account). The first run with the new account otherwise fails for every existing page because the new account is not the last editor yet.

## What changes

- Adds `forcePublish` to `ConfluenceSettings` (`false` by default).
- Adds config support:
  - JSON: `forcePublish`
  - env: `CONFLUENCE_FORCE_PUBLISH=true`
  - CLI: `--forcePublish`
- Skips the last-editor check only when `forcePublish` is true.

## Intended usage

Use this for controlled, one-off seeding or migration runs. Leave it disabled for normal publishing so the existing safety guard continues protecting manually edited pages.

Example:

```bash
CONFLUENCE_FORCE_PUBLISH=true markdown-confluence
```

## Validation

- Verified in production migration workflows where a new OAuth service account needed to seed itself as the last editor.
- Default behavior is unchanged (`forcePublish: false`).

---

## Temporary fork for OAuth users

If anyone needs to use OAuth 2.0 publishing before these changes land upstream, I am maintaining a temporary fork with the OAuth PR, v2 content adapter, and this force-publish support merged:

- Fork: <https://github.com/theherk/markdown-confluence>
- Branch: `main`
- Included branches/PRs:
  - `oauth2` (#795)
  - `v2-content-adapter` (#830)
  - `force-publish-clean` (this PR)

```mermaid
gitGraph
    commit id: "upstream/main"
    branch oauth2
    checkout oauth2
    commit id: "OAuth 2.0 auth"
    commit id: "OAuth review fixes"
    branch v2-content-adapter
    checkout v2-content-adapter
    commit id: "ConfluenceV2Client"
    commit id: "v2 wiring + fixes"
    checkout main
    branch force-publish-clean
    checkout force-publish-clean
    commit id: "forcePublish setting"
    checkout main
    merge oauth2
    merge v2-content-adapter
    merge force-publish-clean
```
