### PR TITLE
Add macro ID uniqueness

### DIFF
--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -313,6 +313,39 @@ test("converts toc code fences and wiki markup to Confluence TOC macros", () => 
 	expect(JSON.stringify(wikiTocMacro)).toContain('"maxLevel":{"value":"3"}');
 });
 
+test("assigns distinct IDs to identical macros parsed in separate page fragments", () => {
+	type MacroAttributes = {
+		localId?: string;
+		parameters?: {
+			macroMetadata?: {
+				macroId?: { value?: string };
+			};
+		};
+	};
+
+	const markdown: MarkdownFile = {
+		folderName: "macros",
+		absoluteFilePath: "/path/to/duplicate-macro-ids.md",
+		fileName: "duplicate-macro-ids.md",
+		contents: ["```toc", "```"].join("\n"),
+		pageTitle: "Duplicate macro IDs",
+		frontmatter: {},
+	};
+
+	const adfFile = convertMDtoADF(
+		markdown,
+		createTestSettings({ pageHeaderMarkdown: ["```toc", "```"].join("\n") }),
+	);
+	const [headerMacro, bodyMacro] = adfFile.contents.content ?? [];
+	const headerMacroAttributes = headerMacro?.content?.[0]?.attrs as MacroAttributes | undefined;
+	const bodyMacroAttributes = bodyMacro?.content?.[0]?.attrs as MacroAttributes | undefined;
+
+	expect(headerMacroAttributes?.localId).not.toBe(bodyMacroAttributes?.localId);
+	expect(headerMacroAttributes?.parameters?.macroMetadata?.macroId?.value).not.toBe(
+		bodyMacroAttributes?.parameters?.macroMetadata?.macroId?.value,
+	);
+});
+
 test("adds configured page header and footer while ignoring configured code blocks", () => {
 	const markdown: MarkdownFile = {
 		folderName: "transforms",

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -16,6 +16,8 @@ const frontmatterRegex = /^\s*?---\n([\s\S]*?)\n---\s*/g;
 const transformer = new MarkdownTransformer();
 const serializer = new JSONTransformer();
 
+type PageFragment = "header" | "body" | "footer";
+
 export function stripMarkdownHtmlComments(markdown: string): string {
 	const lines = markdown.split("\n");
 	const strippedLines: string[] = [];
@@ -102,10 +104,18 @@ function countBacktickRun(line: string, position: number): number {
 }
 
 export function parseMarkdownToADF(markdown: string, confluenceBaseUrl: string) {
+	return parsePageFragmentToADF(markdown, confluenceBaseUrl, "body");
+}
+
+function parsePageFragmentToADF(
+	markdown: string,
+	confluenceBaseUrl: string,
+	pageFragment: PageFragment,
+) {
 	const prosenodes = transformer.parse(stripMarkdownHtmlComments(markdown));
 	const adfNodes = serializer.encode(prosenodes);
 	const nodes = processADF(adfNodes, confluenceBaseUrl);
-	return replaceSupportedMacroPlaceholders(nodes);
+	return replaceSupportedMacroPlaceholders(nodes, pageFragment);
 }
 
 function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
@@ -245,7 +255,10 @@ type ADFNode = {
 	marks?: unknown[];
 };
 
-function replaceSupportedMacroPlaceholders(adf: JSONDocNode): JSONDocNode {
+function replaceSupportedMacroPlaceholders(
+	adf: JSONDocNode,
+	pageFragment: PageFragment,
+): JSONDocNode {
 	if (!adf.content) {
 		return adf;
 	}
@@ -258,6 +271,7 @@ function replaceSupportedMacroPlaceholders(adf: JSONDocNode): JSONDocNode {
 				"Table of Contents",
 				{},
 				macroIndex,
+				pageFragment,
 			);
 			macroIndex++;
 			return macroNode;
@@ -270,6 +284,7 @@ function replaceSupportedMacroPlaceholders(adf: JSONDocNode): JSONDocNode {
 				"Table of Contents",
 				tocParameters,
 				macroIndex,
+				pageFragment,
 			);
 			macroIndex++;
 			return macroNode;
@@ -337,8 +352,9 @@ function createConfluenceMacroParagraph(
 	title: string,
 	parameters: Record<string, string>,
 	index: number,
+	pageFragment: PageFragment, // required to generate unique macro IDs
 ): ADFNode {
-	const seed = `${extensionKey}:${JSON.stringify(parameters)}:${index}`;
+	const seed = `${pageFragment}:${extensionKey}:${JSON.stringify(parameters)}:${index}`;
 	const macroId = SparkMD5.hash(seed);
 
 	return {
@@ -400,10 +416,12 @@ function addConfiguredPageChrome(adfContent: JSONDocNode, settings: ConfluenceSe
 	const headerContent = parseConfiguredPageChromeMarkdown(
 		settings.pageHeaderMarkdown,
 		settings.confluenceBaseUrl,
+		"header",
 	);
 	const footerContent = parseConfiguredPageChromeMarkdown(
 		settings.pageFooterMarkdown,
 		settings.confluenceBaseUrl,
+		"footer",
 	);
 
 	if (headerContent.length === 0 && footerContent.length === 0) {
@@ -416,12 +434,14 @@ function addConfiguredPageChrome(adfContent: JSONDocNode, settings: ConfluenceSe
 function parseConfiguredPageChromeMarkdown(
 	markdown: string | undefined,
 	confluenceBaseUrl: string,
+	pageFragment: PageFragment,
 ): ADFNode[] {
 	if (!markdown?.trim()) {
 		return [];
 	}
 
-	return (parseMarkdownToADF(markdown, confluenceBaseUrl).content ?? []) as ADFNode[];
+	return (parsePageFragmentToADF(markdown, confluenceBaseUrl, pageFragment).content ??
+		[]) as ADFNode[];
 }
 
 function getCodeBlockText(node: ADFNode): string {


### PR DESCRIPTION
Hi! #764 would be super useful for me. I'm hoping this addition will help the header feature get merged soon.

(This is my first open source PR btw)

I was looking over #764 and noticed if the header and body contain a `toc` macro, they will share the same ID. Unsure if that's actually an issue, but figured @andymac4182 you would know. 