### PR TITLE
test: make integration checks repeatable across packages and Obsidian

### DIFF
--- a/.env.integration.example
+++ b/.env.integration.example
@@ -1,0 +1,14 @@
+# Copy to .env.integration. This is the dedicated test space from release testing.
+CONFLUENCE_E2E_BASE_URL=https://markdown-confluence.atlassian.net
+CONFLUENCE_E2E_PARENT_ID=986448062
+CONFLUENCE_E2E_SPACE_KEY=MCRT20260907
+
+# Either supply credentials here (keep this local file private), or point to an
+# existing dedicated test vault's plugin settings. Never commit real credentials.
+# ATLASSIAN_USERNAME=you@example.com
+# ATLASSIAN_API_TOKEN=
+# CONFLUENCE_E2E_SETTINGS_FILE=../your-test-vault/.obsidian/plugins/confluence-integration/data.json
+
+# Optional desktop profile settings. The CLI must be enabled in Obsidian.
+# CONFLUENCE_E2E_VAULT=../markdown-confluence-integration-vault
+# OBSIDIAN_CLI=/Applications/Obsidian.app/Contents/MacOS/Obsidian

--- a/.github/workflows/confluence-e2e.yml
+++ b/.github/workflows/confluence-e2e.yml
@@ -33,13 +33,18 @@ jobs:
           run-install: false
       - name: Install dependencies
         run: vp install --frozen-lockfile
-      - name: Build the release artifacts
-        run: vp run build
       - name: Publish synthetic fixtures and verify create, unchanged and update behavior
-        run: vp run test:confluence-e2e
+        run: vp run test:integration live
         env:
           ATLASSIAN_USERNAME: ${{ secrets.ATLASSIAN_USERNAME }}
           ATLASSIAN_API_TOKEN: ${{ secrets.ATLASSIAN_API_TOKEN }}
           CONFLUENCE_E2E_BASE_URL: https://markdown-confluence.atlassian.net
           CONFLUENCE_E2E_PARENT_ID: "986448062"
           CONFLUENCE_E2E_SPACE_KEY: MCRT20260907
+      - name: Upload integration reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-confluence
+          path: reports/integration/
+          if-no-files-found: ignore

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -20,6 +20,7 @@ jobs:
       tests_status: ${{ steps.tests.outcome }}
       build_status: ${{ steps.build.outcome }}
       builddocker_status: ${{ steps.builddocker.outcome }}
+      integration_status: ${{ steps.integration.outcome }}
 
     steps:
     - name: Harden Runner
@@ -70,6 +71,20 @@ jobs:
       continue-on-error: true
       run: vp run -r build:docker
 
+    - name: Verify isolated npm packages and real diagram rendering
+      id: integration
+      if: steps.build.outcome == 'success'
+      continue-on-error: true
+      run: vp run test:integration packages --skip-build
+
+    - name: Upload integration reports
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: integration-linux
+        path: reports/integration/
+        if-no-files-found: ignore
+
     - name: Report Errors
       if: ${{ always() }}
       run: |
@@ -78,11 +93,13 @@ jobs:
         echo "Tests status: ${{ steps.tests.outcome }}"
         echo "Build status: ${{ steps.build.outcome }}"
         echo "Build Docker status: ${{ steps.builddocker.outcome }}"
+        echo "Integration status: ${{ steps.integration.outcome }}"
         if [[ ${{ steps.eslint.outcome }} == 'failure' ]] \
         || [[ ${{ steps.prettier.outcome }} == 'failure' ]] \
         || [[ ${{ steps.tests.outcome }} == 'failure' ]] \
         || [[ ${{ steps.build.outcome }} == 'failure' ]] \
         || [[ ${{ steps.builddocker.outcome }} == 'failure' ]] \
+        || [[ ${{ steps.integration.outcome }} == 'failure' ]] \
         ; then
           exit 1
         fi
@@ -111,3 +128,14 @@ jobs:
         ATLASSIAN_USERNAME: ${{ secrets.ATLASSIAN_USERNAME }}
         ATLASSIAN_API_TOKEN: ${{ secrets.ATLASSIAN_API_TOKEN }}
         CONFLUENCE_PARENT_ID: "IGNORE ME"
+
+    - name: Verify built CLI and real Chromium rendering on Windows
+      run: vp run test:integration
+
+    - name: Upload integration reports
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: integration-windows
+        path: reports/integration/
+        if-no-files-found: ignore

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,6 +98,15 @@ jobs:
           vp test run
           vp run build
           vp run release:prepare
+      - name: Verify the npm tarballs before publication
+        run: vp run test:integration packages --skip-build
+      - name: Upload package verification report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-release-packages
+          path: reports/integration/
+          if-no-files-found: ignore
       - name: Publish npm packages
         run: vp pm publish -r --filter '@markdown-confluence/*' --access public --no-git-checks
       - name: Log in to the container registry

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ data.json
 .DS_Store
 
 dist/
+.env.integration
+.release-repo/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ For detailed installation and usage instructions, please visit our [documentatio
 ## Contributing
 Contributions are welcome! If you have a feature request, bug report, or want to improve the plugin, please open an issue or submit a pull request on the GitHub repository.
 
+Run `vp run test:integration` for a build and integration smoke test. The [testing guide](documentation/TESTING.md) covers isolated npm consumers, live Confluence, Docker, and the dedicated Obsidian test vault.
+
 ## License
 This project is licensed under the [Apache 2.0](https://github.com/markdown-confluence/markdown-confluence/blob/main/LICENSE) License.
 

--- a/documentation/TESTING.md
+++ b/documentation/TESTING.md
@@ -1,0 +1,137 @@
+# Integration testing
+
+Use Node **24.15.0** and Vite+ (`vp`), with the repository's pinned pnpm version.
+Install dependencies once with `vp install --frozen-lockfile`.
+
+## Fast development loop
+
+```sh
+vp run test:integration
+```
+
+This builds all packages, validates the Obsidian release artifacts, imports the
+built packages, renders a real Mermaid PNG in Chromium, and converts all ten
+Markdown fixtures through the CLI. CLI output must match the library's ADF,
+including Unicode and TOC macros. It also checks CommonJS dynamic import and a
+nonzero CLI error exit. It does not publish anything or require Confluence credentials.
+
+After a build, or while using the existing watch commands, reuse the artifacts:
+
+```sh
+vp run test:integration --skip-build
+```
+
+`--skip-build` deliberately trusts `dist`; it does not detect stale builds. The
+default always builds first. Unit tests and static checks remain separate:
+`vp test run`, `vp run check`, and `vp run fmt:check`.
+
+## Choose the scope
+
+| Command | What it exercises | Requirements |
+| --- | --- | --- |
+| `vp run test:integration` | Built library, CLI, real Chromium/Mermaid, artifact validation | Installed workspace dependencies |
+| `vp run test:integration:packages` | All five actual npm tarballs installed in a fresh consumer, then the same runtime checks | npm registry access; pnpm/browser caches are reused |
+| `vp run test:integration:live` | Live Confluence publish, unchanged republish, one-note update, built CLI, error recovery | Dedicated space and test credentials |
+| `vp run test:integration:docker` | Local image build, container CLI conversion, unconfigured-publishing failure exit | Running Docker engine |
+| `vp run test:vault` | Create a synthetic Obsidian vault or refresh only its built plugin | Desktop Obsidian for opening the result |
+| `vp run test:integration:obsidian` | Installed desktop plugin, Electron Mermaid, live publish, unchanged/update verification through the API | Prepared/open test vault, enabled plugin and Obsidian CLI |
+
+All profiles accept `--skip-build`. Run `vp run test:integration --help` for options.
+Successful and failed runs write timed `summary.json` and `summary.md` reports to
+`reports/integration/<profile>-<timestamp>/`. Live checks also record test page IDs.
+Reports contain no credentials. Temporary npm consumers are automatically removed,
+including after failure. No command publishes npm packages, tags, images, or releases.
+
+The package profile overrides **every internal package**, including transitive
+dependencies, to the local tarballs. This prevents an already published version
+from masking a broken candidate. It installs only in a temporary directory, keeping
+the repository lockfile unchanged. PlantUML uses a deterministic test transport in
+the fast/package profiles; the live and desktop profiles use the real server.
+
+## Configure live testing once
+
+Copy `.env.integration.example` to `.env.integration` (Git ignores the latter).
+Set an HTTPS origin, a parent page ID, and the expected space key. The example
+already names the dedicated `MCRT20260907` space used for release verification.
+The harness reads the parent's space before any publishing and refuses a mismatch.
+
+Provide `ATLASSIAN_USERNAME` and `ATLASSIAN_API_TOKEN` through the environment or
+the private local file. Alternatively set `CONFLUENCE_E2E_SETTINGS_FILE` to the
+`data.json` in a **dedicated test vault**. This reuses its credentials without
+copying the token into the repository or passing it as a command argument.
+Environment values take precedence over settings-file values.
+
+```sh
+vp run test:integration live --skip-build
+```
+
+The live harness copies synthetic fixtures into a temporary directory and prefixes
+page titles per run. It verifies formatting, heading embeds, exclusions, folder
+hierarchy, tags, images, files, Mermaid and PlantUML attachments. Repeated publishing
+must preserve page versions, content, attachments and labels. It then verifies a
+single-note update, built-CLI republishing, duplicate-title and missing-embed
+rejection, recovery after an injected upload failure, and a real HTTP 409 conflict.
+
+Local fixture copies are removed automatically. Remote test pages are deliberately
+retained for inspection; their links are in the report. Runs add pages to the
+dedicated space, so clear old test batches through Confluence when appropriate.
+
+## Obsidian: setup once, then one command
+
+```sh
+vp run test:vault
+```
+
+The default vault is `../markdown-confluence-integration-vault`; override it with
+`--vault PATH` or `CONFLUENCE_E2E_VAULT`. Open that directory as a vault in Obsidian,
+enable Confluence Integration, and enable **Settings → General → Command line
+interface**. Use the current [official Obsidian CLI](https://obsidian.md/help/cli)
+with a supported desktop installer. Set `OBSIDIAN_CLI` if its executable is not in PATH.
+
+The setup command creates a marker identifying a disposable integration vault.
+It refuses to modify an existing unmarked directory. Subsequent runs refresh
+`main.js` and `manifest.json` while preserving notes, published IDs and settings.
+New settings files receive restrictive file permissions. Existing credentials and
+settings are never replaced by a refresh; edit them in Obsidian if needed.
+
+```sh
+vp run test:integration obsidian --skip-build
+```
+
+The desktop check targets the named vault, verifies its full path, reloads the
+installed plugin, checks its destination, and awaits its real publishing method.
+It verifies remote content, attachment versions, labels, hierarchy and selection;
+publishes twice to check idempotency; updates one note; and restores the fixture.
+It uses Obsidian's vault API for edits so the application's file events participate.
+The desktop app must remain running. CLI failures, a disabled plugin, wrong vault,
+or wrong destination fail the check rather than reporting a skipped success.
+
+This checks the plugin runtime and upload adapter. Visual layout, command-palette
+interaction, notices/modal appearance, live OAuth credentials and a second-editor
+permission boundary still need separate checks. The Docker profile is a local
+container smoke test; it does not verify published multi-architecture images or
+the companion GitHub Action release.
+
+## GitHub Actions
+
+Pull requests run package integration on Linux and the built CLI/Chromium check
+on Windows. Both reuse the existing workflows and upload reports even on failure.
+Release publication tests the packed npm artifacts before publishing them.
+
+For live Confluence testing, add `run-confluence-e2e` to an internal PR, or run
+**Confluence End-to-End Verification → Run workflow**. The workflow uses the same
+`vp run test:integration live` command and repository secrets, serializes live runs,
+and uploads reports. Fork pull requests cannot automatically run credentialed tests.
+
+To add coverage for a feature, add a synthetic note to `test-fixtures/release-vault`
+and a concrete assertion in `scripts/confluence-release-e2e.js`. Simple conversion
+fixtures automatically enter the CLI parity check. Use unit tests for edge cases;
+keep live assertions focused on behavior that depends on Confluence or Obsidian.
+
+### Diagnosing a live failure
+
+The post-conflict idempotency assertion failed once during local validation, then
+passed on two fresh runs. It remains strict: a failure logs the synthetic stored
+and requested ADF for diagnosis, rather than retrying an extra publish to hide an
+unexpected version update. Treat this as an observed intermittent behavior, not
+a resolved product defect. CI reports identify the failed step.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,13 @@
 		"mutation:dry-run": "stryker run --dryRunOnly",
 		"test": "vp test run",
 		"release:prepare": "node scripts/prepare-release-assets.js",
-		"test:confluence-e2e": "node scripts/confluence-release-e2e.js"
+		"test:confluence-e2e": "node scripts/confluence-release-e2e.js",
+		"test:integration": "node --env-file-if-exists=.env.integration scripts/integration-tests.js",
+		"test:integration:packages": "vp run test:integration packages",
+		"test:integration:live": "vp run test:integration live",
+		"test:integration:docker": "vp run test:integration docker",
+		"test:integration:obsidian": "vp run test:integration obsidian",
+		"test:vault": "vp run test:integration vault"
 	},
 	"devDependencies": {
 		"@effect-oxlint/effect-oxlint": "jsr:^0.2.0",

--- a/scripts/check-descriptive-names.js
+++ b/scripts/check-descriptive-names.js
@@ -8,11 +8,13 @@ import { fileURLToPath } from "node:url";
 
 const skippedDirectoryNames = new Set([
 	".git",
+	".release-repo",
 	".husky",
 	"coverage",
 	"dev-vault",
 	"dist",
 	"node_modules",
+	"reports",
 ]);
 const blockedTerms = new Set([
 	"util",

--- a/scripts/confluence-release-e2e.js
+++ b/scripts/confluence-release-e2e.js
@@ -220,6 +220,9 @@ const program = Effect.scoped(
 		assert.ok(localFormatting.includes(formatting.pageId));
 
 		requestedBodies.clear();
+		yield* Console.log(
+			"[confluence] Verify unchanged content, attachments, labels and versions",
+		);
 		const second = yield* publish();
 		for (const result of second) {
 			if (result.successfulUploadResult.contentResult !== "same") {
@@ -387,7 +390,22 @@ const program = Effect.scoped(
 		assert.ok(
 			conflictPage.body.atlas_doc_format.value.includes("RECOVERED AFTER VERSION CONFLICT."),
 		);
+		let finalRequestedBody;
+		client.content.updateContent = async (parameters) => {
+			finalRequestedBody = parameters.body?.atlas_doc_format?.value;
+			return updateContent(parameters);
+		};
 		const finalPublish = yield* Effect.tryPromise(publishFormatting);
+		if (finalPublish[0].successfulUploadResult?.contentResult !== "same") {
+			yield* Console.log(
+				JSON.stringify({
+					check: "unchanged-after-conflict",
+					storedBody: conflictPage.body.atlas_doc_format.value,
+					requestedBody: finalRequestedBody,
+				}),
+			);
+		}
+		client.content.updateContent = updateContent;
 		assert.equal(finalPublish[0].successfulUploadResult?.contentResult, "same");
 		assert.equal(
 			(yield* fetchPage(formatting.pageId)).version.number,
@@ -398,7 +416,39 @@ const program = Effect.scoped(
 			.join("\n");
 		const summary = `## Confluence release verification passed\n\nCreated/verified ${first.length} pages; unchanged publishing preserved content, attachments, labels and versions; one changed note updated successfully; the built CLI republished without further changes. Duplicate titles and missing embed headings were rejected without page updates. The same publisher recovered from an injected transport failure and a real HTTP version conflict, then preserved the unchanged page version.\n\n${pageLinks}\n`;
 		const summaryPath = yield* runtime.getEnv("GITHUB_STEP_SUMMARY");
-		if (summaryPath) yield* fs.writeFileString(summaryPath, summary);
+		if (summaryPath) yield* fs.writeFileString(summaryPath, summary, { flag: "a" });
+		const reportPath = yield* runtime.getEnv("CONFLUENCE_E2E_REPORT_PATH");
+		if (reportPath)
+			yield* fs.writeFileString(
+				reportPath,
+				JSON.stringify(
+					{
+						status: "passed",
+						checks: [
+							"create",
+							"formatting",
+							"embeds",
+							"hierarchy",
+							"selection",
+							"attachments",
+							"unchanged",
+							"update",
+							"built-cli",
+							"duplicate-title",
+							"missing-embed",
+							"transport-recovery",
+							"version-conflict",
+						],
+						pages: first.map((result) => ({
+							id: result.node.file.pageId,
+							title: result.node.file.pageTitle,
+							url: result.node.file.pageUrl,
+						})),
+					},
+					null,
+					2,
+				),
+			);
 		yield* Console.log(summary);
 	}),
 );

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { Effect } from "effect";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import { RuntimeEnvironmentService } from "../packages/lib/src/effects/index.ts";
+import { vaultMarker } from "./integration-vault.js";
+
+const publishedNotes = [
+	"Release Tests/Release Tests.md",
+	"Release Tests/Formatting.md",
+	"Release Tests/Media.md",
+	"Release Tests/Embeds.md",
+	"Release Tests/Hierarchy/README.md",
+	"Release Tests/Hierarchy/Child.md",
+	"Tagged/Tag selection.md",
+];
+
+export function parseObsidianOutput(output) {
+	const line = output.split("\n").find((entry) => entry.startsWith("=> "));
+	assert.ok(
+		line,
+		"Obsidian CLI did not return a result. Enable Settings > General > Command line interface and open the test vault.",
+	);
+	return JSON.parse(line.slice(3));
+}
+
+/** Test the installed plugin in the real Electron/Obsidian runtime, without a UI mock. */
+export function runObsidianIntegration({ vaultPath, environment, reportDirectory }) {
+	return Effect.gen(function* () {
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		const runtime = yield* RuntimeEnvironmentService;
+		const marker = JSON.parse(yield* fs.readFileString(path.join(vaultPath, vaultMarker)));
+		assert.equal(marker.kind, "markdown-confluence-integration", "Run test:vault first");
+		const executable = (yield* runtime.getEnv("OBSIDIAN_CLI")) || "obsidian";
+		const desktopCommand = (args) =>
+			Effect.tryPromise(
+				() =>
+					new Promise((resolve, reject) => {
+						execFile(
+							executable,
+							args,
+							{ cwd: vaultPath, timeout: 180000, maxBuffer: 1024 * 1024 },
+							(error, stdout) => {
+								if (error)
+									reject(
+										new Error(
+											`Obsidian CLI failed (${error.code ?? "launch error"})`,
+										),
+									);
+								else resolve(stdout);
+							},
+						);
+					}),
+			);
+		const baseUrl = environment.CONFLUENCE_E2E_BASE_URL;
+		const parentId = environment.CONFLUENCE_E2E_PARENT_ID;
+		const authorization = `Basic ${Buffer.from(`${environment.ATLASSIAN_USERNAME}:${environment.ATLASSIAN_API_TOKEN}`).toString("base64")}`;
+		const get = (suffix) =>
+			Effect.tryPromise(async () => {
+				const response = await fetch(`${baseUrl}/wiki/rest/api/${suffix}`, {
+					headers: { Authorization: authorization, Accept: "application/json" },
+					redirect: "error",
+					signal: AbortSignal.timeout(30000),
+				});
+				if (!response.ok)
+					throw new Error(
+						`Confluence verification request failed: HTTP ${response.status}`,
+					);
+				return response.json();
+			});
+		const parent = yield* get(`content/${parentId}?expand=space`);
+		assert.equal(
+			parent.space?.key,
+			environment.CONFLUENCE_E2E_SPACE_KEY,
+			"Refusing to publish outside the dedicated space",
+		);
+		const evaluate = (body) =>
+			Effect.gen(function* () {
+				// The prefix checks the vault path on every operation, including read-only probes.
+				const code = `(async () => { if(app.vault.adapter.getBasePath() !== ${JSON.stringify(vaultPath)}) throw Error('Wrong test vault'); ${body} })()`;
+				const output = yield* desktopCommand([
+					`vault=${path.basename(vaultPath)}`,
+					"eval",
+					`code=${code}`,
+				]);
+				return parseObsidianOutput(output);
+			});
+		// Validate runtime settings as well as the API account used to verify results.
+		yield* evaluate("return JSON.stringify({vault:true});");
+		yield* desktopCommand([
+			`vault=${path.basename(vaultPath)}`,
+			"plugin:reload",
+			"id=confluence-integration",
+		]);
+		yield* evaluate(
+			`const p=app.plugins.plugins['confluence-integration']; if(!p) throw Error('Enable Confluence Integration in the test vault'); if(p.settings.confluenceBaseUrl !== ${JSON.stringify(baseUrl)} || String(p.settings.confluenceParentId) !== ${JSON.stringify(parentId)}) throw Error('Plugin destination differs from test configuration'); return JSON.stringify({ready:true});`,
+		);
+		const snapshot = () =>
+			Effect.gen(function* () {
+				const pages = {};
+				for (const filename of publishedNotes) {
+					const markdown = yield* fs.readFileString(path.join(vaultPath, filename));
+					const pageId = markdown.match(/^connie-page-id:\s*['"]?(\d+)/m)?.[1];
+					assert.ok(pageId, `No published ID in ${filename}`);
+					assert.ok(
+						markdown.includes("connie-page-url:"),
+						`No published URL in ${filename}`,
+					);
+					const page = yield* get(
+						`content/${pageId}?expand=space,version,body.atlas_doc_format,ancestors`,
+					);
+					assert.equal(page.space?.key, environment.CONFLUENCE_E2E_SPACE_KEY);
+					const attachments = yield* get(
+						`content/${pageId}/child/attachment?limit=250&expand=version`,
+					);
+					const labels = yield* get(`content/${pageId}/label?limit=250`);
+					pages[filename] = {
+						id: pageId,
+						version: page.version.number,
+						body: JSON.parse(page.body.atlas_doc_format.value),
+						ancestors: page.ancestors.map((ancestor) => ancestor.id),
+						attachments: Object.fromEntries(
+							attachments.results.map((attachment) => [
+								attachment.title,
+								attachment.version.number,
+							]),
+						),
+						labels: labels.results.map((label) => label.name).sort(),
+					};
+				}
+				for (const excluded of [
+					"Release Tests/Excluded.md",
+					"Release Tests-private/Unselected.md",
+					"Source Notes/Reusable.md",
+				])
+					assert.doesNotMatch(
+						yield* fs.readFileString(path.join(vaultPath, excluded)),
+						/^connie-page-id:/m,
+					);
+				const media = pages["Release Tests/Media.md"];
+				assert.ok(
+					Object.keys(media.attachments).some((title) =>
+						title.startsWith("RenderedMermaidChart-"),
+					),
+				);
+				assert.ok(
+					Object.keys(media.attachments).some((title) =>
+						title.startsWith("RenderedPlantumlChart-"),
+					),
+				);
+				assert.ok(Object.keys(media.attachments).length >= 5);
+				assert.ok(pages["Tagged/Tag selection.md"].labels.includes("release-test"));
+				assert.equal(
+					pages["Release Tests/Hierarchy/Child.md"].ancestors.at(-1),
+					pages["Release Tests/Hierarchy/README.md"].id,
+				);
+				return pages;
+			});
+		const publish = () =>
+			evaluate(
+				`const result=await app.plugins.plugins['confluence-integration'].doPublish(); if(result.errorMessage || result.failedFiles.length || result.filesUploadResult.length < 7) throw Error('Desktop publish failed'); return JSON.stringify({count:result.filesUploadResult.length});`,
+			);
+		yield* publish();
+		const first = yield* snapshot();
+		yield* publish();
+		assert.deepEqual(
+			yield* snapshot(),
+			first,
+			"Desktop republishing changed unchanged pages or attachments",
+		);
+		const filename = "Release Tests/Formatting.md";
+		const sentinel = `DESKTOP INTEGRATION UPDATE ${Date.now()}`;
+		const original = yield* fs.readFileString(path.join(vaultPath, filename));
+		// Use Obsidian's vault API so metadata caches and file events participate.
+		yield* evaluate(
+			`const file=app.vault.getAbstractFileByPath(${JSON.stringify(filename)}); await app.vault.modify(file, (await app.vault.read(file)) + ${JSON.stringify(`\n\n${sentinel}\n`)}); return JSON.stringify({modified:true});`,
+		);
+		let updated;
+		yield* Effect.gen(function* () {
+			yield* publish();
+			updated = yield* snapshot();
+			for (const [note, page] of Object.entries(updated)) {
+				if (note === filename) {
+					assert.equal(page.version, first[note].version + 1);
+					assert.ok(JSON.stringify(page.body).includes(sentinel));
+					assert.deepEqual(page.attachments, first[note].attachments);
+				} else assert.deepEqual(page, first[note], `Updating one note changed ${note}`);
+			}
+		}).pipe(
+			Effect.ensuring(
+				evaluate(
+					`const file=app.vault.getAbstractFileByPath(${JSON.stringify(filename)}); await app.vault.modify(file, ${JSON.stringify(original)}); return JSON.stringify({restored:true});`,
+				),
+			),
+		);
+		// Restore the remote fixture too, so the next run starts from the same note.
+		yield* publish();
+		yield* fs.writeFileString(
+			path.join(reportDirectory, "obsidian.json"),
+			JSON.stringify(
+				{
+					status: "passed",
+					checks: [
+						"desktop-publish",
+						"unchanged",
+						"single-note-update",
+						"electron-mermaid",
+						"plantuml",
+						"hierarchy",
+						"selection",
+					],
+					pagesAfterUpdate: Object.fromEntries(
+						Object.entries(updated).map(([note, page]) => [
+							note,
+							{ id: page.id, version: page.version },
+						]),
+					),
+				},
+				null,
+				2,
+			),
+		);
+	});
+}

--- a/scripts/integration-options.js
+++ b/scripts/integration-options.js
@@ -1,0 +1,52 @@
+export const integrationProfiles = ["quick", "packages", "live", "docker", "vault", "obsidian"];
+
+export function parseIntegrationOptions(argv) {
+	const options = { profile: "quick", skipBuild: false };
+	const args = [...argv];
+	if (args[0] && !args[0].startsWith("--")) options.profile = args.shift();
+	if (!integrationProfiles.includes(options.profile))
+		throw new Error(`Unknown integration profile: ${options.profile}`);
+	const valueOptions = { "--vault": "vault", "--settings-from": "settingsFile" };
+	while (args.length) {
+		const argument = args.shift();
+		if (argument === "--") continue;
+		if (argument === "--skip-build") options.skipBuild = true;
+		else if (argument === "--help") options.help = true;
+		else if (valueOptions[argument]) {
+			const value = args.shift();
+			if (!value || value.startsWith("--")) throw new Error(`${argument} requires a path`);
+			options[valueOptions[argument]] = value;
+		} else throw new Error(`Unknown integration option: ${argument}`);
+	}
+	return options;
+}
+
+/** Require an explicit remote destination before starting any build or publication. */
+export function validateLiveEnvironment(environment) {
+	for (const name of [
+		"ATLASSIAN_USERNAME",
+		"ATLASSIAN_API_TOKEN",
+		"CONFLUENCE_E2E_BASE_URL",
+		"CONFLUENCE_E2E_PARENT_ID",
+		"CONFLUENCE_E2E_SPACE_KEY",
+	]) {
+		if (!environment[name]?.trim())
+			throw new Error(
+				`Missing ${name}. Configure .env.integration; see documentation/TESTING.md.`,
+			);
+	}
+	const url = new URL(environment.CONFLUENCE_E2E_BASE_URL);
+	if (
+		url.protocol !== "https:" ||
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash ||
+		!["", "/"].includes(url.pathname)
+	)
+		throw new Error(
+			"CONFLUENCE_E2E_BASE_URL must be an HTTPS origin without credentials or a path",
+		);
+	if (!/^\d+$/.test(environment.CONFLUENCE_E2E_PARENT_ID))
+		throw new Error("CONFLUENCE_E2E_PARENT_ID must be a numeric page ID");
+}

--- a/scripts/integration-options.test.js
+++ b/scripts/integration-options.test.js
@@ -1,0 +1,58 @@
+import { expect, test } from "@effect/vitest";
+import { parseIntegrationOptions, validateLiveEnvironment } from "./integration-options.js";
+import { parseObsidianOutput } from "./integration-obsidian.js";
+
+test("does not treat a successful CLI exit without a result as a passing desktop test", () => {
+	expect(parseObsidianOutput('=> {"ready":true}\n')).toEqual({ ready: true });
+	for (const output of [
+		"",
+		"Command line interface is not enabled.",
+		"Error: Vault not found",
+		"=> invalid-json\n",
+	])
+		expect(() => parseObsidianOutput(output)).toThrow();
+});
+
+test("defaults to credential-free checks and rejects misspelled live options", () => {
+	expect(parseIntegrationOptions([])).toEqual({ profile: "quick", skipBuild: false });
+	expect(parseIntegrationOptions(["packages", "--skip-build"]).skipBuild).toBe(true);
+	expect(() => parseIntegrationOptions(["lve"])).toThrow("Unknown integration profile");
+	expect(() => parseIntegrationOptions(["live", "--settings-from"])).toThrow("requires a path");
+	expect(() => parseIntegrationOptions(["live", "--skip-buid"])).toThrow(
+		"Unknown integration option",
+	);
+});
+
+const configured = {
+	ATLASSIAN_USERNAME: "integration@example.test",
+	ATLASSIAN_API_TOKEN: "test-token",
+	CONFLUENCE_E2E_BASE_URL: "https://example.atlassian.net",
+	CONFLUENCE_E2E_PARENT_ID: "1234",
+	CONFLUENCE_E2E_SPACE_KEY: "TEST",
+};
+
+test("requires every live destination and credential field before publication", () => {
+	expect(() => validateLiveEnvironment(configured)).not.toThrow();
+	for (const key of Object.keys(configured)) {
+		expect(() => validateLiveEnvironment({ ...configured, [key]: "" })).toThrow(
+			`Missing ${key}`,
+		);
+	}
+});
+
+test("rejects ambiguous or credential-bearing test destinations", () => {
+	for (const base of [
+		"http://example.test",
+		"https://user:secret@example.test",
+		"https://example.test/wiki",
+		"https://example.test/?token=secret",
+		"https://example.test/#secret",
+	]) {
+		expect(() =>
+			validateLiveEnvironment({ ...configured, CONFLUENCE_E2E_BASE_URL: base }),
+		).toThrow();
+	}
+	expect(() =>
+		validateLiveEnvironment({ ...configured, CONFLUENCE_E2E_PARENT_ID: "not-a-page" }),
+	).toThrow("numeric page ID");
+});

--- a/scripts/integration-package-smoke.js
+++ b/scripts/integration-package-smoke.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+
+/** Runs unchanged against workspace builds and an isolated tarball consumer. */
+export async function verifyPackageImports(resolvePackage) {
+	const libraryUrl = resolvePackage("lib");
+	const library = await import(libraryUrl);
+	const { HttpPlantumlRenderer } = await import(resolvePackage("plantuml-renderer"));
+	const { PuppeteerMermaidRenderer } = await import(resolvePackage("mermaid-puppeteer-renderer"));
+	const adf = library.parseMarkdownToADF(
+		"# Integration check\n\n中文 café ✓\n\n```toc\n```\n\n**Bold** and [link](https://example.com).",
+		"https://example.atlassian.net",
+	);
+	assert.equal(adf.type, "doc");
+	assert.ok(JSON.stringify(adf).includes('"extensionKey":"toc"'));
+	assert.ok(JSON.stringify(adf).includes('"type":"strong"'));
+	assert.ok(JSON.stringify(adf).includes("中文 café ✓"));
+	// This deterministic transport checks the packaged renderer contract. The live
+	// profile separately exercises the real PlantUML server and attachment upload.
+	const plantuml = new HttpPlantumlRenderer({
+		serverUrl: "https://example.test/plantuml",
+		format: "svg",
+		fetchImpl: async (url) => {
+			assert.match(url, /^https:\/\/example\.test\/plantuml\/svg\/[^/]+$/);
+			return new Response('<svg xmlns="http://www.w3.org/2000/svg"/>');
+		},
+	});
+	const diagrams = await plantuml.capturePlantumlCharts([
+		{ name: "integration.svg", data: "@startuml\nAlice -> Bob: Test\n@enduml" },
+	]);
+	assert.match(diagrams.get("integration.svg").toString(), /<svg/);
+	const mermaid = new PuppeteerMermaidRenderer({ protocolTimeout: 60000 });
+	const images = await mermaid.captureMermaidCharts([
+		{ name: "integration.png", data: "flowchart LR\nMarkdown --> Confluence" },
+	]);
+	assert.deepEqual(
+		[...images.get("integration.png").subarray(0, 8)],
+		[137, 80, 78, 71, 13, 10, 26, 10],
+	);
+	assert.ok(images.get("integration.png").length > 100);
+	console.log(
+		"Package imports, Markdown/TOC, PlantUML contract and real Chromium rendering passed.",
+	);
+}

--- a/scripts/integration-tests.js
+++ b/scripts/integration-tests.js
@@ -1,0 +1,424 @@
+import assert from "node:assert/strict";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Console, Effect, Stream } from "effect";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import { ChildProcess } from "effect/unstable/process";
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import {
+	RuntimeEnvironmentLive,
+	RuntimeEnvironmentService,
+} from "../packages/lib/src/effects/index.ts";
+import { prepareReleaseAssets, releasePackages } from "./prepare-release-assets.js";
+import { parseIntegrationOptions, validateLiveEnvironment } from "./integration-options.js";
+import { prepareIntegrationVault } from "./integration-vault.js";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const help = `Integration profiles (vp run test:integration [profile] [options]):
+  quick      Build, check all fixture conversions and render real Mermaid PNGs (default).
+  packages   Pack all five npm packages, install into a fresh consumer and verify them.
+  live       Publish synthetic fixtures to Confluence; verify unchanged/update/recovery.
+  docker     Build the local image and exercise its CLI without Confluence credentials.
+  vault      Create a dedicated Obsidian fixture vault, or refresh only its plugin build.
+  obsidian   Run the desktop plugin test in the prepared, open vault via Obsidian CLI.
+
+  --skip-build          Reuse the current build (CI/watch mode; does not check freshness).
+  --vault PATH          Dedicated vault path; defaults to ../markdown-confluence-integration-vault.
+  --settings-from PATH  Read test credentials from an existing plugin data.json.
+  --help                Show this help without building or publishing.
+
+Configuration: .env.integration (see .env.integration.example).
+Reports: reports/integration/. See documentation/TESTING.md for coverage and setup.`;
+
+function command(executable, args, options = {}) {
+	return Effect.scoped(
+		Effect.gen(function* () {
+			const child = yield* ChildProcess.make(executable, args, {
+				cwd: repositoryRoot,
+				extendEnv: true,
+				stdin: "ignore",
+				stdout: options.capture ? "pipe" : "inherit",
+				stderr: "inherit",
+				...options,
+			});
+			const [exitCode, output] = yield* Effect.all(
+				[
+					child.exitCode,
+					options.capture
+						? child.stdout.pipe(
+								Stream.decodeText(),
+								Stream.runCollect,
+								Effect.map((chunks) => chunks.join("")),
+							)
+						: Effect.succeed(""),
+				],
+				{ concurrency: "unbounded" },
+			);
+			if (exitCode !== (options.expectedExitCode ?? 0))
+				return yield* Effect.fail(
+					new Error(
+						`${executable} exited ${exitCode}; expected ${options.expectedExitCode ?? 0}`,
+					),
+				);
+			return output;
+		}),
+	).pipe(Effect.timeout("15 minutes"));
+}
+
+function readTestEnvironment(options) {
+	return Effect.gen(function* () {
+		const runtime = yield* RuntimeEnvironmentService;
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		const settingsFile =
+			options.settingsFile ?? (yield* runtime.getEnv("CONFLUENCE_E2E_SETTINGS_FILE"));
+		const settings = settingsFile
+			? JSON.parse(yield* fs.readFileString(path.resolve(repositoryRoot, settingsFile)))
+			: {};
+		const mapping = {
+			ATLASSIAN_USERNAME: "atlassianUserName",
+			ATLASSIAN_API_TOKEN: "atlassianApiToken",
+			CONFLUENCE_E2E_BASE_URL: "confluenceBaseUrl",
+			CONFLUENCE_E2E_PARENT_ID: "confluenceParentId",
+			CONFLUENCE_E2E_SPACE_KEY: undefined,
+		};
+		const environment = {};
+		for (const [name, setting] of Object.entries(mapping))
+			environment[name] = (yield* runtime.getEnv(name)) || settings[setting];
+		return environment;
+	});
+}
+
+function normalizeAdf(value) {
+	if (Array.isArray(value)) return value.map(normalizeAdf);
+	if (value && typeof value === "object")
+		return Object.fromEntries(
+			Object.entries(value)
+				.filter(([key]) => key !== "localId")
+				.map(([key, item]) => [key, normalizeAdf(item)]),
+		);
+	return value;
+}
+
+function verifyCli(node, cliPath, cwd, libraryUrl) {
+	return Effect.gen(function* () {
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		const library = yield* Effect.promise(() => import(libraryUrl));
+		const fixtures = path.join(repositoryRoot, "test-fixtures/release-vault");
+		let count = 0;
+		for (const relative of yield* fs.readDirectory(fixtures, { recursive: true })) {
+			if (!relative.endsWith(".md")) continue;
+			const filename = path.join(fixtures, relative);
+			const markdown = yield* fs.readFileString(filename);
+			const output = yield* command(
+				node,
+				[cliPath, "to-adf", filename, "--base-url", "https://example.atlassian.net"],
+				{ cwd, capture: true },
+			);
+			assert.deepEqual(
+				normalizeAdf(JSON.parse(output)),
+				normalizeAdf(library.parseMarkdownToADF(markdown, "https://example.atlassian.net")),
+				relative,
+			);
+			count++;
+		}
+		// CommonJS consumers use dynamic import because the public package is ESM.
+		yield* command(
+			node,
+			[
+				"--input-type=commonjs",
+				"-e",
+				`import(${JSON.stringify(libraryUrl)}).then(m => { if (typeof m.parseMarkdownToADF !== 'function') throw Error('Missing public export'); })`,
+			],
+			{ cwd },
+		);
+		const invalid = yield* command(node, [cliPath, "to-adf", "--invalid-integration-option"], {
+			cwd,
+			capture: true,
+			expectedExitCode: 1,
+		});
+		assert.ok(!invalid.trim(), "Failed conversion must not emit an ADF document");
+		yield* Console.log(
+			`Built CLI matches the library for ${count} Markdown fixtures; CommonJS import and failure exit verified.`,
+		);
+	});
+}
+
+function runIntegration() {
+	return Effect.scoped(
+		Effect.gen(function* () {
+			const fs = yield* FileSystem;
+			const path = yield* Path;
+			const runtime = yield* RuntimeEnvironmentService;
+			const argv = yield* runtime.argv;
+			const node = argv[0];
+			const options = parseIntegrationOptions(argv.slice(2));
+			if (options.help) return yield* Console.log(help);
+			const runId = `${options.profile}-${new Date().toISOString().replaceAll(/[:.]/g, "-")}`;
+			const reportDirectory = path.join(repositoryRoot, "reports/integration", runId);
+			yield* fs.makeDirectory(reportDirectory, { recursive: true });
+			const report = {
+				profile: options.profile,
+				startedAt: new Date().toISOString(),
+				reusedBuild: options.skipBuild,
+				status: "running",
+				steps: [],
+			};
+			const step = (name, task) =>
+				Effect.gen(function* () {
+					const started = Date.now();
+					yield* Console.log(`\n[integration] ${name}`);
+					return yield* task.pipe(
+						Effect.onExit((exit) =>
+							Effect.sync(() => {
+								report.steps.push({
+									name,
+									status: exit._tag === "Success" ? "passed" : "failed",
+									durationSeconds: Math.round((Date.now() - started) / 100) / 10,
+								});
+							}),
+						),
+					);
+				});
+			const work = Effect.gen(function* () {
+				const live = ["live", "obsidian"].includes(options.profile);
+				const environment = ["live", "obsidian", "vault"].includes(options.profile)
+					? yield* readTestEnvironment(options)
+					: {};
+				if (live) validateLiveEnvironment(environment);
+				if (!options.skipBuild)
+					yield* step("Build workspace", command("vp", ["run", "build"]));
+				yield* step("Validate release artifacts", prepareReleaseAssets(repositoryRoot));
+				const vaultPath = path.resolve(
+					repositoryRoot,
+					options.vault ??
+						(yield* runtime.getEnv("CONFLUENCE_E2E_VAULT")) ??
+						"../markdown-confluence-integration-vault",
+				);
+				if (options.profile === "vault") {
+					const result = yield* step(
+						"Prepare dedicated Obsidian vault",
+						prepareIntegrationVault(repositoryRoot, vaultPath, {
+							confluenceBaseUrl: environment.CONFLUENCE_E2E_BASE_URL,
+							confluenceSiteUrl: environment.CONFLUENCE_E2E_BASE_URL,
+							confluenceParentId: environment.CONFLUENCE_E2E_PARENT_ID,
+							atlassianUserName: environment.ATLASSIAN_USERNAME,
+							atlassianApiToken: environment.ATLASSIAN_API_TOKEN,
+						}),
+					);
+					report.vault = result;
+					yield* Console.log(
+						`Open ${vaultPath} in Obsidian and enable Confluence Integration once. Existing notes and settings are preserved on refresh.`,
+					);
+					return;
+				}
+				if (options.profile === "obsidian") {
+					yield* step(
+						"Refresh dedicated test-vault plugin",
+						prepareIntegrationVault(repositoryRoot, vaultPath),
+					);
+					const { runObsidianIntegration } = yield* Effect.promise(
+						() => import("./integration-obsidian.js"),
+					);
+					yield* step(
+						"Desktop plugin create/unchanged/update verification",
+						runObsidianIntegration({
+							vaultPath,
+							environment,
+							reportDirectory,
+						}),
+					);
+					return;
+				}
+				if (options.profile === "live") {
+					yield* step(
+						"Live Confluence create/unchanged/update/recovery",
+						command(node, ["scripts/confluence-release-e2e.js"], {
+							env: {
+								...environment,
+								CONFLUENCE_E2E_REPORT_PATH: path.join(
+									reportDirectory,
+									"confluence.json",
+								),
+							},
+						}),
+					);
+					return;
+				}
+				if (options.profile === "docker") {
+					yield* step(
+						"Build local Docker image",
+						command("vp", ["run", "-r", "build:docker"]),
+					);
+					const fixture = path.join(repositoryRoot, "test-fixtures/release-vault");
+					const output = yield* step(
+						"Container CLI conversion",
+						command(
+							"docker",
+							[
+								"run",
+								"--rm",
+								"--mount",
+								`type=bind,source=${fixture},target=/fixtures,readonly`,
+								"markdown-confluence/markdown-confluence",
+								"to-adf",
+								"/fixtures/Release Tests/Formatting.md",
+							],
+							{ capture: true },
+						),
+					);
+					assert.equal(JSON.parse(output).type, "doc");
+					yield* step(
+						"Container rejects unconfigured publishing",
+						command(
+							"docker",
+							["run", "--rm", "markdown-confluence/markdown-confluence"],
+							{ expectedExitCode: 1 },
+						),
+					);
+					return;
+				}
+				let cwd = repositoryRoot;
+				let cliPath = path.join(repositoryRoot, "packages/cli/dist/index.js");
+				let libraryUrl = pathToFileURL(
+					path.join(repositoryRoot, "packages/lib/dist/index.js"),
+				).href;
+				let resolver = `(name) => new URL('../packages/' + name + '/dist/index.js', import.meta.url).href`;
+				let smokePath = path.join(repositoryRoot, "scripts/integration-package-smoke.js");
+				if (options.profile === "packages") {
+					cwd = yield* fs.makeTempDirectoryScoped({ prefix: "confluence-package-test-" });
+					const tarballs = path.join(cwd, "tarballs");
+					yield* fs.makeDirectory(tarballs);
+					yield* step(
+						"Pack all five npm packages",
+						command("vp", [
+							"pm",
+							"pack",
+							"-r",
+							"--filter",
+							"@markdown-confluence/*",
+							"--pack-destination",
+							tarballs,
+						]),
+					);
+					const rootPackage = JSON.parse(
+						yield* fs.readFileString(path.join(repositoryRoot, "package.json")),
+					);
+					const dependencies = {};
+					for (const packageName of releasePackages.filter(
+						(name) => name !== "obsidian",
+					)) {
+						const metadata = JSON.parse(
+							yield* fs.readFileString(
+								path.join(repositoryRoot, "packages", packageName, "package.json"),
+							),
+						);
+						const tarball = path.join(
+							tarballs,
+							`${metadata.name.replace("@", "").replace("/", "-")}-${metadata.version}.tgz`,
+						);
+						assert.ok(yield* fs.exists(tarball), `Missing packed ${metadata.name}`);
+						dependencies[metadata.name] = pathToFileURL(tarball).href;
+					}
+					yield* fs.writeFileString(
+						path.join(cwd, "package.json"),
+						JSON.stringify({
+							private: true,
+							type: "module",
+							packageManager: rootPackage.packageManager,
+							dependencies,
+						}),
+					);
+					yield* fs.copyFile(
+						path.join(repositoryRoot, ".node-version"),
+						path.join(cwd, ".node-version"),
+					);
+					// Override internal transitive dependencies too: no published older package may
+					// silently substitute for the candidate being tested.
+					yield* fs.writeFileString(
+						path.join(cwd, "pnpm-workspace.yaml"),
+						`overrides: ${JSON.stringify(dependencies)}\nallowBuilds:\n  puppeteer: true\n  msgpackr-extract: false\n  esbuild: false\n  "@parcel/watcher": false\n`,
+					);
+					yield* step(
+						"Install into isolated consumer",
+						command("vp", ["install", "--no-frozen-lockfile"], { cwd }),
+					);
+					for (const packageName of Object.keys(dependencies)) {
+						const packageRoot = path.join(cwd, "node_modules", packageName);
+						const metadata = JSON.parse(
+							yield* fs.readFileString(path.join(packageRoot, "package.json")),
+						);
+						assert.equal(metadata.version, rootPackage.version);
+						if (metadata.types)
+							assert.ok(
+								yield* fs.exists(path.join(packageRoot, metadata.types)),
+								`Missing packed declarations: ${packageName}`,
+							);
+					}
+					report.packages = Object.keys(dependencies).map((name) => ({
+						name,
+						version: rootPackage.version,
+					}));
+					cliPath = path.join(cwd, "node_modules/@markdown-confluence/cli/dist/index.js");
+					libraryUrl = pathToFileURL(
+						path.join(cwd, "node_modules/@markdown-confluence/lib/dist/index.js"),
+					).href;
+					const consumerSmoke = path.join(cwd, "integration-package-smoke.js");
+					yield* fs.copyFile(smokePath, consumerSmoke);
+					smokePath = consumerSmoke;
+					resolver = `(name) => '@markdown-confluence/' + name`;
+				}
+				// Resolve workspace paths from the smoke module, not from the child's cwd.
+				const runner = `import { verifyPackageImports } from ${JSON.stringify(pathToFileURL(smokePath).href)}; await verifyPackageImports(${options.profile === "packages" ? resolver : `(name) => ${JSON.stringify(pathToFileURL(path.join(repositoryRoot, "packages/")).href)} + name + '/dist/index.js'`});`;
+				yield* step(
+					"ESM imports and diagram rendering",
+					command(node, ["--input-type=module", "-e", runner], { cwd }),
+				);
+				yield* step(
+					"CLI fixture parity and error handling",
+					verifyCli(node, cliPath, cwd, libraryUrl),
+				);
+			});
+			yield* work.pipe(
+				Effect.onExit((exit) =>
+					Effect.gen(function* () {
+						report.status = exit._tag === "Success" ? "passed" : "failed";
+						report.finishedAt = new Date().toISOString();
+						report.commit = (yield* command("git", ["rev-parse", "HEAD"], {
+							capture: true,
+						}).pipe(Effect.catch(() => Effect.succeed("")))).trim();
+						report.workingTreeDirty = Boolean(
+							(yield* command("git", ["status", "--porcelain"], {
+								capture: true,
+							}).pipe(Effect.catch(() => Effect.succeed("")))).trim(),
+						);
+						yield* fs.writeFileString(
+							path.join(reportDirectory, "summary.json"),
+							JSON.stringify(report, null, 2),
+						);
+						const markdown = `## Integration: ${options.profile} — ${report.status}\n\n${report.steps.map((entry) => `- ${entry.status}: ${entry.name} (${entry.durationSeconds}s)`).join("\n")}\n`;
+						yield* fs.writeFileString(
+							path.join(reportDirectory, "summary.md"),
+							markdown,
+						);
+						const summaryPath = yield* runtime.getEnv("GITHUB_STEP_SUMMARY");
+						if (summaryPath)
+							yield* fs.writeFileString(summaryPath, markdown, { flag: "a" });
+						yield* Console.log(
+							`\nIntegration ${report.status}. Report: ${path.join(reportDirectory, "summary.json")}`,
+						);
+					}),
+				),
+			);
+		}),
+	);
+}
+
+if (import.meta.main)
+	NodeRuntime.runMain(
+		runIntegration().pipe(
+			Effect.provide(NodeServices.layer),
+			Effect.provide(RuntimeEnvironmentLive),
+		),
+	);

--- a/scripts/integration-vault.js
+++ b/scripts/integration-vault.js
@@ -1,0 +1,79 @@
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import { Effect } from "effect";
+
+export const vaultMarker = ".confluence-integration-vault.json";
+
+/** Only refresh plugin artifacts in a vault created by this harness. */
+export function prepareIntegrationVault(repositoryRoot, vaultPath, settings = {}) {
+	return Effect.gen(function* () {
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		const markerPath = path.join(vaultPath, vaultMarker);
+		const exists = yield* fs.exists(vaultPath);
+		if (exists && !(yield* fs.exists(markerPath))) {
+			return yield* Effect.fail(
+				new Error(
+					"Refusing to overwrite an existing unmarked vault. Choose a new --vault path.",
+				),
+			);
+		}
+		if (exists) {
+			const marker = JSON.parse(yield* fs.readFileString(markerPath));
+			if (marker.kind !== "markdown-confluence-integration" || marker.version !== 1)
+				return yield* Effect.fail(new Error("Unrecognized integration vault marker"));
+		} else {
+			yield* fs.copy(path.join(repositoryRoot, "test-fixtures/release-vault"), vaultPath);
+			const prefix = `Desktop ${Date.now()} `;
+			for (const filename of yield* fs.readDirectory(vaultPath, { recursive: true })) {
+				if (!filename.endsWith(".md")) continue;
+				const target = path.join(vaultPath, filename);
+				const markdown = yield* fs.readFileString(target);
+				yield* fs.writeFileString(
+					target,
+					markdown.replace(
+						/^connie-title: (.+)$/m,
+						(_match, title) => `connie-title: ${prefix}${title}`,
+					),
+				);
+			}
+			yield* fs.writeFileString(
+				markerPath,
+				JSON.stringify(
+					{ kind: "markdown-confluence-integration", version: 1, prefix },
+					null,
+					2,
+				),
+			);
+		}
+		const pluginPath = path.join(vaultPath, ".obsidian/plugins/confluence-integration");
+		yield* fs.makeDirectory(pluginPath, { recursive: true });
+		for (const filename of ["main.js", "manifest.json"]) {
+			yield* fs.copyFile(
+				path.join(repositoryRoot, "packages/obsidian/dist", filename),
+				path.join(pluginPath, filename),
+			);
+		}
+		const settingsPath = path.join(pluginPath, "data.json");
+		if (!(yield* fs.exists(settingsPath))) {
+			yield* fs.writeFileString(
+				settingsPath,
+				JSON.stringify(
+					{
+						...settings,
+						contentRoot: vaultPath,
+						folderToPublish: "Release Tests",
+						tagsToPublish: "release-test",
+						ignoredCodeBlockLanguages: ["dataview", "button"],
+						plantuml: { enabled: true, serverUrl: "https://www.plantuml.com/plantuml" },
+						showPublishResultsModal: true,
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+		}
+		return { vaultPath, created: !exists, pluginPath };
+	});
+}

--- a/scripts/integration-vault.test.js
+++ b/scripts/integration-vault.test.js
@@ -1,0 +1,96 @@
+import { Effect } from "effect";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import { NodeServices } from "@effect/platform-node";
+import { expect, test } from "@effect/vitest";
+import { prepareIntegrationVault, vaultMarker } from "./integration-vault.js";
+
+test("creates an isolated vault and refreshes artifacts without overwriting notes or credentials", async () => {
+	await Effect.runPromise(
+		Effect.scoped(
+			Effect.gen(function* () {
+				const fs = yield* FileSystem;
+				const path = yield* Path;
+				const root = yield* fs.makeTempDirectoryScoped();
+				const source = path.join(root, "repository");
+				const vault = path.join(root, "vault");
+				yield* fs.makeDirectory(path.join(source, "test-fixtures/release-vault"), {
+					recursive: true,
+				});
+				yield* fs.makeDirectory(path.join(source, "packages/obsidian/dist"), {
+					recursive: true,
+				});
+				yield* fs.writeFileString(
+					path.join(source, "test-fixtures/release-vault/Fixture.md"),
+					"---\nconnie-title: Example\n---\nOriginal",
+				);
+				for (const name of ["main.js", "manifest.json"])
+					yield* fs.writeFileString(
+						path.join(source, "packages/obsidian/dist", name),
+						"version-one",
+					);
+				expect(
+					(yield* prepareIntegrationVault(source, vault, {
+						atlassianApiToken: "first-test-token",
+					})).created,
+				).toBe(true);
+				expect(yield* fs.readFileString(path.join(vault, "Fixture.md"))).toMatch(
+					/connie-title: Desktop \d+ Example/,
+				);
+				yield* fs.writeFileString(
+					path.join(vault, "Fixture.md"),
+					"Existing page ID and user edits",
+				);
+				yield* fs.writeFileString(
+					path.join(source, "packages/obsidian/dist/main.js"),
+					"version-two",
+				);
+				expect(
+					(yield* prepareIntegrationVault(source, vault, {
+						atlassianApiToken: "replacement-test-token",
+					})).created,
+				).toBe(false);
+				expect(yield* fs.readFileString(path.join(vault, "Fixture.md"))).toBe(
+					"Existing page ID and user edits",
+				);
+				expect(
+					yield* fs.readFileString(
+						path.join(vault, ".obsidian/plugins/confluence-integration/main.js"),
+					),
+				).toBe("version-two");
+				expect(
+					JSON.parse(
+						yield* fs.readFileString(
+							path.join(vault, ".obsidian/plugins/confluence-integration/data.json"),
+						),
+					).atlassianApiToken,
+				).toBe("first-test-token");
+			}),
+		).pipe(Effect.provide(NodeServices.layer)),
+	);
+});
+
+test("refuses existing unmarked or unrelated vaults before copying any plugin", async () => {
+	await Effect.runPromise(
+		Effect.scoped(
+			Effect.gen(function* () {
+				const fs = yield* FileSystem;
+				const path = yield* Path;
+				const vault = yield* fs.makeTempDirectoryScoped();
+				expect(
+					(yield* Effect.result(prepareIntegrationVault("missing-repository", vault)))
+						._tag,
+				).toBe("Failure");
+				yield* fs.writeFileString(
+					path.join(vault, vaultMarker),
+					'{"kind":"unrelated","version":1}',
+				);
+				expect(
+					(yield* Effect.result(prepareIntegrationVault("missing-repository", vault)))
+						._tag,
+				).toBe("Failure");
+				expect(yield* fs.exists(path.join(vault, ".obsidian"))).toBe(false);
+			}),
+		).pipe(Effect.provide(NodeServices.layer)),
+	);
+});


### PR DESCRIPTION
Integration checks previously required a mixture of the live release harness and one-off local scripts. This adds repeatable Vite+ profiles for built artifacts, isolated npm consumers, live Confluence, Docker and the real Obsidian plugin, with timed reports and a documented setup.

`vp run test:integration` is the default build-and-smoke command; `--skip-build` gives a short development loop. The npm profile installs all five candidate tarballs in a temporary consumer and overrides transitive internal dependencies to prevent published versions masking failures. The desktop profile refreshes a marked test vault, reloads the installed plugin through Obsidian CLI, verifies remote publishing/update behavior and restores its edited fixture. Configuration is local and ignored by Git; reports omit credentials.

Linux PR verification and release publication run the npm integration check. Windows PR verification builds and runs the CLI/Chromium check. The existing opt-in live Confluence workflow uses the same runner. All workflows upload reports, including on failure.

Validation:
- `vp run check`, `vp run fmt:check`, `vp test run`: 188 passed, one existing opt-in test skipped.
- All six profiles passed locally: quick, packages, live, docker, vault and obsidian.
- Warm local timings: full quick profile 21 seconds including build; packages 11 seconds, live 26 seconds and desktop 17 seconds with `--skip-build`.
- Actual dedicated Confluence space and running Obsidian 1.13.4 tested; official CLI enabled with the user's approval.
- Changed workflows pass actionlint 1.7.12.

Coverage limits: desktop checks exercise the real plugin publishing method, not visual UI layout. Docker is a local smoke test, not published multi-architecture or companion Action verification. The existing post-conflict idempotency assertion failed once locally and passed on two subsequent fresh runs; it remains strict and now logs synthetic stored/requested ADF to diagnose recurrence. No product fix for that intermittent behavior is claimed.

GitHub validation on `987eeca06eaed9276b1f6d3c16393101954a5874`: [Linux package integration and Windows built-artifact checks](https://github.com/markdown-confluence/markdown-confluence/actions/runs/34077239821) and [live Confluence verification](https://github.com/markdown-confluence/markdown-confluence/actions/runs/34077264053) passed. All three uploaded reports were downloaded and verified. CodeQL, dependency review and Snyk also passed. The optional mutation run is separate and was still running at review time.
