### PR TITLE
feat: add lossless ADF conversion and Confluence export commands

### DIFF
--- a/documentation/CONVERSION.md
+++ b/documentation/CONVERSION.md
@@ -39,6 +39,7 @@ The existing configuration and environment variables provide authentication:
 bearer/OAuth settings. `CONFLUENCE_CONFIG_FILE` also selects the configuration file.
 A publishing parent ID is **not required** for these reads. An OAuth gateway
 configuration still needs `confluenceSiteUrl` for the human-facing page URL.
+Authenticated page reads require an HTTPS `confluenceBaseUrl`.
 
 Supported page references are numeric IDs with `--page`, full `/pages/ID/Title`
 URLs, legacy `viewpage.action?pageId=ID` URLs, and space overview URLs containing

--- a/documentation/CONVERSION.md
+++ b/documentation/CONVERSION.md
@@ -1,0 +1,141 @@
+# Markdown and ADF conversion
+
+`to-adf` converts Markdown into Atlassian Document Format (ADF) JSON. `to-markdown`
+converts ADF into Markdown; `from-adf` is an alias. Both commands read files or
+stdin, write files or stdout, and can read a Confluence page by URL or ID.
+Conversion does not publish pages or change source files.
+
+## Files and streams
+
+```bash
+vp dlx @markdown-confluence/cli to-adf "notes/source page.md" --output "exports/page.adf.json"
+vp dlx @markdown-confluence/cli to-markdown "exports/page.adf.json" --output "exports/page.md"
+vp dlx @markdown-confluence/cli from-adf --input "exports/page.adf.json" --output "exports/readable.md" --readable
+
+cat notes/page.md | vp dlx @markdown-confluence/cli to-adf - > page.adf.json
+cat page.adf.json | vp dlx @markdown-confluence/cli to-markdown - > page.md
+```
+
+During development, replace `vp dlx @markdown-confluence/cli` with
+`node packages/cli/dist/index.js` after `vp run build`. Output directories must
+already exist. An explicitly named output file is replaced only after input has
+been read and converted successfully. `-o` abbreviates `--output`, `-i` abbreviates
+`--input`, and `--output -` selects stdout. Use `--` before filenames that begin
+with a hyphen. One source is converted per invocation.
+
+## Confluence input
+
+```bash
+vp dlx @markdown-confluence/cli to-markdown \
+  "https://example.atlassian.net/wiki/spaces/DOCS/pages/123456/Page" \
+  --config .markdown-confluence.json --output page.md
+
+vp dlx @markdown-confluence/cli to-adf --page 123456 \
+  --config .markdown-confluence.json --output page.adf.json
+```
+
+The existing configuration and environment variables provide authentication:
+`CONFLUENCE_BASE_URL`, `ATLASSIAN_USERNAME`, `ATLASSIAN_API_TOKEN`, or the existing
+bearer/OAuth settings. `CONFLUENCE_CONFIG_FILE` also selects the configuration file.
+A publishing parent ID is **not required** for these reads. An OAuth gateway
+configuration still needs `confluenceSiteUrl` for the human-facing page URL.
+
+Supported page references are numeric IDs with `--page`, full `/pages/ID/Title`
+URLs, legacy `viewpage.action?pageId=ID` URLs, and space overview URLs containing
+`homepageId=ID`. Short share links need their full page URL or numeric ID. URL
+input must match the configured site; requests use the existing configured
+Confluence client. `to-adf URL` exports the page's original ADF directly.
+
+Local JSON input may be a complete ADF document or a Confluence REST response
+containing `body.atlas_doc_format.value`. Invalid JSON/documents fail with a
+nonzero exit status and diagnostics on stderr, leaving stdout empty.
+
+## Existing ADF fence preservation
+
+The repository already supports an `adf` fenced code block containing a node to
+insert into a document. Conversion reuses that format; it does not introduce a
+second syntax for Confluence features.
+
+````markdown
+```adf
+{
+  "type": "paragraph",
+  "content": [{ "type": "status", "attrs": { "text": "READY", "color": "green", "localId": "status-1" } }]
+}
+```
+````
+
+Complete `{ "type": "doc", "version": 1, "content": [...] }` documents can also
+be placed inside a fence. A complete document on its own is restored as the
+document, while its content is inserted when mixed with other Markdown. Raw ADF
+is restored after Markdown normalization, preserving its attributes, marks,
+extension parameters, and ordered-list starts. Malformed examples remain code.
+
+`to-markdown` defaults to lossless conversion: ordinary blocks remain Markdown
+when they reproduce the original ADF; blocks that would lose information use the
+existing `adf` fence. This includes media IDs, layout widths, comment annotations,
+unknown extensions, and unsupported node attributes. Empty paragraphs, adjacent
+lists or document metadata can require preserving the complete document. A final
+conversion check verifies that all ADF fields survive.
+
+`--readable` prefers readable Markdown and may simplify presentation metadata:
+cards become links, external images become Markdown images, dates become ISO
+dates, statuses become bold text, and decisions become list items. Unsupported
+content still uses ADF fences. It is intended for reading, not exact restoration.
+Media with only Confluence attachment IDs stays in ADF; this command does not
+download attachments or migrate IDs to a different page/site. Comments and macro
+payloads are preserved as data, not recreated as server-side objects.
+
+## Coverage of #260 and #264
+
+The old issue checklists mix Markdown features with Confluence-only features.
+The following is the supported conversion contract. “ADF fence” means the
+existing reversible representation, rather than a new Markdown notation.
+
+| Feature | Markdown input / ADF output | ADF input / Markdown output |
+| --- | --- | --- |
+| Paragraphs, text, headings, quotes, rules, line breaks | Native Markdown | Native Markdown |
+| Bullet/ordered lists and list items | Native Markdown, including starting numbers | Native Markdown, retaining nesting and starting numbers |
+| Task lists/items | `- [ ]` and `- [x]` | Task syntax; fences preserve original IDs in lossless mode |
+| Tables, rows, header/data cells | Pipe tables, with column alignment | Pipe tables with alignment; merged/mixed cells use ADF fences |
+| Code blocks and inline code | Markdown fences/backticks | Delimiters lengthened when content contains backticks |
+| Strong, emphasis, strike, links | Native Markdown | Native Markdown with literal text escaped |
+| Underline, subscript, superscript | `<u>`, `<sub>`, `<sup>` | Same limited formatting markup |
+| Text/background color | `<span style="color: #rrggbb">` / `background-color` | Same limited markup; arbitrary HTML remains disabled |
+| Inline cards | Existing link conversion or ADF fence | Links; ADF fence when payload needs preserving |
+| Block/embed cards | ADF fence | Readable links; lossless ADF fence |
+| Emoji and mentions | Existing mention syntax; `:id\|short_name:` emoji; Unicode text; ADF fence | Unicode/mention text; ADF fence retains IDs and metadata |
+| Expand and panels | Existing callout syntax; ADF fence | Callouts; ADF fence preserves exact titles/custom attributes |
+| Nested expand | ADF fence (nested callout flattening remains intentional) | Readable expand; lossless ADF fence |
+| Image, media, mediaSingle | Existing Markdown images/embeds or ADF fence | External URLs as images; media IDs and sizing preserved via ADF fence |
+| Caption, mediaGroup, mediaInline | ADF fence | Captions/external images where representable; otherwise ADF fence |
+| Date, decision list/item, status, placeholder | ADF fence | Readable date/list/bold/text; lossless ADF fence |
+| Layout section/column | ADF fence | ADF fence preserves hierarchy and column widths |
+| Unknown/unsupported block/inline and Confluence variants | ADF fence | ADF fence |
+| Bodied/inline/ordinary extensions and Jira macros | Existing macro syntax where supported; ADF fence for arbitrary payloads | ADF fence |
+| Alignment, indentation, annotation, inline comment, border, breakout | Table alignment or ADF fence | Table alignment; other block/annotation marks use ADF fence |
+| Data consumer, fragment, type-ahead query, unsupported marks/node attributes | ADF fence | ADF fence preserves original values |
+
+The document schema is described in the [Atlassian ADF documentation](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/).
+Preserving a node does not guarantee that every Confluence product accepts it;
+the converter retains it without claiming server-side support.
+
+## Acceptance criteria
+
+- **File input and file output for both commands:** read Markdown from a file and
+  write ADF JSON to a file; read ADF JSON from a file and write Markdown to a file.
+- Both directions accept positional input and `--input`, explicit `--output`,
+  filenames containing spaces, stdin, and stdout.
+- Markdown → ADF → Markdown → ADF preserves the generated ADF. Rich ADF →
+  Markdown → ADF preserves every original JSON field in the default lossless mode.
+- Invalid input exits nonzero without producing an output file or partial stdout.
+- Confluence URLs and page IDs work with existing authentication without a parent
+  ID, and conversion leaves the page version unchanged.
+- Unknown nodes, marks and attributes survive using the **existing `adf` fences**.
+- Formatting, table alignment, list starts, media/captions, special characters,
+  nested structures and malformed ADF have focused regression coverage.
+- The quick, packaged-consumer and live integration profiles exercise the actual
+  built CLI. Live verification uses the dedicated Confluence test space.
+
+Run `vp run test:integration`, `vp run test:integration packages --skip-build`, and
+`vp run test:integration live --skip-build`. See [TESTING.md](TESTING.md) for setup.

--- a/documentation/TESTING.md
+++ b/documentation/TESTING.md
@@ -135,3 +135,11 @@ passed on two fresh runs. It remains strict: a failure logs the synthetic stored
 and requested ADF for diagnosis, rather than retrying an extra publish to hide an
 unexpected version update. Treat this as an observed intermittent behavior, not
 a resolved product defect. CI reports identify the failed step.
+
+### Conversion acceptance checks
+
+The quick and packaged-consumer profiles also test both conversion CLI commands
+with file input/output and stdin, an exact rich ADF round trip, readable export,
+formatting and invalid JSON. The live profile exports a page by URL and ID,
+round-trips its media IDs, and verifies its version remains unchanged. See
+[CONVERSION.md](CONVERSION.md#acceptance-criteria) for the full acceptance criteria.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,13 +42,21 @@ set ATLASSIAN_API_TOKEN="YOUR API TOKEN"
 vp dlx @markdown-confluence/cli
 ```
 
-**Convert Markdown to ADF**
+**Convert files or Confluence pages**
 
 ```bash
-npx @markdown-confluence/cli to-adf ./docs/page.md
-npx @markdown-confluence/cli to-adf ./docs/page.md --output page.adf.json
-cat ./docs/page.md | npx @markdown-confluence/cli to-adf
+vp dlx @markdown-confluence/cli to-adf "notes/page.md" --output "page.adf.json"
+vp dlx @markdown-confluence/cli to-markdown "page.adf.json" --output "page.md"
+vp dlx @markdown-confluence/cli to-markdown --page 123456 --output "confluence-page.md"
+vp dlx @markdown-confluence/cli to-adf "https://example.atlassian.net/wiki/spaces/DOCS/pages/123456/Page" --output "confluence-page.adf.json"
 ```
+
+Both commands support file input/output and stdin/stdout. `from-adf` is an alias
+for `to-markdown`. Local conversion needs no credentials; page input reuses your
+existing authentication and requires no publishing parent ID. Markdown export
+preserves rich content through the existing `adf` fences by default; `--readable`
+prefers readable Markdown. See the [conversion guide](../../documentation/CONVERSION.md)
+for examples, feature coverage, limitations, and acceptance criteria.
 
 ### Docker Container
 

--- a/packages/cli/src/conversionOptions.test.ts
+++ b/packages/cli/src/conversionOptions.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@effect/vitest";
+import { parseConversionOptions } from "./conversionOptions";
+
+test("conversion commands accept files, stdin, output and explicit page references", () => {
+	expect(parseConversionOptions(["notes.md", "-o", "page.json"], "to-adf")).toMatchObject({
+		input: "notes.md",
+		output: "page.json",
+	});
+	expect(parseConversionOptions(["-", "--output=-"], "to-adf")).toMatchObject({
+		input: "-",
+		output: "-",
+	});
+	expect(
+		parseConversionOptions(
+			["--page", "123", "--config", "test.json", "--readable"],
+			"to-markdown",
+		),
+	).toMatchObject({ page: "123", config: "test.json", lossless: false });
+	expect(
+		parseConversionOptions(
+			["https://example.atlassian.net/wiki/spaces/D/pages/123/Title"],
+			"to-markdown",
+		),
+	).toMatchObject({ page: "https://example.atlassian.net/wiki/spaces/D/pages/123/Title" });
+	expect(parseConversionOptions(["--", "-file.json"], "to-markdown").input).toBe("-file.json");
+});
+
+test("rejects ambiguous inputs, unsupported options and missing values", () => {
+	for (const args of [
+		["one", "two"],
+		["one", "--page", "123"],
+		["--output"],
+		["--output", "--readable"],
+		["--unknown"],
+		["--input", "a", "--input", "b"],
+	]) {
+		expect(() => parseConversionOptions(args, "to-markdown")).toThrow();
+	}
+	expect(() => parseConversionOptions(["--readable"], "to-adf")).toThrow(
+		"only supported by to-markdown",
+	);
+});

--- a/packages/cli/src/conversionOptions.ts
+++ b/packages/cli/src/conversionOptions.ts
@@ -1,0 +1,92 @@
+export type ConversionOptions = {
+	input?: string;
+	page?: string;
+	output?: string;
+	config?: string;
+	baseUrl: string;
+	lossless: boolean;
+	help: boolean;
+};
+
+export function parseConversionOptions(
+	args: string[],
+	command: "to-adf" | "to-markdown",
+): ConversionOptions {
+	const options: ConversionOptions = {
+		baseUrl: "https://confluence.atlassian.com",
+		lossless: true,
+		help: false,
+	};
+	for (let index = 0; index < args.length; index++) {
+		const argument = args[index]!;
+		if (argument === "--help" || argument === "-h") {
+			options.help = true;
+			continue;
+		}
+		if (argument === "--readable" || argument === "--lossless") {
+			if (command !== "to-markdown")
+				throw new Error(`${argument} is only supported by to-markdown.`);
+			options.lossless = argument === "--lossless";
+			continue;
+		}
+		if (argument === "--") {
+			for (const input of args.slice(index + 1)) setInput(options, input);
+			break;
+		}
+		if (argument === "-" || !argument.startsWith("-")) {
+			setInput(options, argument);
+			continue;
+		}
+		const separator = argument.indexOf("=");
+		const option = separator === -1 ? argument : argument.slice(0, separator);
+		const field = (
+			{
+				"-i": "input",
+				"--input": "input",
+				"-o": "output",
+				"--output": "output",
+				"-b": "baseUrl",
+				"--base-url": "baseUrl",
+				"--page": "page",
+				"-c": "config",
+				"--config": "config",
+			} as Record<string, "input" | "output" | "baseUrl" | "page" | "config">
+		)[option];
+		if (!field) throw new Error(`Unknown ${command} option: ${option}`);
+		const value = separator === -1 ? args[++index] : argument.slice(separator + 1);
+		if (!value || (value.startsWith("-") && value !== "-"))
+			throw new Error(`${option} requires a value.`);
+		if (field === "input") setInput(options, value);
+		else options[field] = value;
+	}
+	if (options.input && options.page)
+		throw new Error("Use either an input file/URL or --page, not both.");
+	if (options.input && /^https?:\/\//i.test(options.input)) {
+		options.page = options.input;
+		delete options.input;
+	}
+	return options;
+}
+
+function setInput(options: ConversionOptions, input: string): void {
+	if (options.input !== undefined)
+		throw new Error("Only one input file or Confluence URL can be converted at a time.");
+	options.input = input;
+}
+
+export function conversionHelp(command: "to-adf" | "to-markdown"): string {
+	return `Usage: markdown-confluence ${command} [FILE | CONFLUENCE_URL | -] [options]
+
+${command === "to-adf" ? "Convert Markdown to ADF JSON, or export a Confluence page's ADF." : "Convert ADF JSON or a Confluence page to Markdown."}
+Omit the input (or use -) to read stdin. Local conversion needs no credentials.
+
+  -i, --input FILE       Input file (also accepts a Confluence page URL)
+  --page ID_OR_URL       Read a Confluence page using the configured authentication
+  -o, --output FILE      Write to FILE; defaults to stdout (-)
+  -b, --base-url URL     Base URL used when converting local Markdown links
+  -c, --config FILE      Existing Confluence config (or CONFLUENCE_CONFIG_FILE)
+${command === "to-markdown" ? "  --lossless            Preserve exact ADF using existing adf fences (default)\n  --readable            Prefer readable Markdown; presentation metadata may be lost\n" : ""}  -h, --help            Show this help
+
+Confluence reads use the existing config/environment authentication settings.
+No parent page ID is required. These commands do not publish or modify pages.`;
+}

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -8,7 +8,6 @@ import {
 	fetchConfluencePageAdf,
 	confluenceReadSettingsConfig,
 	makeConfluenceSettingsConfigProvider,
-	validateConfluenceSettings,
 } from "@markdown-confluence/lib";
 import { conversionHelp, parseConversionOptions } from "./conversionOptions";
 
@@ -27,14 +26,6 @@ export function convertDocument(command: "to-adf" | "to-markdown", args: string[
 			const settings = yield* confluenceReadSettingsConfig
 				.parse(provider)
 				.pipe(Effect.mapError(toError));
-			const issues = validateConfluenceSettings(settings).issues.filter(
-				(issue) =>
-					!["confluenceParentId", "folderToPublish", "contentRoot"].includes(issue.field),
-			);
-			if (issues.length)
-				return yield* Effect.fail(
-					new Error(issues.map((issue) => issue.message).join("\n")),
-				);
 			input = yield* fetchConfluencePageAdf(settings, options.page);
 			options.baseUrl = settings.confluenceSiteUrl || settings.confluenceBaseUrl;
 		} else {

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -1,0 +1,67 @@
+import { Console, Effect } from "effect";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import {
+	parseMarkdownToADF,
+	convertADFToMarkdown,
+	StandardInputService,
+	fetchConfluencePageAdf,
+	confluenceReadSettingsConfig,
+	makeConfluenceSettingsConfigProvider,
+	validateConfluenceSettings,
+} from "@markdown-confluence/lib";
+import { conversionHelp, parseConversionOptions } from "./conversionOptions";
+
+export function convertDocument(command: "to-adf" | "to-markdown", args: string[]) {
+	return Effect.gen(function* () {
+		const options = yield* Effect.try({
+			try: () => parseConversionOptions(args, command),
+			catch: toError,
+		});
+		if (options.help) return yield* Console.log(conversionHelp(command));
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		let input: unknown;
+		if (options.page) {
+			const provider = yield* makeConfluenceSettingsConfigProvider();
+			const settings = yield* confluenceReadSettingsConfig
+				.parse(provider)
+				.pipe(Effect.mapError(toError));
+			const issues = validateConfluenceSettings(settings).issues.filter(
+				(issue) =>
+					!["confluenceParentId", "folderToPublish", "contentRoot"].includes(issue.field),
+			);
+			if (issues.length)
+				return yield* Effect.fail(
+					new Error(issues.map((issue) => issue.message).join("\n")),
+				);
+			input = yield* fetchConfluencePageAdf(settings, options.page);
+			options.baseUrl = settings.confluenceSiteUrl || settings.confluenceBaseUrl;
+		} else {
+			input =
+				options.input && options.input !== "-"
+					? yield* fs.readFileString(path.resolve(options.input), "utf-8")
+					: yield* (yield* StandardInputService).readAll;
+		}
+		const output = yield* Effect.try({
+			try: () =>
+				command === "to-adf"
+					? JSON.stringify(
+							options.page
+								? input
+								: parseMarkdownToADF(input as string, options.baseUrl),
+							null,
+							2,
+						)
+					: convertADFToMarkdown(input, options),
+			catch: toError,
+		});
+		if (options.output && options.output !== "-")
+			yield* fs.writeFileString(path.resolve(options.output), `${output}\n`);
+		else yield* Console.log(output);
+	});
+}
+
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from "@markdown-confluence/lib";
 import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { getErrorMessage } from "./errorMessage";
-import { markdownToAdf } from "./toAdf";
+import { convertDocument } from "./convert";
 import { HttpPlantumlRenderer } from "@markdown-confluence/plantuml-renderer";
 
 const program = Effect.gen(function* () {
@@ -79,8 +79,16 @@ const program = Effect.gen(function* () {
 const command = Effect.gen(function* () {
 	const runtime = yield* RuntimeEnvironmentService;
 	const argv = yield* runtime.argv;
-	if (argv[2] === "to-adf") {
-		return yield* markdownToAdf(argv.slice(3)).pipe(Effect.provide(StandardInputLive));
+	if (argv[2] === "to-adf" || argv[2] === "to-markdown" || argv[2] === "from-adf") {
+		const conversion = argv[2] === "to-adf" ? "to-adf" : "to-markdown";
+		return yield* convertDocument(conversion, argv.slice(3)).pipe(
+			Effect.provide(StandardInputLive),
+		);
+	}
+	if (argv[2] === "--help" || argv[2] === "-h") {
+		return yield* Console.log(
+			"Usage: markdown-confluence [publishing options]\n\nCommands:\n  to-adf       Convert Markdown or export Confluence ADF\n  to-markdown  Convert ADF or a Confluence page to Markdown\n  from-adf     Alias for to-markdown\n\nUse COMMAND --help for conversion options. Without a command, publish using the configured settings.",
+		);
 	}
 	return yield* program.pipe(
 		Effect.provide(MarkdownWorkspaceLive),

--- a/packages/cli/src/toAdf.ts
+++ b/packages/cli/src/toAdf.ts
@@ -1,88 +1,9 @@
-import { parseMarkdownToADF, StandardInputService } from "@markdown-confluence/lib";
-import { Console, Effect } from "effect";
-import { FileSystem } from "effect/FileSystem";
-import { Path } from "effect/Path";
+import { convertDocument } from "./convert";
+import { parseConversionOptions } from "./conversionOptions";
 
 export function markdownToAdf(args: string[]) {
-	return Effect.gen(function* () {
-		const options = yield* Effect.try({ try: () => parseToAdfOptions(args), catch: toError });
-		const fs = yield* FileSystem;
-		const path = yield* Path;
-		const markdown = options.input
-			? yield* fs.readFileString(path.resolve(options.input), "utf-8")
-			: yield* (yield* StandardInputService).readAll;
-		const adf = yield* Effect.try({
-			try: () => parseMarkdownToADF(markdown, options.baseUrl),
-			catch: toError,
-		});
-		const output = JSON.stringify(adf, null, 2);
-		if (options.output) {
-			yield* fs.writeFileString(path.resolve(options.output), `${output}\n`);
-		} else {
-			yield* Console.log(output);
-		}
-	});
+	return convertDocument("to-adf", args);
 }
-
-function toError(error: unknown): Error {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-type ToAdfOptions = {
-	input?: string;
-	output?: string;
-	baseUrl: string;
-};
-
-export function parseToAdfOptions(args: string[]): ToAdfOptions {
-	const options: ToAdfOptions = {
-		baseUrl: "https://confluence.atlassian.com",
-	};
-
-	for (let index = 0; index < args.length; index++) {
-		const arg = args[index];
-		if (!arg) {
-			continue;
-		}
-
-		if (arg === "-o" || arg === "--output") {
-			options.output = requireOptionValue(arg, args[++index]);
-			continue;
-		}
-
-		if (arg.startsWith("--output=")) {
-			options.output = requireOptionValue("--output", arg.slice("--output=".length));
-			continue;
-		}
-
-		if (arg === "-b" || arg === "--base-url") {
-			options.baseUrl = requireOptionValue(arg, args[++index]);
-			continue;
-		}
-
-		if (arg.startsWith("--base-url=")) {
-			options.baseUrl = requireOptionValue("--base-url", arg.slice("--base-url=".length));
-			continue;
-		}
-
-		if (arg.startsWith("-")) {
-			throw new Error(`Unknown to-adf option: ${arg}`);
-		}
-
-		if (options.input) {
-			throw new Error("Only one Markdown input file can be converted.");
-		}
-
-		options.input = arg;
-	}
-
-	return options;
-}
-
-function requireOptionValue(option: string, value: string | undefined) {
-	if (!value || value.startsWith("--")) {
-		throw new Error(`${option} requires a value.`);
-	}
-
-	return value;
+export function parseToAdfOptions(args: string[]) {
+	return parseConversionOptions(args, "to-adf");
 }

--- a/packages/lib/src/ADFToMarkdown.ts
+++ b/packages/lib/src/ADFToMarkdown.ts
@@ -298,7 +298,9 @@ function renderTable(element: ADFEntity) {
 			alignments[column] = markdownAlignment;
 			const cellContent = renderChildren(tableCell);
 			if (typeof cellContent === "string") {
-				rowCells.push(cellContent.replace(/\|/g, "\\|").replace(/\n/g, "<br>"));
+				// Text is escaped before adding Markdown marks. Re-escaping the rendered
+				// cell would change backslashes and pipes inside inline code and links.
+				rowCells.push(cellContent.replace(/\n/g, "<br>"));
 			}
 		}
 		tableCells.push(rowCells);
@@ -349,12 +351,12 @@ function renderChildren(element: ADFEntity) {
 }
 
 function escapeMarkdownText(text: string): string {
-	return text.replace(/([\\`*_[\]<>~])/g, "\\$1");
+	return text.replace(/([\\`*_[\]<>~|])/g, "\\$1");
 }
 
 function markdownDestination(value: unknown): string {
-	return String(value).replace(/[\s<>()[\]\\]/g, (character) =>
-		encodeURIComponent(character).replace("(", "%28").replace(")", "%29"),
+	return String(value).replace(/[\s<>()[\]\\|]/g, (character) =>
+		encodeURIComponent(character).replaceAll("(", "%28").replaceAll(")", "%29"),
 	);
 }
 

--- a/packages/lib/src/ADFToMarkdown.ts
+++ b/packages/lib/src/ADFToMarkdown.ts
@@ -1,6 +1,6 @@
 import { ADFEntity } from "@atlaskit/adf-utils/dist/types/types";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
-import { Console, Effect } from "effect";
+import { fencedCode } from "./AdfDocument";
 import { markdownTable } from "markdown-table";
 
 export function renderADFDoc(adfDoc: JSONDocNode) {
@@ -27,10 +27,10 @@ export function renderADFDoc(adfDoc: JSONDocNode) {
 
 function renderTextMarks(element: ADFEntity) {
 	if (!element.marks || !element.text) {
-		return element.text;
+		return element.text ? escapeMarkdownText(element.text) : element.text;
 	}
 
-	let returnText = element.text;
+	let returnText = escapeMarkdownText(element.text);
 	for (const mark of element.marks) {
 		switch (mark.type) {
 			case "strong":
@@ -40,10 +40,10 @@ function renderTextMarks(element: ADFEntity) {
 				returnText = `*${returnText}*`;
 				break;
 			case "strike":
-				returnText = `~${returnText}~`;
+				returnText = `~~${returnText}~~`;
 				break;
 			case "code":
-				returnText = `\`${returnText}\``;
+				returnText = renderInlineCode(element.text);
 				break;
 			case "subsup": {
 				const subsupType = mark.attrs && mark.attrs["type"] ? mark.attrs["type"] : "sup";
@@ -51,8 +51,20 @@ function renderTextMarks(element: ADFEntity) {
 				break;
 			}
 			case "link": {
-				const linkHref = mark.attrs && mark.attrs["href"] ? mark.attrs["href"] : "#";
+				const linkHref = markdownDestination(mark.attrs?.["href"] ?? "#");
 				returnText = `[${returnText}](${linkHref})`;
+				break;
+			}
+			case "underline":
+				returnText = `<u>${returnText}</u>`;
+				break;
+			case "textColor":
+			case "backgroundColor": {
+				const color = mark.attrs?.["color"];
+				if (typeof color !== "string" || !/^#[\da-f]{3,8}$/i.test(color))
+					return new Error("Unsupported color");
+				const property = mark.type === "textColor" ? "color" : "background-color";
+				returnText = `<span style="${property}: ${color}">${returnText}</span>`;
 				break;
 			}
 			default:
@@ -67,6 +79,20 @@ function renderADFContent(
 	parent: ADFEntity,
 	currentIndex: number,
 ): string | Error | undefined {
+	if (
+		element.type !== "text" &&
+		element.marks?.length &&
+		!(
+			parent.type.startsWith("table") &&
+			element.marks.every((mark) => mark.type === "alignment")
+		)
+	)
+		return new Error("Block marks require ADF preservation");
+	if (element.type === "codeBlock")
+		return renderCodeBlock(
+			element.attrs?.["language"] ?? "",
+			(element.content ?? []).map((child) => child?.text ?? "").join(""),
+		);
 	const renderChildrenResult = renderChildren(element);
 	if (renderChildrenResult instanceof Error) {
 		return renderChildrenResult;
@@ -97,11 +123,6 @@ function renderADFContent(
 			const beforeText = "#".repeat(headingLevel);
 			return beforeText + " " + renderChildrenResult;
 		}
-		case "codeBlock": {
-			const language =
-				element.attrs && element.attrs["language"] ? element.attrs["language"] : "";
-			return renderCodeBlock(language, renderChildrenResult);
-		}
 		case "taskList":
 		case "bulletList":
 		case "orderedList": {
@@ -118,16 +139,18 @@ function renderADFContent(
 					break;
 				case "orderedList": {
 					const orderAttr =
-						element.attrs && element.attrs["order"]
-							? parseInt(element.attrs["order"])
-							: 1;
+						parent.attrs && parent.attrs["order"] ? parseInt(parent.attrs["order"]) : 1;
 					prefix = `${orderAttr + currentIndex}. `;
 					break;
 				}
 				default:
 					return new Error("Unhandled listItem parent");
 			}
-			return prefix + renderChildrenResult;
+			return (
+				prefix +
+				renderChildrenResult.trimEnd().replace(/\n/g, `\n${" ".repeat(prefix.length)}`) +
+				"\n"
+			);
 		}
 		case "blockquote": {
 			const result = renderChildrenResult
@@ -148,6 +171,7 @@ function renderADFContent(
 			const headerRow = `> [!${panelType}]\n`;
 			return headerRow + result;
 		}
+		case "nestedExpand":
 		case "expand": {
 			const title = element.attrs && element.attrs["title"] ? element.attrs["title"] : "info";
 			const result = renderChildrenResult
@@ -190,12 +214,38 @@ function renderADFContent(
 				shortName = `|${shortName.replaceAll(":", "")}`;
 			}
 
-			return `:${emojiId}${shortName}:`;
+			return emojiId
+				? `:${emojiId}${shortName}:`
+				: (element.attrs?.["text"] ?? element.attrs?.["shortName"] ?? "");
 		}
+		case "blockCard":
+		case "embedCard":
 		case "inlineCard": {
 			const inlineCardUrl =
 				element.attrs && element.attrs["url"] ? element.attrs["url"] : undefined;
-			return `[${inlineCardUrl}](${inlineCardUrl})`;
+			if (typeof inlineCardUrl !== "string")
+				return new Error("Card data requires ADF preservation");
+			return `[${escapeMarkdownText(inlineCardUrl)}](${markdownDestination(inlineCardUrl)})`;
+		}
+		case "status":
+			return `**${escapeMarkdownText(String(element.attrs?.["text"] ?? ""))}**`;
+		case "placeholder":
+			return escapeMarkdownText(String(element.attrs?.["text"] ?? ""));
+		case "caption":
+			return renderChildrenResult;
+		case "mediaSingle":
+		case "mediaGroup":
+			return (element.content ?? [])
+				.map((child, index) => renderADFContent(child!, element, index))
+				.join("\n\n");
+		case "media":
+		case "mediaInline":
+		case "image": {
+			const url = element.attrs?.["url"] ?? element.attrs?.["src"];
+			if (typeof url !== "string" || !url)
+				return new Error("Media IDs require ADF preservation");
+			const alt = escapeMarkdownText(String(element.attrs?.["alt"] ?? ""));
+			return `![${alt}](${markdownDestination(url.replace(/^file:\/\//, ""))})`;
 		}
 		case "table": {
 			return renderTable(element);
@@ -206,7 +256,6 @@ function renderADFContent(
 			return renderChildrenResult;
 		}
 		default:
-			Effect.runSync(Console.warn(`Unknown ADFEntity Type ${element.type}`));
 			return new Error(`Unknown ADFEntity Type ${element.type}`);
 	}
 }
@@ -218,30 +267,48 @@ function renderTable(element: ADFEntity) {
 
 	const tableCells: string[][] = [];
 
-	// TODO: Handle alignment
+	const alignments: ("left" | "right" | "center" | null)[] = [];
 	for (const tableRow of element.content) {
 		if (!tableRow || !tableRow.content) {
 			continue;
 		}
 
 		const rowCells: string[] = [];
-		for (const tableCell of tableRow.content) {
+		for (const [column, tableCell] of tableRow.content.entries()) {
 			if (!tableCell || !tableCell.content) {
 				continue;
 			}
+			if (
+				(tableCell.attrs?.["colspan"] ?? 1) !== 1 ||
+				(tableCell.attrs?.["rowspan"] ?? 1) !== 1
+			)
+				return new Error("Merged cells require ADF preservation");
+			const alignment = tableCell.content[0]?.marks?.find((mark) => mark.type === "alignment")
+				?.attrs?.["align"];
+			const markdownAlignment =
+				alignment === "end"
+					? "right"
+					: alignment === "center"
+						? "center"
+						: alignment === "start"
+							? "left"
+							: null;
+			if (alignments[column] !== undefined && alignments[column] !== markdownAlignment)
+				return new Error("Mixed column alignment requires ADF preservation");
+			alignments[column] = markdownAlignment;
 			const cellContent = renderChildren(tableCell);
 			if (typeof cellContent === "string") {
-				rowCells.push(cellContent);
+				rowCells.push(cellContent.replace(/\|/g, "\\|").replace(/\n/g, "<br>"));
 			}
 		}
 		tableCells.push(rowCells);
 	}
 
-	return markdownTable(tableCells);
+	return markdownTable(tableCells, { align: alignments });
 }
 
 function renderCodeBlock(language: string, code: string) {
-	return `\`\`\`${language} \n${code}\n\`\`\``;
+	return fencedCode(language, code);
 }
 
 function renderDate(timestamp: unknown) {
@@ -279,4 +346,22 @@ function renderChildren(element: ADFEntity) {
 	}
 	const result = lines.join("");
 	return result;
+}
+
+function escapeMarkdownText(text: string): string {
+	return text.replace(/([\\`*_[\]<>~])/g, "\\$1");
+}
+
+function markdownDestination(value: unknown): string {
+	return String(value).replace(/[\s<>()[\]\\]/g, (character) =>
+		encodeURIComponent(character).replace("(", "%28").replace(")", "%29"),
+	);
+}
+
+function renderInlineCode(text: string): string {
+	const marker = "`".repeat(
+		Math.max(1, ...(text.match(/`+/g) ?? []).map((run) => run.length + 1)),
+	);
+	const padding = /^[` ]|[` ]$/.test(text) ? " " : "";
+	return `${marker}${padding}${text}${padding}${marker}`;
 }

--- a/packages/lib/src/AdfConversion.test.ts
+++ b/packages/lib/src/AdfConversion.test.ts
@@ -1,0 +1,372 @@
+import { expect, test } from "@effect/vitest";
+import { convertADFToMarkdown } from "./AdfConversion";
+import { renderADFDoc } from "./ADFToMarkdown";
+import { adfCodeFence, readAdfDocument, type AdfValue } from "./AdfDocument";
+import { parseMarkdownToADF } from "./MdToADF";
+
+const baseUrl = "https://example.atlassian.net";
+const text = (value: string): AdfValue => ({ type: "text", text: value });
+const paragraph = (...content: AdfValue[]): AdfValue => ({ type: "paragraph", content });
+const document = (...content: AdfValue[]) => ({ type: "doc", version: 1, content });
+
+const richNodes: AdfValue[] = [
+	{ type: "blockCard", attrs: { url: "https://example.com/card", localId: "card" } },
+	{ type: "embedCard", attrs: { url: "https://example.com/embed", layout: "wide" } },
+	{
+		type: "mediaSingle",
+		attrs: { layout: "center", width: 65 },
+		content: [
+			{
+				type: "media",
+				attrs: {
+					type: "file",
+					id: "media-id",
+					collection: "attachments",
+					width: 640,
+					height: 480,
+				},
+			},
+			{ type: "caption", content: [text("The caption")] },
+		],
+	},
+	{
+		type: "mediaGroup",
+		content: [
+			{ type: "media", attrs: { type: "file", id: "pdf-id", collection: "attachments" } },
+		],
+	},
+	paragraph({
+		type: "mediaInline",
+		attrs: { id: "inline-id", collection: "attachments", type: "file" },
+	}),
+	paragraph({
+		type: "image",
+		attrs: { src: "https://example.com/image.png", alt: "Image", width: 42 },
+	}),
+	paragraph(
+		{ type: "date", attrs: { timestamp: "1788739200000" } },
+		text(" "),
+		{ type: "status", attrs: { text: "READY", color: "green", localId: "status" } },
+		text(" "),
+		{ type: "placeholder", attrs: { text: "Your name" } },
+	),
+	paragraph({ type: "emoji", attrs: { id: "1f92f", shortName: ":exploding_head:", text: "🤯" } }),
+	{
+		type: "decisionList",
+		attrs: { localId: "decisions" },
+		content: [
+			{
+				type: "decisionItem",
+				attrs: { localId: "decision", state: "DECIDED" },
+				content: [text("Ship it")],
+			},
+		],
+	},
+	{
+		type: "layoutSection",
+		content: [
+			{ type: "layoutColumn", attrs: { width: 50 }, content: [paragraph(text("Left"))] },
+			{ type: "layoutColumn", attrs: { width: 50 }, content: [paragraph(text("Right"))] },
+		],
+	},
+	{
+		type: "expand",
+		attrs: { title: "Outer" },
+		content: [
+			{
+				type: "nestedExpand",
+				attrs: { title: "Inner" },
+				content: [paragraph(text("Nested text"))],
+			},
+		],
+	},
+	{
+		type: "taskList",
+		attrs: { localId: "tasks" },
+		content: [
+			{
+				type: "taskItem",
+				attrs: { localId: "task", state: "DONE" },
+				content: [text("Finished")],
+			},
+		],
+	},
+	{
+		type: "table",
+		attrs: { layout: "wide" },
+		content: [
+			{
+				type: "tableRow",
+				content: [
+					{
+						type: "tableHeader",
+						attrs: {
+							colspan: 2,
+							rowspan: 1,
+							colwidth: [120, 200],
+							background: "#ffffff",
+						},
+						content: [paragraph(text("Merged"))],
+					},
+				],
+			},
+		],
+	},
+];
+
+for (const [index, node] of richNodes.entries()) {
+	test(`preserves rich ADF case ${index}: ${node.type} including IDs and attributes`, () => {
+		const original = document(node);
+		const markdown = convertADFToMarkdown(original, { baseUrl });
+		expect(parseMarkdownToADF(markdown, baseUrl)).toEqual(original);
+	});
+}
+
+for (const type of [
+	"unknownBlock",
+	"unsupportedBlock",
+	"unsupportedInline",
+	"confluenceUnsupportedBlock",
+	"confluenceUnsupportedInline",
+	"bodiedExtension",
+	"confluenceJiraIssue",
+	"extension",
+	"inlineExtension",
+]) {
+	test(`preserves ${type} through the existing adf fence format`, () => {
+		const original = document({
+			type,
+			attrs: {
+				extensionKey: "custom",
+				parameters: { originalValue: { nested: [1, "two"] } },
+			},
+			content: [paragraph(text("Extension content"))],
+		});
+		expect(parseMarkdownToADF(convertADFToMarkdown(original), baseUrl)).toEqual(original);
+	});
+}
+
+for (const type of [
+	"alignment",
+	"annotation",
+	"border",
+	"breakout",
+	"confluenceInlineComment",
+	"dataConsumer",
+	"fragment",
+	"indentation",
+	"textColor",
+	"backgroundColor",
+	"typeAheadQuery",
+	"underline",
+	"unsupportedMark",
+	"unsupportedNodeAttribute",
+]) {
+	test(`retains ${type} mark payloads instead of dropping them`, () => {
+		const original = document({
+			...paragraph(text("Marked")),
+			marks: [
+				{
+					type,
+					attrs: {
+						id: "comment-id",
+						align: "center",
+						level: 2,
+						color: "#ff0000",
+						originalValue: { retained: true },
+					},
+				},
+			],
+		});
+		expect(parseMarkdownToADF(convertADFToMarkdown(original), baseUrl)).toEqual(original);
+	});
+}
+
+test("uses readable Markdown for ordinary content and only fences the unsupported block", () => {
+	const original = document(
+		paragraph(text("Hello")),
+		{ type: "extension", attrs: { extensionKey: "toc" } },
+		paragraph(text("After")),
+	);
+	const markdown = convertADFToMarkdown(original);
+	expect(markdown.startsWith("Hello\n\n```adf\n")).toBe(true);
+	expect(markdown.endsWith("After")).toBe(true);
+	expect(parseMarkdownToADF(markdown, baseUrl)).toEqual(original);
+});
+
+test("restores full documents and nested raw blocks without a nested doc or normalization", () => {
+	const original = document({
+		type: "orderedList",
+		attrs: { order: 7 },
+		content: [{ type: "listItem", content: [paragraph(text("Seven"))] }],
+	});
+	expect(parseMarkdownToADF(adfCodeFence(original), baseUrl)).toEqual(original);
+	expect(
+		parseMarkdownToADF(`> ${adfCodeFence(original).replace(/\n/g, "\n> ")}`, baseUrl)
+			.content?.[0]?.content,
+	).toEqual(original.content);
+});
+
+test("fences remain reversible with backticks, empty paragraphs and unknown document attributes", () => {
+	const original = {
+		...document(
+			paragraph(),
+			{
+				type: "codeBlock",
+				attrs: { language: "adf" },
+				content: [text('{"type":"paragraph","content":[{"type":"text","text":"```"}]}')],
+			},
+			paragraph(),
+		),
+		attrs: { custom: "retained" },
+	};
+	expect(parseMarkdownToADF(convertADFToMarkdown(original), baseUrl)).toEqual(original);
+});
+
+test("invalid ADF examples stay code and invalid CLI documents fail clearly", () => {
+	for (const value of [null, 42, [], { type: "paragraph", content: [null] }, { type: "text" }]) {
+		expect(parseMarkdownToADF(adfCodeFence(value), baseUrl).content?.[0]?.type).toBe(
+			"codeBlock",
+		);
+		expect(() => readAdfDocument(value)).toThrow();
+	}
+	expect(() => readAdfDocument({ type: "doc", version: 2, content: [] })).toThrow();
+	expect(
+		readAdfDocument({
+			body: {
+				atlas_doc_format: {
+					value: JSON.stringify(document(paragraph(text("API response")))),
+				},
+			},
+		}),
+	).toEqual(document(paragraph(text("API response"))));
+});
+
+test("reads underline, subscript, superscript and nested color spans without enabling arbitrary HTML", () => {
+	const adf = parseMarkdownToADF(
+		'<u>Under</u> H<sub>2</sub>O x<sup>2</sup> <span style="color: #ff0000"><u>Red</u></span> `<u>Code</u>` <script>alert(1)</script>',
+		baseUrl,
+	);
+	const content = adf.content?.[0]?.content;
+	expect(content).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({ text: "Under", marks: [{ type: "underline" }] }),
+			expect.objectContaining({
+				text: "2",
+				marks: [{ type: "subsup", attrs: { type: "sub" } }],
+			}),
+			expect.objectContaining({
+				text: "2",
+				marks: [{ type: "subsup", attrs: { type: "sup" } }],
+			}),
+			expect.objectContaining({
+				text: "Red",
+				marks: expect.arrayContaining([
+					{ type: "underline" },
+					{ type: "textColor", attrs: { color: "#ff0000" } },
+				]),
+			}),
+			expect.objectContaining({ text: "<u>Code</u>", marks: [{ type: "code" }] }),
+		]),
+	);
+	expect(JSON.stringify(adf)).toContain("<script>alert(1)</script>");
+});
+
+test("preserves Markdown table column alignment and numbered list starting values", () => {
+	const adf = parseMarkdownToADF(
+		"| Left | Center | Right |\n| :--- | :---: | ---: |\n| A | B | C |\n\n7. Seven\n8. Eight",
+		baseUrl,
+	);
+	const table = adf.content?.[0];
+	expect(table?.content?.[0]?.content?.map((cell) => cell?.content?.[0]?.marks)).toEqual([
+		[{ type: "alignment", attrs: { align: "start" } }],
+		[{ type: "alignment", attrs: { align: "center" } }],
+		[{ type: "alignment", attrs: { align: "end" } }],
+	]);
+	expect(adf.content?.[1]?.attrs).toEqual({ order: 7 });
+	const markdown = renderADFDoc(adf);
+	expect(markdown).toContain("7. Seven\n8. Eight");
+	expect(markdown).toMatch(/\| :-+ \| :-+: \| -+: \|/);
+});
+
+test("readable export renders cards, media captions, status and dates", () => {
+	const markdown = convertADFToMarkdown(
+		document(
+			{ type: "blockCard", attrs: { url: "https://example.com" } },
+			{
+				type: "mediaSingle",
+				content: [
+					{
+						type: "media",
+						attrs: { type: "external", url: "https://example.com/image.png" },
+					},
+					{ type: "caption", content: [text("Caption")] },
+				],
+			},
+			paragraph({ type: "status", attrs: { text: "READY", color: "green" } }, text(" "), {
+				type: "date",
+				attrs: { timestamp: "0" },
+			}),
+		),
+		{ lossless: false },
+	);
+	expect(markdown).toContain("[https://example.com](https://example.com)");
+	expect(markdown).toContain("![](https://example.com/image.png)\n\nCaption");
+	expect(markdown).toContain("**READY** 1970-01-01");
+});
+
+test("escapes literal Markdown and uses longer code delimiters when needed", () => {
+	const adf = document(
+		paragraph(text("**literal** [link] <tag>"), { ...text("a`b"), marks: [{ type: "code" }] }),
+		{ type: "codeBlock", attrs: { language: "text" }, content: [text("```\n**raw**")] },
+	);
+	const markdown = renderADFDoc(readAdfDocument(adf));
+	expect(markdown).toContain("\\*\\*literal\\*\\* \\[link\\] \\<tag\\>");
+	expect(markdown).toContain("``a`b``");
+	expect(markdown).toContain("````text\n```\n**raw**\n````");
+});
+
+test("parses the established emoji identifier syntax and background color markup", () => {
+	const adf = parseMarkdownToADF(
+		':1f92f|exploding_head: <span style="background-color: #ffeeaa">Highlighted</span>',
+		baseUrl,
+	);
+	expect(adf.content?.[0]?.content).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				type: "emoji",
+				attrs: expect.objectContaining({ id: "1f92f", shortName: ":exploding_head:" }),
+			}),
+			expect.objectContaining({
+				text: "Highlighted",
+				marks: [{ type: "backgroundColor", attrs: { color: "#ffeeaa" } }],
+			}),
+		]),
+	);
+});
+
+test("lossless export retains Confluence link metadata even though publishing ignores it for equality", () => {
+	const original = document(
+		paragraph({
+			type: "text",
+			text: "Page",
+			marks: [
+				{
+					type: "link",
+					attrs: {
+						href: "https://example.atlassian.net/wiki/spaces/D/pages/123/Title",
+						__confluenceMetadata: {
+							isRenamedTitle: true,
+							linkType: "page",
+							contentTitle: "Title",
+							versionAtSave: "1",
+						},
+					},
+				},
+			],
+		}),
+	);
+	expect(parseMarkdownToADF(convertADFToMarkdown(original, { baseUrl }), baseUrl)).toEqual(
+		original,
+	);
+});

--- a/packages/lib/src/AdfConversion.test.ts
+++ b/packages/lib/src/AdfConversion.test.ts
@@ -289,6 +289,24 @@ test("preserves Markdown table column alignment and numbered list starting value
 	expect(markdown).toMatch(/\| :-+ \| :-+: \| -+: \|/);
 });
 
+test("formatting closing tags inside inline code and escaped text stay literal", () => {
+	const converted = parseMarkdownToADF("<u>Before `</u>` \\</u> after</u> outside", baseUrl);
+	expect(converted.content[0]?.content).toEqual([
+		{ ...text("Before "), marks: [{ type: "underline" }] },
+		{ ...text("</u>"), marks: [{ type: "code" }] },
+		{ ...text(" </u> after"), marks: [{ type: "underline" }] },
+		text(" outside"),
+	]);
+});
+
+test("readable media export preserves unsupported children as ADF, never error text", () => {
+	const original = document(richNodes[2]!);
+	const markdown = convertADFToMarkdown(original, { lossless: false });
+	expect(markdown).toContain("```adf");
+	expect(markdown).not.toContain("Error:");
+	expect(parseMarkdownToADF(markdown, baseUrl)).toEqual(original);
+});
+
 test("readable export renders cards, media captions, status and dates", () => {
 	const markdown = convertADFToMarkdown(
 		document(
@@ -313,6 +331,46 @@ test("readable export renders cards, media captions, status and dates", () => {
 	expect(markdown).toContain("[https://example.com](https://example.com)");
 	expect(markdown).toContain("![](https://example.com/image.png)\n\nCaption");
 	expect(markdown).toContain("**READY** 1970-01-01");
+});
+
+test("table export keeps literal backslashes, pipes, inline code and links in their cells", () => {
+	const cells = [
+		text("literal \\| pipe | and \\ backslash"),
+		{ ...text("code \\| and |"), marks: [{ type: "code" }] },
+		{
+			...text("label \\| and |"),
+			marks: [{ type: "link", attrs: { href: "https://example.com/a(b)(c)?q=a|b" } }],
+		},
+	];
+	const original = document({
+		type: "table",
+		content: [
+			{
+				type: "tableRow",
+				content: cells.map((cell) => ({ type: "tableHeader", content: [paragraph(cell)] })),
+			},
+		],
+	});
+	const markdown = renderADFDoc(readAdfDocument(original));
+	expect(markdown).not.toContain("```adf");
+	const converted = parseMarkdownToADF(markdown, baseUrl);
+	expect(
+		converted.content[0]?.content?.[0]?.content?.map((cell) => cell?.content?.[0]?.content),
+	).toEqual([
+		[cells[0]],
+		[cells[1]],
+		[
+			{
+				...text("label \\| and |"),
+				marks: [
+					{
+						type: "link",
+						attrs: { href: "https://example.com/a%28b%29%28c%29?q=a%7Cb" },
+					},
+				],
+			},
+		],
+	]);
 });
 
 test("escapes literal Markdown and uses longer code delimiters when needed", () => {
@@ -369,4 +427,30 @@ test("lossless export retains Confluence link metadata even though publishing ig
 	expect(parseMarkdownToADF(convertADFToMarkdown(original, { baseUrl }), baseUrl)).toEqual(
 		original,
 	);
+});
+
+test("parses formatting inside link labels and consumes closing-tag whitespace", () => {
+	const adf = parseMarkdownToADF(
+		'[<u>Underlined link</u>](https://example.com) <span style="color: #ff0000">Red</span >',
+		baseUrl,
+	);
+	expect(adf.content?.[0]?.content).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				text: "Underlined link",
+				marks: expect.arrayContaining([
+					{ type: "underline" },
+					expect.objectContaining({
+						type: "link",
+						attrs: expect.objectContaining({ href: "https://example.com" }),
+					}),
+				]),
+			}),
+			expect.objectContaining({
+				text: "Red",
+				marks: [{ type: "textColor", attrs: { color: "#ff0000" } }],
+			}),
+		]),
+	);
+	expect(JSON.stringify(adf)).not.toContain('"text":">"');
 });

--- a/packages/lib/src/AdfConversion.ts
+++ b/packages/lib/src/AdfConversion.ts
@@ -1,0 +1,48 @@
+import type { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import { renderADFDoc } from "./ADFToMarkdown";
+import { parseMarkdownToADF } from "./MdToADF";
+import { adfCodeFence, readAdfDocument } from "./AdfDocument";
+
+export type AdfToMarkdownOptions = {
+	/** Preserve all attributes, marks and extension payloads. Defaults to true. */
+	lossless?: boolean;
+	baseUrl?: string;
+};
+
+export function convertADFToMarkdown(input: unknown, options: AdfToMarkdownOptions = {}): string {
+	const document = readAdfDocument(input);
+	if (options.lossless === false) return renderADFDoc(document);
+	const baseUrl = options.baseUrl ?? "https://confluence.atlassian.com";
+	const blocks = (document.content ?? []).map((node) => {
+		const fragment = { version: 1, type: "doc", content: [node] } as JSONDocNode;
+		try {
+			const markdown = renderADFDoc(fragment);
+			return sameJson(parseMarkdownToADF(markdown, baseUrl), fragment)
+				? markdown.trimEnd()
+				: adfCodeFence(node);
+		} catch {
+			return adfCodeFence(node);
+		}
+	});
+	const markdown = blocks.join("\n\n");
+	// Adjacent lists, empty paragraphs and document metadata also need protection.
+	return sameJson(parseMarkdownToADF(markdown, baseUrl), document)
+		? markdown
+		: adfCodeFence(document);
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+	return JSON.stringify(canonicalJson(left)) === JSON.stringify(canonicalJson(right));
+}
+
+function canonicalJson(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalJson);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([key, child]) => [key, canonicalJson(child)]),
+		);
+	}
+	return value;
+}

--- a/packages/lib/src/AdfDocument.ts
+++ b/packages/lib/src/AdfDocument.ts
@@ -1,0 +1,104 @@
+import type { JSONDocNode } from "@atlaskit/editor-json-transformer";
+
+export type AdfValue = {
+	type: string;
+	attrs?: Record<string, unknown>;
+	content?: AdfValue[];
+	marks?: { type: string; attrs?: Record<string, unknown>; [key: string]: unknown }[];
+	text?: string;
+	[key: string]: unknown;
+};
+
+/** Validate structure without deleting extension nodes or attributes from newer schemas. */
+export function isAdfValue(value: unknown, depth = 0): value is AdfValue {
+	if (!isRecord(value) || depth > 100 || typeof value["type"] !== "string" || !value["type"])
+		return false;
+	if (value["attrs"] !== undefined && !isRecord(value["attrs"])) return false;
+	if (value["text"] !== undefined && typeof value["text"] !== "string") return false;
+	if (value["type"] === "text" && typeof value["text"] !== "string") return false;
+	if (
+		value["content"] !== undefined &&
+		(!Array.isArray(value["content"]) ||
+			!value["content"].every((child) => isAdfValue(child, depth + 1)))
+	)
+		return false;
+	if (
+		value["marks"] !== undefined &&
+		(!Array.isArray(value["marks"]) ||
+			!value["marks"].every(
+				(mark) =>
+					isRecord(mark) &&
+					typeof mark["type"] === "string" &&
+					(mark["attrs"] === undefined || isRecord(mark["attrs"])),
+			))
+	)
+		return false;
+	return true;
+}
+
+export function readAdfDocument(input: unknown): JSONDocNode {
+	let value = typeof input === "string" ? JSON.parse(input) : input;
+	if (isRecord(value) && isRecord(value["body"])) {
+		const body = value["body"]["atlas_doc_format"];
+		if (isRecord(body)) value = body["value"];
+	}
+	if (typeof value === "string") value = JSON.parse(value);
+	if (
+		!isAdfValue(value) ||
+		value.type !== "doc" ||
+		value["version"] !== 1 ||
+		!Array.isArray(value.content)
+	) {
+		throw new Error(
+			"Expected an ADF document with type 'doc', version 1, and a content array (or a Confluence response containing body.atlas_doc_format.value).",
+		);
+	}
+	return value as JSONDocNode;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function adfCodeFence(value: unknown): string {
+	return fencedCode("adf", JSON.stringify(value, null, 2));
+}
+
+export function fencedCode(language: string, code: string): string {
+	const runs = code.match(/`+/g) ?? [];
+	const marker = "`".repeat(Math.max(3, ...runs.map((run) => run.length + 1)));
+	return `${marker}${language.replace(/[\r\n`]/g, "")}\n${code}\n${marker}`;
+}
+
+/** Restore after Markdown normalization so raw ADF is never rewritten as Markdown. */
+export function restoreAdfCodeBlocks(document: JSONDocNode): JSONDocNode {
+	const restore = (node: AdfValue): AdfValue[] => {
+		if (node.type === "codeBlock" && node.attrs?.["language"] === "adf") {
+			try {
+				const value: unknown = JSON.parse(
+					(node.content ?? []).map((child) => child.text ?? "").join(""),
+				);
+				if (isAdfValue(value)) {
+					if (value.type === "doc") return readAdfDocument(value).content as AdfValue[];
+					return [value];
+				}
+			} catch {
+				/* Invalid examples remain ordinary fenced code. */
+			}
+			return [node];
+		}
+		return [{ ...node, ...(node.content ? { content: node.content.flatMap(restore) } : {}) }];
+	};
+	const onlyChild =
+		document.content?.length === 1 ? (document.content[0] as AdfValue) : undefined;
+	if (onlyChild?.type === "codeBlock" && onlyChild.attrs?.["language"] === "adf") {
+		try {
+			return readAdfDocument(
+				(onlyChild.content ?? []).map((child) => child?.text ?? "").join(""),
+			);
+		} catch {
+			/* A single node fence is handled below. */
+		}
+	}
+	return restore(document as AdfValue)[0] as JSONDocNode;
+}

--- a/packages/lib/src/AdfEqual.test.ts
+++ b/packages/lib/src/AdfEqual.test.ts
@@ -126,3 +126,47 @@ test("ignores redundant server image width while retaining explicit resizing", (
 	expect(adfEqual(media(160), media())).toBe(true);
 	expect(adfEqual(media(80), media())).toBe(false);
 });
+
+test("ignores asynchronous Confluence link metadata without changing input or authored link fields", () => {
+	const original: ADFEntity = {
+		type: "doc",
+		version: 1,
+		content: [
+			{
+				type: "paragraph",
+				content: [
+					{
+						type: "text",
+						text: "Child page",
+						marks: [
+							{
+								type: "link",
+								attrs: {
+									href: "https://example.atlassian.net/wiki/spaces/D/pages/123#Heading",
+									title: "Authored title",
+								},
+							},
+						],
+					},
+				],
+			},
+		],
+	};
+	const stored = structuredClone(original);
+	const attrs = stored.content![0]!.content![0]!.marks![0]!.attrs!;
+	attrs["href"] = "https://example.atlassian.net/wiki/spaces/D/pages/123/Page+Title#Heading";
+	attrs["__confluenceMetadata"] = {
+		isRenamedTitle: true,
+		linkType: "page",
+		contentTitle: "Page Title",
+		versionAtSave: "1",
+		anchorName: "Heading",
+	};
+	expect(adfEqual(original, stored)).toBe(true);
+	expect(attrs["__confluenceMetadata"]).toBeDefined();
+	attrs["title"] = "Changed authored title";
+	expect(adfEqual(original, stored)).toBe(false);
+	attrs["title"] = "Authored title";
+	attrs["href"] = "https://example.atlassian.net/wiki/spaces/D/pages/123#Another-heading";
+	expect(adfEqual(original, stored)).toBe(false);
+});

--- a/packages/lib/src/AdfEqual.ts
+++ b/packages/lib/src/AdfEqual.ts
@@ -41,6 +41,10 @@ export function normalizeAdfForComparison(adf: ADFEntity): ADFEntity {
 			for (const mark of node.marks ?? []) {
 				if (mark.type === "link" && typeof mark.attrs?.["href"] === "string") {
 					mark.attrs["href"] = canonicalConfluencePageLink(mark.attrs["href"]);
+					// Confluence asynchronously adds the target title/version it resolved.
+					// This cache is not an authored link change. Keep it in exports, but
+					// ignore it when deciding whether an unchanged page needs an update.
+					delete mark.attrs["__confluenceMetadata"];
 				}
 			}
 			// Confluence writes the default pixel display width onto media wrappers.

--- a/packages/lib/src/ConfluencePage.test.ts
+++ b/packages/lib/src/ConfluencePage.test.ts
@@ -75,10 +75,38 @@ test("reports failed reads without exposing transport headers or credentials", a
 			},
 		} as unknown as RequiredConfluenceClient),
 	);
-	await expect(Effect.runPromise(fetchConfluencePageAdf(readSettings, "123"))).rejects.toThrow(
-		"Unable to read Confluence page 123 (HTTP 403)",
-	);
+	await expect(
+		Effect.runPromise(fetchConfluencePageAdf(readSettings, "123")),
+	).rejects.toMatchObject({
+		message:
+			"Unable to read Confluence page 123 (HTTP 403). Check the configured site, authentication and page permissions.",
+	});
 });
+
+for (const confluenceAuthType of ["basic", "bearer", "oauth2"] as const) {
+	test(`rejects HTTP before creating a ${confluenceAuthType} client or requesting tokens`, async () => {
+		const createClient = vi
+			.spyOn(authentication, "createAuthenticatedConfluenceClient")
+			.mockReturnValue(Effect.die("Client must not be created"));
+		await expect(
+			Effect.runPromise(
+				fetchConfluencePageAdf(
+					{
+						...readSettings,
+						confluenceBaseUrl: "http://example.atlassian.net",
+						confluenceAuthType,
+						atlassianClientId: "test-client",
+						atlassianClientSecret: "test-secret",
+					},
+					"123",
+				),
+			),
+		).rejects.toMatchObject({
+			message: "Confluence page reads require an HTTPS base URL to protect credentials.",
+		});
+		expect(createClient).not.toHaveBeenCalled();
+	});
+}
 
 test("rejects invalid connection settings before creating an authenticated client", async () => {
 	const createClient = vi

--- a/packages/lib/src/ConfluencePage.test.ts
+++ b/packages/lib/src/ConfluencePage.test.ts
@@ -9,6 +9,12 @@ import type { RequiredConfluenceClient } from "./ConfluenceClient";
 afterEach(() => vi.restoreAllMocks());
 
 const site = "https://example.atlassian.net";
+const readSettings = {
+	...DEFAULT_SETTINGS,
+	confluenceBaseUrl: site,
+	atlassianUserName: "tester@example.com",
+	atlassianApiToken: "test-token",
+};
 
 test("connection-only configuration requires no publishing parent or folder", async () => {
 	const settings = await Effect.runPromise(
@@ -42,7 +48,7 @@ test("reads ADF through the configured authenticated client without mutating con
 	vi.spyOn(authentication, "createAuthenticatedConfluenceClient").mockReturnValue(
 		Effect.succeed({ content: { getContentById } } as unknown as RequiredConfluenceClient),
 	);
-	const settings = { ...DEFAULT_SETTINGS, confluenceBaseUrl: site };
+	const settings = readSettings;
 	expect(
 		await Effect.runPromise(
 			fetchConfluencePageAdf(settings, `${site}/wiki/spaces/D/pages/123/Title`),
@@ -69,11 +75,27 @@ test("reports failed reads without exposing transport headers or credentials", a
 			},
 		} as unknown as RequiredConfluenceClient),
 	);
+	await expect(Effect.runPromise(fetchConfluencePageAdf(readSettings, "123"))).rejects.toThrow(
+		"Unable to read Confluence page 123 (HTTP 403)",
+	);
+});
+
+test("rejects invalid connection settings before creating an authenticated client", async () => {
+	const createClient = vi
+		.spyOn(authentication, "createAuthenticatedConfluenceClient")
+		.mockReturnValue(Effect.die("Client must not be created"));
 	await expect(
 		Effect.runPromise(
-			fetchConfluencePageAdf({ ...DEFAULT_SETTINGS, confluenceBaseUrl: site }, "123"),
+			fetchConfluencePageAdf(
+				{
+					...readSettings,
+					confluenceBaseUrl: "file:///tmp/confluence",
+				},
+				"123",
+			),
 		),
-	).rejects.toThrow("Unable to read Confluence page 123 (HTTP 403)");
+	).rejects.toThrow(/https/i);
+	expect(createClient).not.toHaveBeenCalled();
 });
 
 test("reads canonical, legacy and overview Confluence page references", () => {

--- a/packages/lib/src/ConfluencePage.test.ts
+++ b/packages/lib/src/ConfluencePage.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, expect, test, vi } from "@effect/vitest";
+import { ConfigProvider, Effect } from "effect";
+import { fetchConfluencePageAdf, resolveConfluencePageId } from "./ConfluencePage";
+import * as authentication from "./AuthenticatedConfluenceClient";
+import { confluenceReadSettingsConfig } from "./SettingsConfig";
+import { DEFAULT_SETTINGS } from "./Settings";
+import type { RequiredConfluenceClient } from "./ConfluenceClient";
+
+afterEach(() => vi.restoreAllMocks());
+
+const site = "https://example.atlassian.net";
+
+test("connection-only configuration requires no publishing parent or folder", async () => {
+	const settings = await Effect.runPromise(
+		confluenceReadSettingsConfig.parse(
+			ConfigProvider.fromUnknown({
+				confluenceBaseUrl: site,
+				confluenceParentId: "",
+				folderToPublish: null,
+				atlassianUserName: "tester",
+				atlassianApiToken: "test-token",
+			}),
+		),
+	);
+	expect(settings).toMatchObject({
+		confluenceBaseUrl: site,
+		confluenceParentId: "",
+		atlassianUserName: "tester",
+		atlassianApiToken: "test-token",
+	});
+});
+
+test("reads ADF through the configured authenticated client without mutating content", async () => {
+	const adf = {
+		type: "doc",
+		version: 1,
+		content: [{ type: "paragraph", content: [{ type: "text", text: "Remote page" }] }],
+	};
+	const getContentById = vi
+		.fn()
+		.mockResolvedValue({ body: { atlas_doc_format: { value: JSON.stringify(adf) } } });
+	vi.spyOn(authentication, "createAuthenticatedConfluenceClient").mockReturnValue(
+		Effect.succeed({ content: { getContentById } } as unknown as RequiredConfluenceClient),
+	);
+	const settings = { ...DEFAULT_SETTINGS, confluenceBaseUrl: site };
+	expect(
+		await Effect.runPromise(
+			fetchConfluencePageAdf(settings, `${site}/wiki/spaces/D/pages/123/Title`),
+		),
+	).toEqual(adf);
+	expect(getContentById).toHaveBeenCalledExactlyOnceWith({
+		id: "123",
+		expand: ["body.atlas_doc_format"],
+	});
+	expect(authentication.createAuthenticatedConfluenceClient).toHaveBeenCalledExactlyOnceWith(
+		settings,
+	);
+});
+
+test("reports failed reads without exposing transport headers or credentials", async () => {
+	vi.spyOn(authentication, "createAuthenticatedConfluenceClient").mockReturnValue(
+		Effect.succeed({
+			content: {
+				getContentById: () =>
+					Promise.reject({
+						response: { status: 403 },
+						config: { headers: { Authorization: "do-not-print" } },
+					}),
+			},
+		} as unknown as RequiredConfluenceClient),
+	);
+	await expect(
+		Effect.runPromise(
+			fetchConfluencePageAdf({ ...DEFAULT_SETTINGS, confluenceBaseUrl: site }, "123"),
+		),
+	).rejects.toThrow("Unable to read Confluence page 123 (HTTP 403)");
+});
+
+test("reads canonical, legacy and overview Confluence page references", () => {
+	for (const reference of [
+		"123",
+		`${site}/wiki/spaces/D/pages/123/Title#heading`,
+		`${site}/wiki/pages/viewpage.action?pageId=123`,
+		`${site}/wiki/spaces/D/overview?homepageId=123`,
+	]) {
+		expect(resolveConfluencePageId(reference, site)).toBe("123");
+	}
+});
+
+test("rejects a different site, credentials in URLs and ambiguous share links", () => {
+	for (const reference of [
+		"https://elsewhere.example/wiki/spaces/D/pages/123",
+		"https://example.atlassian.net.evil.example/wiki/spaces/D/pages/123",
+		"https://user:password@example.atlassian.net/wiki/spaces/D/pages/123",
+		`${site}/wiki/x/abc`,
+		`${site}/wiki/spaces/D/pages/abc`,
+		`${site}/wiki/pages/viewpage.action?pageId=1/2`,
+		"not-a-page",
+	]) {
+		expect(() => resolveConfluencePageId(reference, site)).toThrow();
+	}
+});

--- a/packages/lib/src/ConfluencePage.ts
+++ b/packages/lib/src/ConfluencePage.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { createAuthenticatedConfluenceClient } from "./AuthenticatedConfluenceClient";
 import { readAdfDocument } from "./AdfDocument";
-import { resolveSiteUrl, type ConfluenceSettings } from "./Settings";
+import { resolveSiteUrl, validateConfluenceSettings, type ConfluenceSettings } from "./Settings";
 
 export function resolveConfluencePageId(reference: string, siteUrl: string): string {
 	if (/^\d+$/.test(reference)) return reference;
@@ -29,6 +29,12 @@ export function resolveConfluencePageId(reference: string, siteUrl: string): str
 /** Read only: uses the configured client, never sends credentials to the input URL. */
 export function fetchConfluencePageAdf(settings: ConfluenceSettings, reference: string) {
 	return Effect.gen(function* () {
+		const issues = validateConfluenceSettings(settings).issues.filter(
+			(issue) =>
+				!["confluenceParentId", "folderToPublish", "contentRoot"].includes(issue.field),
+		);
+		if (issues.length)
+			return yield* Effect.fail(new Error(issues.map((issue) => issue.message).join("\n")));
 		const id = yield* Effect.try({
 			try: () => resolveConfluencePageId(reference, resolveSiteUrl(settings)),
 			catch: toError,

--- a/packages/lib/src/ConfluencePage.ts
+++ b/packages/lib/src/ConfluencePage.ts
@@ -35,6 +35,12 @@ export function fetchConfluencePageAdf(settings: ConfluenceSettings, reference: 
 		);
 		if (issues.length)
 			return yield* Effect.fail(new Error(issues.map((issue) => issue.message).join("\n")));
+		if (new URL(settings.confluenceBaseUrl).protocol !== "https:")
+			return yield* Effect.fail(
+				new Error(
+					"Confluence page reads require an HTTPS base URL to protect credentials.",
+				),
+			);
 		const id = yield* Effect.try({
 			try: () => resolveConfluencePageId(reference, resolveSiteUrl(settings)),
 			catch: toError,

--- a/packages/lib/src/ConfluencePage.ts
+++ b/packages/lib/src/ConfluencePage.ts
@@ -1,0 +1,54 @@
+import { Effect } from "effect";
+import { createAuthenticatedConfluenceClient } from "./AuthenticatedConfluenceClient";
+import { readAdfDocument } from "./AdfDocument";
+import { resolveSiteUrl, type ConfluenceSettings } from "./Settings";
+
+export function resolveConfluencePageId(reference: string, siteUrl: string): string {
+	if (/^\d+$/.test(reference)) return reference;
+	let url: URL;
+	try {
+		url = new URL(reference);
+	} catch {
+		throw new Error("Expected a numeric Confluence page ID or a full page URL.");
+	}
+	if (url.origin !== new URL(siteUrl).origin || url.username || url.password) {
+		throw new Error("The Confluence page URL must belong to the configured Confluence site.");
+	}
+	const pageId =
+		url.pathname.match(/\/pages\/(\d+)(?:\/|$)/)?.[1] ??
+		(url.pathname.endsWith("/viewpage.action") ? url.searchParams.get("pageId") : null) ??
+		(url.pathname.endsWith("/overview") ? url.searchParams.get("homepageId") : null);
+	if (!pageId || !/^\d+$/.test(pageId)) {
+		throw new Error(
+			"This URL does not contain a Confluence page ID. Use the full page URL or --page ID (short share links are not supported).",
+		);
+	}
+	return pageId;
+}
+
+/** Read only: uses the configured client, never sends credentials to the input URL. */
+export function fetchConfluencePageAdf(settings: ConfluenceSettings, reference: string) {
+	return Effect.gen(function* () {
+		const id = yield* Effect.try({
+			try: () => resolveConfluencePageId(reference, resolveSiteUrl(settings)),
+			catch: toError,
+		});
+		const client = yield* createAuthenticatedConfluenceClient(settings);
+		const page = yield* Effect.tryPromise({
+			try: () => client.content.getContentById({ id, expand: ["body.atlas_doc_format"] }),
+			catch: (error) => {
+				const status =
+					(error as { response?: { status?: number }; status?: number })?.response
+						?.status ?? (error as { status?: number })?.status;
+				return new Error(
+					`Unable to read Confluence page ${id}${status ? ` (HTTP ${status})` : ""}. Check the configured site, authentication and page permissions.`,
+				);
+			},
+		});
+		return yield* Effect.try({ try: () => readAdfDocument(page), catch: toError });
+	});
+}
+
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/lib/src/MarkdownTransformer/formatting.ts
+++ b/packages/lib/src/MarkdownTransformer/formatting.ts
@@ -1,10 +1,39 @@
 import type MarkdownIt from "markdown-it";
 import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
+import type Token from "markdown-it/lib/token.mjs";
 
 /** A small formatting allowlist; HTML execution remains disabled. */
 export default function formattingPlugin(markdown: MarkdownIt): void {
 	markdown.inline.ruler.before("emphasis", "confluence_formatting", formatting);
 	markdown.inline.ruler.before("emphasis", "confluence_emoji", emoji);
+	markdown.core.ruler.push("confluence_code_marks", (state) => {
+		for (const block of state.tokens) {
+			if (!block.children) continue;
+			const activeMarks: Token[] = [];
+			const children: Token[] = [];
+			for (const token of block.children) {
+				// The ADF code mark excludes formatting marks. Close and reopen the
+				// surrounding marks so ProseMirror does not also drop them after code.
+				if (token.type === "code_inline") {
+					for (const open of [...activeMarks].reverse())
+						children.push(
+							new state.Token(open.type.replace(/_open$/, "_close"), open.tag, -1),
+						);
+					children.push(
+						token,
+						...activeMarks.map((open) =>
+							Object.assign(new state.Token(open.type, open.tag, 1), open),
+						),
+					);
+					continue;
+				}
+				if (token.nesting === 1) activeMarks.push(token);
+				if (token.nesting === -1) activeMarks.pop();
+				children.push(token);
+			}
+			block.children = children;
+		}
+	});
 }
 
 function formatting(state: StateInline, silent: boolean): boolean {
@@ -20,9 +49,12 @@ function formatting(state: StateInline, silent: boolean): boolean {
 	);
 	if (!open) return false;
 	const tag = open[1]?.toLowerCase() ?? "span";
-	const close = findClosingTag(source, tag, open[0].length);
-	if (close === -1) return false;
-	if (silent) return true;
+	const close = findClosingTag(state, tag, open[0].length);
+	if (!close) return false;
+	if (silent) {
+		state.pos += close.end;
+		return true;
+	}
 	const tokenType =
 		tag === "u"
 			? "underline"
@@ -37,23 +69,45 @@ function formatting(state: StateInline, silent: boolean): boolean {
 	const end = state.posMax;
 	const start = state.pos;
 	state.pos += open[0].length;
-	state.posMax = start + close;
+	state.posMax = start + close.index;
 	state.md.inline.tokenize(state);
 	state.push(`${tokenType}_close`, tag, -1);
-	state.pos = start + close + tag.length + 3;
+	state.pos = start + close.end;
 	state.posMax = end;
 	return true;
 }
 
-function findClosingTag(source: string, tag: string, start: number): number {
-	const tags = new RegExp(`<(/?)${tag}(?:\\s[^>]*|)>`, "gi");
-	tags.lastIndex = start;
+function findClosingTag(
+	state: StateInline,
+	tag: string,
+	start: number,
+): { index: number; end: number } | undefined {
+	const tags = new RegExp(`<(/?)${tag}(?:\\s[^>]*|)>`, "iy");
+	const originalPosition = state.pos;
 	let depth = 1;
-	for (let match = tags.exec(source); match; match = tags.exec(source)) {
-		depth += match[1] ? -1 : 1;
-		if (depth === 0) return match.index;
+	state.pos += start;
+	try {
+		while (state.pos < state.posMax) {
+			tags.lastIndex = state.pos;
+			const match = tags.exec(state.src);
+			if (match) {
+				depth += match[1] ? -1 : 1;
+				if (depth === 0)
+					return {
+						index: match.index - originalPosition,
+						end: tags.lastIndex - originalPosition,
+					};
+				state.pos = tags.lastIndex;
+			} else {
+				// Use the same tokenizer as Markdown so code spans, escapes and link
+				// destinations cannot accidentally close an outer formatting tag.
+				state.md.inline.skipToken(state);
+			}
+		}
+	} finally {
+		state.pos = originalPosition;
 	}
-	return -1;
+	return undefined;
 }
 
 function emoji(state: StateInline, silent: boolean): boolean {

--- a/packages/lib/src/MarkdownTransformer/formatting.ts
+++ b/packages/lib/src/MarkdownTransformer/formatting.ts
@@ -1,0 +1,69 @@
+import type MarkdownIt from "markdown-it";
+import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
+
+/** A small formatting allowlist; HTML execution remains disabled. */
+export default function formattingPlugin(markdown: MarkdownIt): void {
+	markdown.inline.ruler.before("emphasis", "confluence_formatting", formatting);
+	markdown.inline.ruler.before("emphasis", "confluence_emoji", emoji);
+}
+
+function formatting(state: StateInline, silent: boolean): boolean {
+	const source = state.src.slice(state.pos, state.posMax);
+	const lineBreak = source.match(/^<br\s*\/?\s*>/i);
+	if (lineBreak) {
+		if (!silent) state.push("hardbreak", "br", 0);
+		state.pos += lineBreak[0].length;
+		return true;
+	}
+	const open = source.match(
+		/^<(u|sub|sup)>|^<span\s+style="(color|background-color):\s*(#[\da-f]{3,8});?\s*">/i,
+	);
+	if (!open) return false;
+	const tag = open[1]?.toLowerCase() ?? "span";
+	const close = findClosingTag(source, tag, open[0].length);
+	if (close === -1) return false;
+	if (silent) return true;
+	const tokenType =
+		tag === "u"
+			? "underline"
+			: tag === "span"
+				? open[2]?.toLowerCase() === "color"
+					? "text_color"
+					: "background_color"
+				: "subsup";
+	const token = state.push(`${tokenType}_open`, tag, 1);
+	if (tag === "span") token.attrSet("color", open[3]!);
+	if (tag === "sub" || tag === "sup") token.attrSet("type", tag);
+	const end = state.posMax;
+	const start = state.pos;
+	state.pos += open[0].length;
+	state.posMax = start + close;
+	state.md.inline.tokenize(state);
+	state.push(`${tokenType}_close`, tag, -1);
+	state.pos = start + close + tag.length + 3;
+	state.posMax = end;
+	return true;
+}
+
+function findClosingTag(source: string, tag: string, start: number): number {
+	const tags = new RegExp(`<(/?)${tag}(?:\\s[^>]*|)>`, "gi");
+	tags.lastIndex = start;
+	let depth = 1;
+	for (let match = tags.exec(source); match; match = tags.exec(source)) {
+		depth += match[1] ? -1 : 1;
+		if (depth === 0) return match.index;
+	}
+	return -1;
+}
+
+function emoji(state: StateInline, silent: boolean): boolean {
+	const match = state.src.slice(state.pos, state.posMax).match(/^:([\w-]+)\|([\w-]+):/);
+	if (!match) return false;
+	if (!silent) {
+		const token = state.push("confluence_emoji", "", 0);
+		token.attrSet("id", match[1]!);
+		token.attrSet("shortName", `:${match[2]}:`);
+	}
+	state.pos += match[0].length;
+	return true;
+}

--- a/packages/lib/src/MarkdownTransformer/index.ts
+++ b/packages/lib/src/MarkdownTransformer/index.ts
@@ -9,6 +9,7 @@ import { markdownItMedia } from "./media";
 import myTokenizer from "./callout";
 import wikilinksPlugin from "./wikilinks";
 import highlightPlugin from "./highlight";
+import formattingPlugin from "./formatting";
 
 interface Transformer<T> {
 	encode(node: PMNode): T;
@@ -56,6 +57,18 @@ const pmSchemaToMdMapping: SchemaMapping = {
 };
 
 const mdToPmMapping = {
+	alignment: { mark: "alignment", attrs: (token: any) => ({ align: token.attrGet("align") }) },
+	underline: { mark: "underline" },
+	subsup: { mark: "subsup", attrs: (token: any) => ({ type: token.attrGet("type") }) },
+	text_color: { mark: "textColor", attrs: (token: any) => ({ color: token.attrGet("color") }) },
+	background_color: {
+		mark: "backgroundColor",
+		attrs: (token: any) => ({ color: token.attrGet("color") }),
+	},
+	confluence_emoji: {
+		node: "emoji",
+		attrs: (token: any) => ({ id: token.attrGet("id"), shortName: token.attrGet("shortName") }),
+	},
 	blockquote: { block: "blockquote" },
 	paragraph: { block: "paragraph" },
 	em: { mark: "em" },
@@ -79,7 +92,7 @@ const mdToPmMapping = {
 	bullet_list: { block: "bulletList" },
 	ordered_list: {
 		block: "orderedList",
-		attrs: (tok: any) => ({ order: +tok.attrGet("order") || 1 }),
+		attrs: (tok: any) => ({ order: +tok.attrGet("start") || 1 }),
 	},
 	code_inline: { mark: "code" },
 	fence: {
@@ -162,6 +175,7 @@ export class MarkdownTransformer implements Transformer<Markdown> {
 
 		tokenizer.use(wikilinksPlugin);
 		tokenizer.use(highlightPlugin);
+		tokenizer.use(formattingPlugin);
 
 		(["nodes", "marks"] as (keyof SchemaMapping)[]).forEach((key) => {
 			for (const idx in pmSchemaToMdMapping[key]) {
@@ -174,6 +188,38 @@ export class MarkdownTransformer implements Transformer<Markdown> {
 
 		if (schema.nodes["table"]) {
 			tokenizer.use(markdownItTable);
+			tokenizer.core.ruler.push("table_alignment", (state) => {
+				for (let index = 0; index < state.tokens.length; index++) {
+					const token = state.tokens[index]!;
+					if (token.type !== "th_open" && token.type !== "td_open") continue;
+					const alignment = token
+						.attrGet("style")
+						?.match(/text-align:\s*(left|right|center)/)?.[1];
+					const paragraph = state.tokens[index + 1];
+					if (alignment && paragraph?.type === "paragraph_open") {
+						const open = new state.Token("alignment_open", "", 1);
+						open.attrSet(
+							"align",
+							alignment === "right"
+								? "end"
+								: alignment === "left"
+									? "start"
+									: "center",
+						);
+						state.tokens.splice(index + 1, 0, open);
+						const closeIndex = state.tokens.findIndex(
+							(candidate, position) =>
+								position > index + 1 && candidate.type === "paragraph_close",
+						);
+						if (closeIndex !== -1)
+							state.tokens.splice(
+								closeIndex + 1,
+								0,
+								new state.Token("alignment_close", "", -1),
+							);
+					}
+				}
+			});
 		}
 
 		if (schema.nodes["media"] && schema.nodes["mediaSingle"]) {

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -4,7 +4,7 @@ import { traverse } from "@atlaskit/adf-utils/traverse";
 import { MarkdownFile } from "./MarkdownWorkspace";
 import { LocalAdfFile } from "./Publisher";
 import { processConniePerPageConfig } from "./ConniePageConfig";
-import { p } from "@atlaskit/adf-utils/builders";
+import { restoreAdfCodeBlocks } from "./AdfDocument";
 import { MarkdownToConfluenceCodeBlockLanguageMap } from "./CodeBlockLanguageMap";
 import { isSafeUrl } from "@atlaskit/adf-schema";
 import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
@@ -140,7 +140,7 @@ function parsePageFragmentToADF(
 			}),
 		}) as JSONDocNode;
 	}
-	return replaceSupportedMacroPlaceholders(nodes, pageFragment);
+	return restoreAdfCodeBlocks(replaceSupportedMacroPlaceholders(nodes, pageFragment));
 }
 
 function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
@@ -212,15 +212,15 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 			return node;
 		},
 		tableHeader: (node, _parent) => {
-			node.attrs = { colspan: 1, rowspan: 1, colwidth: [340] };
+			node.attrs = { colspan: 1, rowspan: 1, colwidth: [340], ...node.attrs };
 			return node;
 		},
 		tableCell: (node, _parent) => {
-			node.attrs = { colspan: 1, rowspan: 1, colwidth: [340] };
+			node.attrs = { colspan: 1, rowspan: 1, colwidth: [340], ...node.attrs };
 			return node;
 		},
 		orderedList: (node, _parent) => {
-			node.attrs = { order: 1 };
+			node.attrs = { ...node.attrs, order: node.attrs?.["order"] ?? 1 };
 			return node;
 		},
 		codeBlock: (node, _parent) => {
@@ -238,22 +238,6 @@ function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
 			if (codeBlockLanguage in MarkdownToConfluenceCodeBlockLanguageMap) {
 				node.attrs["language"] =
 					MarkdownToConfluenceCodeBlockLanguageMap[codeBlockLanguage];
-			}
-
-			if (codeBlockLanguage === "adf") {
-				if (!node?.content?.at(0)?.text) {
-					return node;
-				}
-				try {
-					const parsedAdf = JSON.parse(
-						node?.content?.at(0)?.text ??
-							JSON.stringify(p("ADF missing from ADF Code Block.")),
-					);
-					node = parsedAdf;
-					return node;
-				} catch {
-					return node;
-				}
 			}
 
 			return node;

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -25,12 +25,11 @@ type ArgumentDefinition = {
 
 type ArgumentValue = boolean | string | undefined;
 
-export const confluenceSettingsConfig = Config.all({
+const confluenceConnectionFields = {
 	confluenceBaseUrl: Config.string("confluenceBaseUrl"),
 	confluenceSiteUrl: Config.string("confluenceSiteUrl").pipe(
 		Config.withDefault(DEFAULT_SETTINGS.confluenceSiteUrl),
 	),
-	confluenceParentId: Config.string("confluenceParentId"),
 	mermaidProtocolTimeout: Config.number("mermaidProtocolTimeout").pipe(
 		Config.withDefault(DEFAULT_SETTINGS.mermaidProtocolTimeout),
 	),
@@ -49,6 +48,15 @@ export const confluenceSettingsConfig = Config.all({
 		Config.Record(Schema.String, Schema.String),
 		"confluenceRequestHeaders",
 	).pipe(Config.withDefault(DEFAULT_SETTINGS.confluenceRequestHeaders)),
+};
+
+export const confluenceReadSettingsConfig = Config.all(confluenceConnectionFields).pipe(
+	Config.map((connection) => ({ ...DEFAULT_SETTINGS, ...connection })),
+);
+
+export const confluenceSettingsConfig = Config.all({
+	...confluenceConnectionFields,
+	confluenceParentId: Config.string("confluenceParentId"),
 	folderToPublish: Config.string("folderToPublish"),
 	tagsToPublish: Config.string("tagsToPublish").pipe(
 		Config.withDefault(DEFAULT_SETTINGS.tagsToPublish),

--- a/packages/lib/src/__snapshots__/ADFToMarkdown.test.ts.snap
+++ b/packages/lib/src/__snapshots__/ADFToMarkdown.test.ts.snap
@@ -11,14 +11,15 @@ exports[`ADF To Markdown Test 1`] = `
 2023-05-05
 
 | **Testing** | **Testing 2** | **Testing 3** |
-| ----------- | ------------- | ------------- |
-| Row 1       | Row 1.2       | Row 1.3       |
-| Row 2.1     | Row 2.2       | Row 2.3       |
+| ----------- | ------------: | ------------- |
+| Row 1       |       Row 1.2 | Row 1.3       |
+| Row 2.1     |       Row 2.2 | Row 2.3       |
 Testing [*TESTING*](https://www.google.com/webmasters/tools/siteoverview)
 Testing **New** Line
 
-sdfsdf
-
+\`\`\`adf
+{"type":"paragraph","marks":[{"type":"indentation","attrs":{"level":1}}],"content":[{"text":"sdfsdf","type":"text"}]}
+\`\`\`
 
 
 ***TESTING***
@@ -44,7 +45,7 @@ TESTING BELOW
 ###### **Heading 6**
 
 
-\`\`\`ada 
+\`\`\`ada
 TESTING CODE
 \`\`\`
 
@@ -82,7 +83,7 @@ TESTING CODE
 
 
 
-Testing ~Text~ <sub>Again </sub><sup>Testing More</sup>
+Testing ~~Text~~ <sub>Again </sub><sup>Testing More</sup>
 
 
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,6 @@
+import { fetchConfluencePageAdf, resolveConfluencePageId } from "./ConfluencePage";
+import { convertADFToMarkdown, type AdfToMarkdownOptions } from "./AdfConversion";
+import { readAdfDocument } from "./AdfDocument";
 import * as ConfluencePageConfig from "./ConniePageConfig";
 import { createAuthenticatedConfluenceClient } from "./AuthenticatedConfluenceClient";
 import * as ConfluenceUploadSettings from "./Settings";
@@ -74,6 +77,7 @@ import {
 import {
 	ConfluenceSettingsLive,
 	confluenceSettingsConfig,
+	confluenceReadSettingsConfig,
 	loadConfluenceSettings,
 	loadConfluenceSettingsEffect,
 	makeConfluenceSettingsConfigProvider,
@@ -81,6 +85,11 @@ import {
 } from "./SettingsConfig";
 
 export {
+	fetchConfluencePageAdf,
+	resolveConfluencePageId,
+	convertADFToMarkdown,
+	type AdfToMarkdownOptions,
+	readAdfDocument,
 	AlwaysADFPreprocessors,
 	AlwaysADFProcessingPlugins,
 	ATLASSIAN_OAUTH_AUDIENCE,
@@ -104,6 +113,7 @@ export {
 	StandardInputService,
 	StandardInputLive,
 	confluenceSettingsConfig,
+	confluenceReadSettingsConfig,
 	convertMDtoADF,
 	createConfluenceClientConfig,
 	createAuthenticatedConfluenceClient,

--- a/scripts/confluence-release-e2e.js
+++ b/scripts/confluence-release-e2e.js
@@ -244,6 +244,7 @@ const program = Effect.scoped(
 					JSON.stringify({
 						title: result.node.file.pageTitle,
 						comparison: updateComparisons.get(result.node.file.pageId),
+						existingPageData: result.node.existingPageData,
 						storedBody: JSON.parse(storedBodies.get(result.node.file.pageId)),
 						requestedBody: JSON.parse(requestedBodies.get(result.node.file.pageId)),
 					}),
@@ -450,6 +451,10 @@ const program = Effect.scoped(
 		let finalRequestedBody;
 		client.content.updateContent = async (parameters) => {
 			finalRequestedBody = parameters.body?.atlas_doc_format?.value;
+			updateComparisons.set(parameters.id, {
+				previous: fetchedPages.get(parameters.id),
+				requested: structuredClone(parameters),
+			});
 			return updateContent(parameters);
 		};
 		const finalPublish = yield* Effect.tryPromise(publishFormatting);
@@ -459,6 +464,8 @@ const program = Effect.scoped(
 					check: "unchanged-after-conflict",
 					storedBody: conflictPage.body.atlas_doc_format.value,
 					requestedBody: finalRequestedBody,
+					comparison: updateComparisons.get(formatting.pageId),
+					existingPageData: finalPublish[0].node.existingPageData,
 				}),
 			);
 		}

--- a/scripts/confluence-release-e2e.js
+++ b/scripts/confluence-release-e2e.js
@@ -13,6 +13,7 @@ import {
 	Publisher,
 	RuntimeEnvironmentService,
 	createAuthenticatedConfluenceClient,
+	parseMarkdownToADF,
 } from "../packages/lib/dist/index.js";
 import { PuppeteerMermaidRenderer } from "../packages/mermaid-puppeteer-renderer/dist/index.js";
 import { HttpPlantumlRenderer } from "../packages/plantuml-renderer/dist/index.js";
@@ -79,10 +80,23 @@ const program = Effect.scoped(
 			expectedSpace,
 			"Refusing to publish outside the dedicated test space",
 		);
+		const fetchedPages = new Map();
+		const updateComparisons = new Map();
+		const getContentById = client.content.getContentById.bind(client.content);
+		client.content.getContentById = async (parameters) => {
+			const page = await getContentById(parameters);
+			if (page.body?.atlas_doc_format?.value)
+				fetchedPages.set(parameters.id, structuredClone(page));
+			return page;
+		};
 		const requestedBodies = new Map();
 		const updateContent = client.content.updateContent.bind(client.content);
 		client.content.updateContent = async (parameters) => {
 			requestedBodies.set(parameters.id, parameters.body?.atlas_doc_format?.value);
+			updateComparisons.set(parameters.id, {
+				previous: fetchedPages.get(parameters.id),
+				requested: structuredClone(parameters),
+			});
 			return updateContent(parameters);
 		};
 		const publisher = new Publisher(settings, client, [
@@ -229,6 +243,7 @@ const program = Effect.scoped(
 				yield* Console.log(
 					JSON.stringify({
 						title: result.node.file.pageTitle,
+						comparison: updateComparisons.get(result.node.file.pageId),
 						storedBody: JSON.parse(storedBodies.get(result.node.file.pageId)),
 						requestedBody: JSON.parse(requestedBodies.get(result.node.file.pageId)),
 					}),
@@ -277,6 +292,48 @@ const program = Effect.scoped(
 			JSON.stringify({ ...settings, atlassianApiToken: undefined }),
 		);
 		const cliPath = fileURLToPath(new URL("../packages/cli/dist/index.js", import.meta.url));
+		const conversionConfig = path.join(root, "read-only-conversion.json");
+		yield* fs.writeFileString(
+			conversionConfig,
+			JSON.stringify({ ...settings, confluenceParentId: "", atlassianApiToken: undefined }),
+		);
+		const exportedAdfPath = path.join(root, "exported.adf.json");
+		const exportedMarkdownPath = path.join(root, "exported.md");
+		const pageUrl = `${baseUrl}/wiki/spaces/${expectedSpace}/pages/${media.pageId}`;
+		for (const args of [
+			["to-adf", pageUrl, "--output", exportedAdfPath],
+			["to-markdown", "--page", media.pageId, "--output", exportedMarkdownPath],
+		]) {
+			const conversion = yield* ChildProcess.make(
+				"node",
+				[cliPath, ...args, "--config", conversionConfig],
+				{
+					cwd: root,
+					extendEnv: true,
+					stdout: "inherit",
+					stderr: "inherit",
+				},
+			);
+			assert.equal(
+				yield* conversion.exitCode,
+				0,
+				`Conversion command ${args[0]} must succeed without a parent ID`,
+			);
+		}
+		const exportedAdf = JSON.parse(yield* fs.readFileString(exportedAdfPath));
+		assert.deepEqual(
+			exportedAdf,
+			JSON.parse((yield* fetchPage(media.pageId)).body.atlas_doc_format.value),
+		);
+		assert.deepEqual(
+			parseMarkdownToADF(yield* fs.readFileString(exportedMarkdownPath), baseUrl),
+			exportedAdf,
+			"Live Confluence Markdown export must preserve attachment IDs and every ADF field",
+		);
+		yield* fs.remove(exportedMarkdownPath);
+		yield* Console.log(
+			"[confluence] Both CLI exports passed; exact Markdown/ADF round trip and read-only behavior verified below",
+		);
 		const cliProcess = yield* ChildProcess.make("node", [cliPath, "--config", cliConfig], {
 			cwd: root,
 			extendEnv: true,

--- a/scripts/integration-tests.js
+++ b/scripts/integration-tests.js
@@ -123,6 +123,88 @@ function verifyCli(node, cliPath, cwd, libraryUrl) {
 			);
 			count++;
 		}
+		const conversionRoot = yield* fs.makeTempDirectoryScoped({
+			prefix: "confluence-conversion-",
+		});
+		const adfPath = path.join(
+			repositoryRoot,
+			"test-fixtures/conversion/rich-document.adf.json",
+		);
+		const markdownPath = path.join(conversionRoot, "round trip.md");
+		const originalAdf = JSON.parse(yield* fs.readFileString(adfPath));
+		const spacedAdfPath = path.join(conversionRoot, "input document.adf.json");
+		yield* fs.copyFile(adfPath, spacedAdfPath);
+		yield* command(
+			node,
+			[cliPath, "to-markdown", "--input", spacedAdfPath, "--output", markdownPath],
+			{ cwd },
+		);
+		const roundTrip = yield* command(node, [cliPath, "to-adf", markdownPath], {
+			cwd,
+			capture: true,
+		});
+		assert.deepEqual(
+			JSON.parse(roundTrip),
+			originalAdf,
+			"Rich ADF file round trip must preserve all fields",
+		);
+		const stdinMarkdown = yield* command(node, [cliPath, "from-adf", "-", "--readable"], {
+			cwd,
+			capture: true,
+			stdin: Stream.make(new TextEncoder().encode(JSON.stringify(originalAdf))),
+		});
+		assert.ok(
+			stdinMarkdown.includes("Conversion example") &&
+				stdinMarkdown.includes("The final paragraph"),
+		);
+		const invalidOutput = path.join(conversionRoot, "invalid output.md");
+		const invalidJson = yield* command(
+			node,
+			[cliPath, "to-markdown", "-", "--output", invalidOutput],
+			{
+				cwd,
+				capture: true,
+				expectedExitCode: 1,
+				stdin: Stream.make(new TextEncoder().encode("{invalid")),
+			},
+		);
+		assert.equal(invalidJson, "", "Invalid JSON must not emit Markdown");
+		assert.equal(
+			yield* fs.exists(invalidOutput),
+			false,
+			"Invalid input must not create an output file",
+		);
+		const formatting = path.join(
+			repositoryRoot,
+			"test-fixtures/conversion/conversion-formatting.md",
+		);
+		const formattingAdf = JSON.parse(
+			yield* command(node, [cliPath, "to-adf", formatting], { cwd, capture: true }),
+		);
+		assert.ok(JSON.stringify(formattingAdf).includes('"type":"underline"'));
+		assert.ok(JSON.stringify(formattingAdf).includes('"align":"center"'));
+		const generatedAdfPath = path.join(conversionRoot, "generated page.adf.json");
+		yield* command(
+			node,
+			[cliPath, "to-adf", "--input", formatting, "--output", generatedAdfPath],
+			{ cwd },
+		);
+		assert.deepEqual(JSON.parse(yield* fs.readFileString(generatedAdfPath)), formattingAdf);
+		yield* command(node, [cliPath, "to-markdown", generatedAdfPath, "--output", markdownPath], {
+			cwd,
+		});
+		const generatedRoundTrip = JSON.parse(
+			yield* command(node, [cliPath, "to-adf", markdownPath], { cwd, capture: true }),
+		);
+		assert.deepEqual(
+			generatedRoundTrip,
+			formattingAdf,
+			"Markdown file to ADF file to Markdown file preserves generated ADF",
+		);
+
+		yield* Console.log(
+			"Both conversion commands: file/stdin/output, rich ADF round trip, formatting and invalid input verified.",
+		);
 		// CommonJS consumers use dynamic import because the public package is ESM.
 		yield* command(
 			node,

--- a/test-fixtures/conversion/conversion-formatting.md
+++ b/test-fixtures/conversion/conversion-formatting.md
@@ -1,0 +1,17 @@
+# Conversion formatting
+
+<u>Underline</u>, H<sub>2</sub>O, x<sup>2</sup>, and <span style="color: #ff0000">red text</span>.
+
+| Left | Center | Right |
+| :--- | :---: | ---: |
+| A | B | C |
+
+7. Starts at seven
+8. Continues at eight
+
+- [ ] An incomplete task
+- [x] A completed task
+
+:1f92f|exploding_head:
+
+`<u>This is literal code</u>`

--- a/test-fixtures/conversion/rich-document.adf.json
+++ b/test-fixtures/conversion/rich-document.adf.json
@@ -1,0 +1,88 @@
+{
+	"version": 1,
+	"type": "doc",
+	"content": [
+		{
+			"type": "heading",
+			"attrs": { "level": 1 },
+			"content": [{ "type": "text", "text": "Conversion example" }]
+		},
+		{
+			"type": "paragraph",
+			"content": [
+				{
+					"type": "text",
+					"text": "A comment stays attached",
+					"marks": [
+						{
+							"type": "annotation",
+							"attrs": { "annotationType": "inlineComment", "id": "example-comment" }
+						}
+					]
+				},
+				{ "type": "text", "text": " and " },
+				{
+					"type": "status",
+					"attrs": { "text": "READY", "color": "green", "localId": "example-status" }
+				}
+			]
+		},
+		{
+			"type": "layoutSection",
+			"content": [
+				{
+					"type": "layoutColumn",
+					"attrs": { "width": 50 },
+					"content": [
+						{
+							"type": "paragraph",
+							"content": [{ "type": "text", "text": "Left column" }]
+						}
+					]
+				},
+				{
+					"type": "layoutColumn",
+					"attrs": { "width": 50 },
+					"content": [
+						{
+							"type": "paragraph",
+							"content": [{ "type": "text", "text": "Right column" }]
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "mediaSingle",
+			"attrs": { "layout": "center" },
+			"content": [
+				{
+					"type": "media",
+					"attrs": {
+						"type": "file",
+						"id": "example-media",
+						"collection": "example-attachments",
+						"width": 640,
+						"height": 480
+					}
+				},
+				{
+					"type": "caption",
+					"content": [{ "type": "text", "text": "Attachment IDs must survive export" }]
+				}
+			]
+		},
+		{
+			"type": "extension",
+			"attrs": {
+				"extensionType": "com.atlassian.confluence.macro.core",
+				"extensionKey": "toc",
+				"parameters": { "macroParams": { "maxLevel": { "value": "3" } } }
+			}
+		},
+		{
+			"type": "paragraph",
+			"content": [{ "type": "text", "text": "The final paragraph must remain." }]
+		}
+	]
+}


### PR DESCRIPTION
File conversion now works in both directions, and the CLI can export a Confluence page by URL or ID. `to-adf` accepts Markdown files/stdin or a remote page; `to-markdown` (alias `from-adf`) accepts ADF JSON files/stdin or a remote page. Both support `--input` and `--output`, including paths containing spaces. Page reads reuse existing authentication without requiring publishing settings.

The converters reuse the existing `adf` fenced-block format for features Markdown cannot represent. The default Markdown export verifies exact round-trip preservation of every ADF field; `--readable` prefers ordinary Markdown. Complete documents and nested raw ADF are restored after Markdown normalization. Native formatting now covers underline, sub/superscript, colors, emoji IDs, table alignment, ordered-list starts, cards, media/captions and other readable nodes. Unknown nodes, extensions, annotations and layout attributes retain the established ADF fallback.

Live testing also exposed Confluence asynchronously adding `__confluenceMetadata` to link marks. Publishing now ignores that derived field when comparing unchanged pages, while lossless exports retain it. Actual link URLs, anchors and authored titles still affect comparison.

## Acceptance criteria

- [x] Markdown file input → ADF JSON file output.
- [x] ADF JSON file input → Markdown file output.
- [x] Positional/`--input`, `--output`, spaces in paths, stdin/stdout and invalid-input failure behavior.
- [x] Exact ADF → Markdown → ADF and generated Markdown → ADF → Markdown → ADF round trips.
- [x] Confluence URL and numeric page-ID exports without a publishing parent; page versions remain unchanged.
- [x] Reuse existing `adf` fences for unsupported features and retain all original fields.

The complete feature mapping and usage examples are in `documentation/CONVERSION.md`. Media IDs remain references: exports do not download attachments, migrate them across sites or recreate server-side comments/macros.

Final review also fixed table escaping and formatting around inline code/link labels. Confluence settings are validated in the shared page-read helper before the authenticated client is created. Authenticated exports require HTTPS for basic, bearer and OAuth clients, and the transport-error regression checks the complete sanitized message.

## Validation

- `vp run check`, `vp run fmt:check`, `vp test run`: 250 passed, 1 existing opt-in test skipped.
- `vp run build`.
- Quick and fresh tarball-consumer integration profiles passed, including actual CLI file/stdin/output/error checks.
- Live Confluence integration passed, including both new export commands, exact media-rich round trip, unchanged/update publishing and failure/conflict recovery.
- Desktop Obsidian and Docker integration passed against the dedicated test setup.
- Latest GitHub Linux/Windows verification, CodeQL, Snyk, dependency review and live Confluence verification passed on the final commit `ded65e0`. Optional mutation testing is still running.
- The earlier intermittent unchanged-after-conflict failure did not recur in the latest local or GitHub live runs. Expanded diagnostics retain the exact comparison inputs if it recurs.

Fixes #260.
Fixes #264.

## Review verification

The media-child error comment was checked against the complete renderer: `renderChildren` runs before the node switch, and its early `Error` return causes `renderADFDoc` to preserve the node in an ADF fence. The new readable-media regression verifies an attachment-ID-only child produces an exact recoverable fence and never error text. No behavior change is needed for that comment.
