### PR TITLE
feat: publish Dataview results through an early Markdown source hook

### DIFF
--- a/documentation/DATAVIEW.md
+++ b/documentation/DATAVIEW.md
@@ -1,0 +1,103 @@
+# Publishing Dataview results
+
+Enable Dataview in your Obsidian vault, then turn on **Publish Dataview results** in
+Confluence Integration settings. This setting is off by default. Fenced
+`dataview` TABLE, LIST and TASK queries are evaluated when you publish and their
+results become ordinary Confluence content.
+
+For example, a bibliography can select the notes you link to under `Papers`:
+
+````markdown
+[[Papers/Example paper]]
+
+```dataview
+TABLE authors AS Authors
+FROM "Papers"
+WHERE contains(this.file.outlinks, file.link)
+```
+````
+
+The query stays in your source note, including when publication writes
+`connie-page-id` and `connie-page-url` to frontmatter. Each publication evaluates
+the query again. Editing a paper's authors changes the bibliography on its next
+publication even if the bibliography's source has not changed. Unchanged results
+do not create a new Confluence page version.
+
+Queries inside embedded note sections use the embedded note's context, so `this`
+refers to that note. Only the included section is evaluated. A single-note
+publication evaluates that note and its included content, while other eligible
+notes remain available for the existing Confluence page/link mapping.
+
+## Output and limitations
+
+- Tables, lists and ordinary checked/unchecked tasks use the existing native ADF
+  conversion. Task results are snapshots; changing a task in Confluence does not
+  update Obsidian.
+- Paper links resolve to Confluence when their targets are in the selected
+  publication set. Otherwise the existing publisher retains their text without
+  a link. A query does not automatically select its results for publication.
+- Array and object cells use Dataview's plain Markdown export, avoiding literal
+  HTML list markup in table cells.
+- `ignoredCodeBlockLanguages` takes precedence. If it contains `dataview`, those
+  blocks remain omitted and are not evaluated. Remove that entry to publish their
+  results. Ordinary code examples remain literal.
+- Index initialization and recently edited Markdown dependencies are checked
+  before evaluation. Indexing has a 15-second wait limit and each query has a
+  30-second limit. Missing Dataview, query errors and timeouts identify the source
+  note and stop preparation before Confluence page creation or content updates.
+- CALENDAR and DataviewJS blocks report unsupported output when result publishing
+  is enabled. Inline DQL/JavaScript expressions are not evaluated by this feature.
+- Arbitrary JavaScript views, interactive charts and HTML rendering are outside
+  this implementation. Existing native ADF and `adf` fences continue to handle
+  supported content that Markdown cannot express.
+- Live Dataview evaluation runs in Obsidian. The standalone CLI can accept already
+  generated Markdown/ADF through its existing file and stdin commands.
+
+## Source-transform hook
+
+The library exports `MarkdownSourceTransformerService`, an Effect context
+reference with an identity default. Supply a transformer when constructing a
+workspace or providing `MarkdownWorkspaceLive`:
+
+```ts
+import { Effect } from "effect";
+import {
+  makeMarkdownWorkspaceEffect,
+  MarkdownSourceTransformerService,
+} from "@markdown-confluence/lib";
+
+const workspaceEffect = makeMarkdownWorkspaceEffect(settings).pipe(
+  Effect.provideService(MarkdownSourceTransformerService, {
+    transform: (markdown, context) => Effect.tryPromise({
+      try: () => renderSource(markdown, context),
+      catch: (cause) => cause instanceof Error ? cause : new Error(String(cause)),
+    }),
+  }),
+);
+```
+
+`renderSource` is your asynchronous transformation. Its context provides the
+original platform `absoluteFilePath`, slash-separated `sourcePath` relative to
+the content root, and frontmatter. Return Markdown; the hook runs before embed
+expansion, ADF conversion, Confluence link resolution and image upload. Included
+sections invoke the hook with their own note's context. Raw reads and frontmatter
+write-back bypass it. The exported `transformMarkdownCodeBlocks` helper replaces
+actual fenced blocks while preserving surrounding source and container prefixes.
+
+## Integration test
+
+Install and enable Dataview in the dedicated integration vault, then run:
+
+```sh
+vp run test:integration obsidian --dataview --vault ../markdown-confluence-integration-vault
+```
+
+Use `--skip-build` only after a current build. The standard test-vault marker and
+Confluence destination checks apply. The test creates owned synthetic paper,
+bibliography and embedded-context notes. It checks native output, outgoing links,
+source preservation, unchanged versions, immediate dependency edits and query
+failure without a remote update. It restores changed content and settings; the
+fixture pages remain available for inspection. Results are written to
+`reports/integration/obsidian-<timestamp>/dataview.json`.
+
+See [TESTING.md](TESTING.md) for credentials and desktop setup.

--- a/documentation/TESTING.md
+++ b/documentation/TESTING.md
@@ -112,6 +112,19 @@ permission boundary still need separate checks. The Docker profile is a local
 container smoke test; it does not verify published multi-architecture images or
 the companion GitHub Action release.
 
+### Dataview desktop acceptance
+
+Install and enable Dataview in the dedicated test vault, then add `--dataview`:
+
+```sh
+vp run test:integration obsidian --dataview
+```
+
+This also verifies native tables/lists/tasks, outgoing paper links, embedded note
+context, preserved queries, unchanged versions, dependency-only updates and query
+errors before remote updates. It restores modified source and plugin settings.
+See [DATAVIEW.md](DATAVIEW.md) for setup, supported query forms and hook details.
+
 ## GitHub Actions
 
 Pull requests run package integration on Linux and the built CLI/Chromium check

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -38,6 +38,7 @@ main().catch((error) => {
 
 - Markdown to ADF conversion
 - Wikilink handling
+- Optional asynchronous [source transformation before conversion](../../documentation/DATAVIEW.md#source-transform-hook)
 - Image uploading support
 - Mermaid diagram upload pipeline integration
 - Comment preservation

--- a/packages/lib/src/MarkdownCodeBlocks.test.ts
+++ b/packages/lib/src/MarkdownCodeBlocks.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@effect/vitest";
+import { Effect } from "effect";
+import { transformMarkdownCodeBlocks } from "./MarkdownCodeBlocks";
+
+const replaceQueries = (markdown: string) =>
+	Effect.runPromise(
+		transformMarkdownCodeBlocks(markdown, (block) =>
+			Effect.succeed(
+				block.language === "dataview" ? "| Name |\n| --- |\n| Paper |" : undefined,
+			),
+		),
+	);
+
+test("rewrites fenced queries while preserving literal examples and ordinary code", async () => {
+	const examples =
+		"````markdown\n```dataview\nTABLE example\n```\n````\n\n    ```dataview\n    example\n    ```\n\n<!--\n```dataview\nexample\n```\n-->\n";
+	expect(await replaceQueries(examples)).toBe(examples);
+	const actual = await replaceQueries(`${examples}\n~~~Dataview\nTABLE authors\n~~~\nAfter`);
+	expect(actual).toBe(`${examples}\n| Name |\n| --- |\n| Paper |\nAfter`);
+});
+
+test("preserves blockquote, callout and list containers around generated tables", async () => {
+	expect(await replaceQueries("> [!note]\n> ```dataview\n> TABLE authors\n> ```\n")).toBe(
+		"> [!note]\n> | Name |\n> | --- |\n> | Paper |\n",
+	);
+	expect(await replaceQueries("- ```dataview\n  TABLE authors\n  ```\n")).toBe(
+		"- | Name |\n  | --- |\n  | Paper |\n",
+	);
+	expect(await replaceQueries("> 1. ```dataview\n>    TABLE authors\n>    ```\n")).toBe(
+		"> 1. | Name |\n>    | --- |\n>    | Paper |\n",
+	);
+});
+
+test("keeps CRLF source outside replacements and handles an unclosed final fence", async () => {
+	expect(await replaceQueries("Before\r\n\r\n```dataview\r\nTABLE authors")).toBe(
+		"Before\r\n\r\n| Name |\n| --- |\n| Paper |\n",
+	);
+});
+
+test("does not recursively execute generated query-looking content", async () => {
+	let calls = 0;
+	const result = await Effect.runPromise(
+		transformMarkdownCodeBlocks("```dataview\nTABLE authors\n```", () => {
+			calls++;
+			return Effect.succeed("```dataview\nnot another execution\n```");
+		}),
+	);
+	expect(calls).toBe(1);
+	expect(result).toContain("not another execution");
+});

--- a/packages/lib/src/MarkdownCodeBlocks.ts
+++ b/packages/lib/src/MarkdownCodeBlocks.ts
@@ -1,0 +1,59 @@
+import MarkdownIt from "markdown-it";
+import { Effect } from "effect";
+
+const parser = new MarkdownIt({ html: true });
+
+export interface MarkdownCodeBlock {
+	language: string;
+	content: string;
+	/** One-based line in the supplied Markdown (which may be an embedded section). */
+	line: number;
+}
+
+/** Replace real fenced blocks once, preserving surrounding source and container indentation. */
+export function transformMarkdownCodeBlocks(
+	markdown: string,
+	transform: (block: MarkdownCodeBlock) => Effect.Effect<string | undefined, Error>,
+): Effect.Effect<string, Error> {
+	return Effect.gen(function* () {
+		const lines = markdown.split("\n");
+		const offsets = [0];
+		for (const line of lines) offsets.push(offsets.at(-1)! + line.length + 1);
+		const replacements: { start: number; end: number; content: string }[] = [];
+		for (const token of parser.parse(markdown, {})) {
+			if (token.type !== "fence" || !token.map) continue;
+			const replacement = yield* transform({
+				language: token.info.trim().split(/\s+/)[0]?.toLowerCase() ?? "",
+				content: token.content,
+				line: token.map[0] + 1,
+			});
+			if (replacement === undefined) continue;
+			const opening = lines[token.map[0]]!;
+			const prefix = opening.slice(0, opening.indexOf(token.markup));
+			const continuation = prefix.replace(
+				/(^|>[ \t]*)([-+*]|\d+[.)])([ \t]+)/g,
+				(_match, before: string, marker: string, whitespace: string) =>
+					before + " ".repeat(marker.length + whitespace.length),
+			);
+			const content = replacement
+				.replace(/\r\n/g, "\n")
+				.trimEnd()
+				.split("\n")
+				.map((line, index) => `${index === 0 ? prefix : continuation}${line}`)
+				.join("\n");
+			replacements.push({
+				start: offsets[token.map[0]]!,
+				end: Math.min(offsets[token.map[1]]!, markdown.length),
+				content: `${content}\n`,
+			});
+		}
+		let result = markdown;
+		for (const replacement of replacements.reverse()) {
+			result =
+				result.slice(0, replacement.start) +
+				replacement.content +
+				result.slice(replacement.end);
+		}
+		return result;
+	});
+}

--- a/packages/lib/src/MarkdownSourceTransformer.ts
+++ b/packages/lib/src/MarkdownSourceTransformer.ts
@@ -1,0 +1,25 @@
+import { Context, Effect } from "effect";
+
+export interface MarkdownSourceContext {
+	/** Platform path of the original note, including when processing an embed. */
+	absoluteFilePath: string;
+	/** Slash-separated path relative to the configured content root. */
+	sourcePath: string;
+	frontmatter: Readonly<Record<string, unknown>>;
+}
+
+export interface MarkdownSourceTransformer {
+	transform(markdown: string, context: MarkdownSourceContext): Effect.Effect<string, Error>;
+}
+
+/** Publication-only processing; raw reads and frontmatter write-back never use this hook. */
+export const MarkdownSourceTransformerService = Context.Reference<MarkdownSourceTransformer>(
+	"@markdown-confluence/MarkdownSourceTransformer",
+	{ defaultValue: () => ({ transform: (markdown) => Effect.succeed(markdown) }) },
+);
+
+/** Limits content preparation while retaining other eligible notes for the page/link mapping. */
+export const MarkdownPublishFilter = Context.Reference<string | undefined>(
+	"@markdown-confluence/MarkdownPublishFilter",
+	{ defaultValue: () => undefined },
+);

--- a/packages/lib/src/MarkdownWorkspace.test.ts
+++ b/packages/lib/src/MarkdownWorkspace.test.ts
@@ -4,7 +4,16 @@ import { afterEach, expect, test } from "@effect/vitest";
 import { Effect } from "effect";
 import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 import { RuntimeEnvironmentService, runEffect } from "./effects";
-import { loadMarkdownWorkspace, shouldPublishMarkdownFile } from "./MarkdownWorkspace";
+import {
+	loadMarkdownWorkspace,
+	shouldPublishMarkdownFile,
+	makeMarkdownWorkspaceEffect,
+} from "./MarkdownWorkspace";
+import {
+	MarkdownSourceTransformerService,
+	MarkdownPublishFilter,
+	type MarkdownSourceTransformer,
+} from "./MarkdownSourceTransformer";
 
 test("folder selection respects directory boundaries on all platforms", () => {
 	const settings = { ...DEFAULT_SETTINGS, folderToPublish: "docs" };
@@ -240,3 +249,109 @@ const testSettings: ConfluenceSettings = {
 	firstHeadingPageTitle: false,
 	forceOverwrite: false,
 };
+
+async function transformedWorkspace(
+	files: Record<string, string>,
+	transformer: MarkdownSourceTransformer,
+) {
+	return runEffect(
+		Effect.gen(function* () {
+			const fs = yield* FileSystem;
+			const path = yield* Path;
+			tmpRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-source-hook-" });
+			for (const [name, content] of Object.entries(files)) {
+				const target = path.join(tmpRoot, name);
+				yield* fs.makeDirectory(path.dirname(target), { recursive: true });
+				yield* fs.writeFileString(target, content);
+			}
+			return yield* makeMarkdownWorkspaceEffect({
+				...testSettings,
+				contentRoot: tmpRoot,
+				folderToPublish: "Publish",
+			});
+		}).pipe(Effect.provideService(MarkdownSourceTransformerService, transformer)),
+	);
+}
+
+test("source transforms preserve original queries through frontmatter write-back and raw reads", async () => {
+	const source = "```dataview\nTABLE authors\n```";
+	const workspace = await transformedWorkspace(
+		{ "Publish/Note.md": source },
+		{
+			transform: () => Effect.succeed("| Authors |\n| --- |\n| Ada |"),
+		},
+	);
+	const files = await Effect.runPromise(workspace.getMarkdownFilesToUpload);
+	expect(files[0]?.contents).toContain("| Ada |");
+	await Effect.runPromise(workspace.updateMarkdownValues("Publish/Note.md", { pageId: "123" }));
+	const saved = await runEffect(
+		Effect.gen(function* () {
+			return yield* (yield* FileSystem).readFileString(`${tmpRoot}/Publish/Note.md`);
+		}),
+	);
+	expect(saved).toContain(source);
+	expect(saved).toContain("connie-page-id:");
+	expect(saved).not.toContain("| Ada |");
+	expect(await Effect.runPromise(workspace.readText("Note.md", "Publish/Note.md"))).toContain(
+		source,
+	);
+});
+
+test("selected notes and included sections are transformed with their original context before embed expansion", async () => {
+	const visited: string[] = [];
+	const workspace = await transformedWorkspace(
+		{
+			"Publish/Note.md": "SOURCE",
+			"Notes/Included.md": "# Keep\nEMBED QUERY\n# Skip\nBAD QUERY",
+			"Notes/Other.md": "BAD QUERY",
+		},
+		{
+			transform: (markdown, context) => {
+				visited.push(context.sourcePath);
+				if (markdown.includes("BAD QUERY"))
+					return Effect.fail(new Error("Must not evaluate unrelated content"));
+				return Effect.succeed(
+					markdown
+						.replace("SOURCE", "![[Notes/Included#Keep]]")
+						.replace("EMBED QUERY", `From ${context.sourcePath}`),
+				);
+			},
+		},
+	);
+	const files = await Effect.runPromise(workspace.getMarkdownFilesToUpload);
+	expect(visited).toEqual(["Publish/Note.md", "Notes/Included.md"]);
+	expect(files[0]?.contents).toContain("From Notes/Included.md");
+	expect(files[0]?.contents).not.toContain("EMBED QUERY");
+});
+
+test("single-note publication avoids other queries while retaining their page mapping", async () => {
+	const visited: string[] = [];
+	const workspace = await transformedWorkspace(
+		{
+			"Publish/One.md": "One",
+			"Publish/Two.md": "![[Notes/Title]]",
+			"Notes/Title.md": "# Embedded title",
+		},
+		{
+			transform: (markdown, context) => {
+				visited.push(context.sourcePath);
+				return context.sourcePath.endsWith("Two.md")
+					? Effect.fail(new Error("Invalid query"))
+					: Effect.succeed(markdown);
+			},
+		},
+	);
+	const files = await Effect.runPromise(
+		workspace.getMarkdownFilesToUpload.pipe(
+			Effect.provideService(MarkdownPublishFilter, "Publish/One.md"),
+		),
+	);
+	expect(files).toHaveLength(2);
+	expect(files.find((file) => file.fileName === "Two.md")?.contents).toContain(
+		"# Embedded title",
+	);
+	expect(visited).toEqual(["Publish/One.md"]);
+	await expect(Effect.runPromise(workspace.getMarkdownFilesToUpload)).rejects.toThrow(
+		"Invalid query",
+	);
+});

--- a/packages/lib/src/MarkdownWorkspace.ts
+++ b/packages/lib/src/MarkdownWorkspace.ts
@@ -11,6 +11,10 @@ import { runEffect } from "./effects";
 import { parseMarkdownFrontmatter, stringifyMarkdownFrontmatter } from "./MarkdownFrontmatter";
 import { findMarkdownEmbeds, rebaseEmbeddedLinks, selectEmbeddedMarkdown } from "./MarkdownEmbeds";
 import { ConfluenceSettings, ConfluenceSettingsService } from "./Settings";
+import {
+	MarkdownSourceTransformerService,
+	MarkdownPublishFilter,
+} from "./MarkdownSourceTransformer";
 
 interface MarkdownContent {
 	data: Record<string, unknown>;
@@ -80,6 +84,7 @@ export function makeMarkdownWorkspaceEffect(
 	return Effect.gen(function* () {
 		const fs = yield* FileSystem;
 		const path = yield* Path;
+		const sourceTransformer = yield* MarkdownSourceTransformerService;
 		const contentRoot = normalizeContentRoot(settings.contentRoot, path);
 		yield* validateContentRoot(fs, contentRoot);
 		const workspaceSettings = {
@@ -150,30 +155,55 @@ export function makeMarkdownWorkspaceEffect(
 				yield* fs.writeFileString(actualAbsoluteFilePath, updatedData);
 			}).pipe(Effect.mapError(toError));
 
-		const loadMarkdownFile = (absoluteFilePath: string): Effect.Effect<MarkdownFile, Error> =>
+		const transformSource = (
+			content: string,
+			absoluteFilePath: string,
+			frontmatter: Record<string, unknown>,
+		) =>
+			sourceTransformer.transform(content, {
+				absoluteFilePath,
+				sourcePath: path
+					.relative(workspaceSettings.contentRoot, absoluteFilePath)
+					.replaceAll("\\", "/"),
+				frontmatter,
+			});
+
+		const readMarkdownFile = (absoluteFilePath: string): Effect.Effect<MarkdownFile, Error> =>
 			Effect.gen(function* () {
 				const { data, content } = yield* getFileContent(absoluteFilePath);
-				const contents = yield* expandMarkdownEmbeds(
-					content,
-					absoluteFilePath,
-					new Set([absoluteFilePath]),
-				);
-
-				const folderName = path.basename(path.parse(absoluteFilePath).dir);
 				const fileName = path.basename(absoluteFilePath);
-
-				const extension = path.extname(fileName);
-				const pageTitle = path.basename(fileName, extension);
-
 				return {
-					folderName,
+					folderName: path.basename(path.parse(absoluteFilePath).dir),
 					absoluteFilePath: absoluteFilePath.replace(workspaceSettings.contentRoot, ""),
 					fileName,
-					pageTitle,
-					contents,
+					pageTitle: path.basename(fileName, path.extname(fileName)),
+					contents: content,
 					frontmatter: data,
 				};
 			}).pipe(Effect.mapError(toError));
+
+		const prepareMarkdownFile = (
+			file: MarkdownFile,
+			absoluteFilePath: string,
+			applySourceTransforms = true,
+		): Effect.Effect<MarkdownFile, Error> =>
+			Effect.gen(function* () {
+				const transformed = applySourceTransforms
+					? yield* transformSource(file.contents, absoluteFilePath, file.frontmatter)
+					: file.contents;
+				const contents = yield* expandMarkdownEmbeds(
+					transformed,
+					absoluteFilePath,
+					new Set([absoluteFilePath]),
+					applySourceTransforms,
+				);
+				return { ...file, contents };
+			});
+
+		const loadMarkdownFile = (absoluteFilePath: string): Effect.Effect<MarkdownFile, Error> =>
+			Effect.flatMap(readMarkdownFile(absoluteFilePath), (file) =>
+				prepareMarkdownFile(file, absoluteFilePath),
+			);
 
 		const loadMarkdownFiles = (folderPath: string): Effect.Effect<MarkdownFile[], Error> =>
 			Effect.gen(function* () {
@@ -186,7 +216,7 @@ export function makeMarkdownWorkspaceEffect(
 					const stats = yield* fs.stat(absoluteFilePath);
 
 					if (stats.type === "File" && path.extname(entry) === ".md") {
-						const file = yield* loadMarkdownFile(absoluteFilePath);
+						const file = yield* readMarkdownFile(absoluteFilePath);
 						files.push(file);
 					} else if (stats.type === "Directory") {
 						const subFiles = yield* loadMarkdownFiles(absoluteFilePath);
@@ -200,7 +230,7 @@ export function makeMarkdownWorkspaceEffect(
 		const getMarkdownFilesToUpload: Effect.Effect<FilesToUpload, Error> = Effect.gen(
 			function* () {
 				const files = yield* loadMarkdownFiles(workspaceSettings.contentRoot);
-				const filesToPublish = [];
+				const filesToPublish: MarkdownFile[] = [];
 				for (const file of files) {
 					try {
 						if (
@@ -224,7 +254,19 @@ export function makeMarkdownWorkspaceEffect(
 						);
 					}
 				}
-				return filesToPublish;
+				const publishFilter = yield* MarkdownPublishFilter;
+				const normalize = (value: string) =>
+					value.replaceAll("\\", "/").replace(/^\/+/, "");
+				// Keep ordinary embed expansion for page titles/hierarchy in the link mapping,
+				// but execute source hooks only for the requested page and its own embeds.
+				return yield* Effect.forEach(filesToPublish, (file) =>
+					prepareMarkdownFile(
+						file,
+						path.join(workspaceSettings.contentRoot, file.absoluteFilePath),
+						!publishFilter ||
+							normalize(file.absoluteFilePath) === normalize(publishFilter),
+					),
+				);
 			},
 		).pipe(Effect.mapError(toError));
 
@@ -286,6 +328,7 @@ export function makeMarkdownWorkspaceEffect(
 			contents: string,
 			referencedFromFilePath: string,
 			seenFiles: Set<string>,
+			applySourceTransforms: boolean,
 		): Effect.Effect<string, Error> {
 			return Effect.gen(function* () {
 				let expandedContents = "";
@@ -309,6 +352,7 @@ export function makeMarkdownWorkspaceEffect(
 						embedTarget,
 						referencedFromFilePath,
 						seenFiles,
+						applySourceTransforms,
 					);
 					expandedContents += replacement;
 				}
@@ -323,6 +367,7 @@ export function makeMarkdownWorkspaceEffect(
 			rawTarget: string,
 			referencedFromFilePath: string,
 			seenFiles: Set<string>,
+			applySourceTransforms: boolean,
 		): Effect.Effect<string, Error> {
 			return Effect.gen(function* () {
 				const [targetValue, fragment] = (rawTarget.split("|")[0] ?? "").split("#");
@@ -356,10 +401,18 @@ export function makeMarkdownWorkspaceEffect(
 					try: () => selectEmbeddedMarkdown(embeddedContent.content, fragment),
 					catch: toError,
 				});
+				const transformedContent = applySourceTransforms
+					? yield* transformSource(
+							selectedContent,
+							embeddedFilePath,
+							embeddedContent.data,
+						)
+					: selectedContent;
 				const expandedEmbeddedContent = yield* expandMarkdownEmbeds(
-					selectedContent,
+					transformedContent,
 					embeddedFilePath,
 					new Set([...seenFiles, embeddedFilePath]),
+					applySourceTransforms,
 				);
 
 				const targets = new Set<string>();

--- a/packages/lib/src/Publisher.ts
+++ b/packages/lib/src/Publisher.ts
@@ -1,3 +1,4 @@
+import { MarkdownPublishFilter } from "./MarkdownSourceTransformer";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { Effect, Layer } from "effect";
 import { AlwaysADFPreprocessors, AlwaysADFProcessingPlugins } from "./ADFProcessingPlugins";
@@ -173,7 +174,9 @@ export class Publisher {
 			const spaceToPublishTo = parentPage.space;
 
 			const workspace = yield* MarkdownWorkspaceService;
-			const files = yield* workspace.getMarkdownFilesToUpload;
+			const files = yield* workspace.getMarkdownFilesToUpload.pipe(
+				Effect.provideService(MarkdownPublishFilter, publishFilter),
+			);
 			const folderTree = yield* createLocalAdfTreeEffect(files, settings);
 			let confluencePagesToPublish = yield* ensureAllFilesExistInConfluenceEffect(
 				confluenceClient,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,9 @@
+import {
+	MarkdownSourceTransformerService,
+	type MarkdownSourceTransformer,
+	type MarkdownSourceContext,
+} from "./MarkdownSourceTransformer";
+import { transformMarkdownCodeBlocks, type MarkdownCodeBlock } from "./MarkdownCodeBlocks";
 import { fetchConfluencePageAdf, resolveConfluencePageId } from "./ConfluencePage";
 import { convertADFToMarkdown, type AdfToMarkdownOptions } from "./AdfConversion";
 import { readAdfDocument } from "./AdfDocument";
@@ -85,6 +91,11 @@ import {
 } from "./SettingsConfig";
 
 export {
+	MarkdownSourceTransformerService,
+	type MarkdownSourceTransformer,
+	type MarkdownSourceContext,
+	transformMarkdownCodeBlocks,
+	type MarkdownCodeBlock,
 	fetchConfluencePageAdf,
 	resolveConfluencePageId,
 	convertADFToMarkdown,

--- a/packages/obsidian/README.md
+++ b/packages/obsidian/README.md
@@ -13,6 +13,7 @@ Copyright (c) 2022 Atlassian US, Inc.
 - Publish Obsidian notes to Atlassian Confluence
 - Support for Obsidian markdown extensions
 - Mermaid and PlantUML diagram rendering
+- Optional [Dataview TABLE, LIST and TASK publication](../../documentation/DATAVIEW.md)
 - CLI for pushing markdown files from disk
 - Commands and ribbon icon for easy access
 

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -207,6 +207,18 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Publish Dataview results")
+			.setDesc(
+				"Publish Dataview TABLE, LIST and TASK queries as content. Requires Dataview enabled in this vault. Ignored code block languages remain omitted; DataviewJS and inline queries are not supported.",
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(this.plugin.settings.renderDataview).onChange(async (value) => {
+					this.plugin.settings.renderDataview = value;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
 			.setName("Mermaid Diagram Theme")
 			.setDesc("Pick the theme to apply to mermaid diagrams")
 			.addDropdown((dropdown) => {

--- a/packages/obsidian/src/DataviewTransformer.test.ts
+++ b/packages/obsidian/src/DataviewTransformer.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, expect, test, vi } from "@effect/vitest";
+import type { App } from "obsidian";
+import { Effect } from "effect";
+import { createDataviewTransformer, type DataviewApi } from "./DataviewTransformer";
+
+const context = {
+	absoluteFilePath: "/Notes/Bibliography.md",
+	sourcePath: "Notes/Bibliography.md",
+	frontmatter: {},
+};
+const query = '```dataview\nTABLE authors FROM "Papers"\n```';
+const settings = { renderDataview: true };
+const render = (fixture: ReturnType<typeof setup>, markdown = query) =>
+	Effect.runPromise(
+		createDataviewTransformer(fixture.app, settings).transform(markdown, context),
+	);
+
+function setup() {
+	const queryMarkdown = vi
+		.fn<DataviewApi["queryMarkdown"]>()
+		.mockResolvedValue({ successful: true, value: "| Authors |\n| --- |\n| Ada, Grace |" });
+	const api: DataviewApi = {
+		index: {
+			initialized: true,
+			pages: new Map([["Notes/Bibliography.md", { mtime: { toMillis: () => 10 } }]]),
+		},
+		queryMarkdown,
+	};
+	const files = [{ path: "Notes/Bibliography.md", stat: { mtime: 10 } }];
+	const plugins: { dataview?: { api: DataviewApi } } = { dataview: { api } };
+	const app = {
+		plugins: { plugins },
+		vault: { getMarkdownFiles: () => files },
+	} as unknown as App;
+	return { app, api, queryMarkdown, files, plugins };
+}
+
+afterEach(() => vi.useRealTimers());
+
+test("exports query results with source context and HTML disabled", async () => {
+	const fixture = setup();
+	expect(await render(fixture)).toContain("| Ada, Grace |");
+	expect(fixture.queryMarkdown).toHaveBeenCalledWith(
+		'TABLE authors FROM "Papers"\n',
+		"Notes/Bibliography.md",
+		{ allowHtml: false },
+	);
+});
+
+test("disabled support, ignored languages and literal examples never require Dataview", async () => {
+	const fixture = setup();
+	delete fixture.plugins.dataview;
+	for (const configuration of [
+		{ renderDataview: false },
+		{ ...settings, ignoredCodeBlockLanguages: [" DataView "] },
+	]) {
+		expect(
+			await Effect.runPromise(
+				createDataviewTransformer(fixture.app, configuration).transform(query, context),
+			),
+		).toBe(query);
+	}
+	const example = "````markdown\n" + query + "\n````";
+	expect(await render(fixture, example)).toBe(example);
+	expect(fixture.queryMarkdown).not.toHaveBeenCalled();
+});
+
+test("missing Dataview and query errors identify the source note", async () => {
+	const fixture = setup();
+	delete fixture.plugins.dataview;
+	await expect(render(fixture)).rejects.toThrow(
+		"Dataview in Notes/Bibliography.md (line 1): Enable Dataview",
+	);
+	fixture.plugins.dataview = { api: fixture.api };
+	fixture.queryMarkdown.mockResolvedValue({ successful: false, error: "Invalid query" });
+	await expect(render(fixture)).rejects.toThrow("Invalid query");
+});
+
+test("empty successful results are valid while unsupported forms fail explicitly", async () => {
+	const fixture = setup();
+	fixture.queryMarkdown.mockResolvedValue({ successful: true, value: "" });
+	expect((await render(fixture)).trim()).toBe("");
+	await expect(render(fixture, "```dataviewjs\ndv.table([])\n```")).rejects.toThrow(
+		"DataviewJS publication is not supported",
+	);
+	fixture.queryMarkdown.mockResolvedValue({
+		successful: false,
+		error: "Cannot render calendar queries to markdown.",
+	});
+	await expect(render(fixture, "```dataview\nCALENDAR file.mtime\n```")).rejects.toThrow(
+		"Cannot render calendar",
+	);
+});
+
+test("waits for initial indexing and a recently edited dependency before querying", async () => {
+	vi.useFakeTimers();
+	const fixture = setup();
+	fixture.api.index.initialized = false;
+	fixture.files.push({ path: "Papers/Paper.md", stat: { mtime: 20 } });
+	const result = render(fixture);
+	await vi.advanceTimersByTimeAsync(100);
+	expect(fixture.queryMarkdown).not.toHaveBeenCalled();
+	fixture.api.index.initialized = true;
+	fixture.api.index.pages.set("Papers/Paper.md", { mtime: { toMillis: () => 19 } });
+	await vi.advanceTimersByTimeAsync(100);
+	expect(fixture.queryMarkdown).not.toHaveBeenCalled();
+	fixture.api.index.pages.set("Papers/Paper.md", { mtime: { toMillis: () => 20 } });
+	await vi.advanceTimersByTimeAsync(100);
+	await result;
+	expect(fixture.queryMarkdown).toHaveBeenCalledTimes(1);
+});
+
+test("index readiness wait is bounded", async () => {
+	vi.useFakeTimers();
+	const fixture = setup();
+	fixture.api.index.initialized = false;
+	const assertion = expect(render(fixture)).rejects.toThrow(
+		"indexing did not finish within 15 seconds",
+	);
+	await vi.advanceTimersByTimeAsync(15001);
+	await assertion;
+});
+
+test("queries are bounded and results are recomputed for subsequent publications", async () => {
+	const fixture = setup();
+	await render(fixture);
+	fixture.queryMarkdown.mockResolvedValue({ successful: true, value: "Updated authors" });
+	expect(await render(fixture)).toContain("Updated authors");
+	vi.useFakeTimers();
+	fixture.queryMarkdown.mockImplementation(() => new Promise(() => {}));
+	const assertion = expect(render(fixture)).rejects.toThrow("exceeded 30 seconds");
+	await vi.advanceTimersByTimeAsync(30001);
+	await assertion;
+});

--- a/packages/obsidian/src/DataviewTransformer.ts
+++ b/packages/obsidian/src/DataviewTransformer.ts
@@ -1,0 +1,131 @@
+import type { App } from "obsidian";
+import { Effect } from "effect";
+import {
+	transformMarkdownCodeBlocks,
+	type MarkdownSourceTransformer,
+} from "@markdown-confluence/lib";
+
+/** The optional public Dataview API; no Dataview code is bundled or required by the CLI. */
+export interface DataviewApi {
+	index: {
+		initialized: boolean;
+		pages: Map<string, { mtime: { toMillis(): number } }>;
+	};
+	queryMarkdown(
+		query: string,
+		originFile: string,
+		settings: { allowHtml: false },
+	): Promise<{ successful: true; value: string } | { successful: false; error: string }>;
+}
+
+export interface DataviewSettings {
+	renderDataview: boolean;
+	ignoredCodeBlockLanguages?: readonly string[];
+}
+
+/** Create once per publication so changed dependency notes are checked again on every publish. */
+export function createDataviewTransformer(
+	app: App,
+	settings: DataviewSettings,
+): MarkdownSourceTransformer {
+	const ignoredLanguages = new Set(
+		settings.ignoredCodeBlockLanguages?.map((language) => language.trim().toLowerCase()),
+	);
+	let readyApi: DataviewApi | undefined;
+	const getApi = () =>
+		(
+			app as App & {
+				plugins?: { plugins?: { dataview?: { api?: DataviewApi } } };
+			}
+		).plugins?.plugins?.dataview?.api;
+
+	const waitForIndex = Effect.gen(function* () {
+		const api = getApi();
+		if (!api || typeof api.queryMarkdown !== "function") {
+			return yield* Effect.fail(
+				new Error("Enable Dataview in this vault to publish query results."),
+			);
+		}
+		// Dataview's metadata events are asynchronous. Comparing indexed mtimes also
+		// catches a dependency edited immediately before publishing, without a full reindex.
+		while (true) {
+			if (getApi() !== api)
+				return yield* Effect.fail(
+					new Error("Dataview was disabled or reloaded during publication."),
+				);
+			const files = app.vault.getMarkdownFiles();
+			const paths = new Set(files.map((file) => file.path));
+			if (
+				api.index.initialized &&
+				files.every(
+					(file) =>
+						(api.index.pages.get(file.path)?.mtime.toMillis() ?? -1) >= file.stat.mtime,
+				) &&
+				[...api.index.pages.keys()].every((filePath) => paths.has(filePath))
+			) {
+				return api;
+			}
+			yield* Effect.sleep("50 millis");
+		}
+	}).pipe(
+		Effect.timeout("15 seconds"),
+		Effect.mapError((error) =>
+			error instanceof Error && error.name !== "TimeoutError"
+				? error
+				: new Error(
+						"Dataview indexing did not finish within 15 seconds. Wait for indexing, then publish again.",
+					),
+		),
+	);
+
+	return {
+		transform(markdown, context) {
+			if (!settings.renderDataview) return Effect.succeed(markdown);
+			return transformMarkdownCodeBlocks(markdown, (block) =>
+				Effect.gen(function* () {
+					if (ignoredLanguages.has(block.language)) return undefined;
+					if (block.language === "dataviewjs") {
+						return yield* Effect.fail(
+							new Error(
+								"DataviewJS publication is not supported. Use a dataview TABLE, LIST or TASK query, or ignore dataviewjs blocks.",
+							),
+						);
+					}
+					if (block.language !== "dataview") return undefined;
+					const api = readyApi ?? (yield* waitForIndex);
+					readyApi = api;
+					if (getApi() !== api)
+						return yield* Effect.fail(
+							new Error("Dataview was disabled or reloaded during publication."),
+						);
+					// Obsidian's platform paths are vault paths with an optional leading slash.
+					const originFile = context.absoluteFilePath
+						.replaceAll("\\", "/")
+						.replace(/^\/+/, "");
+					const result = yield* Effect.tryPromise({
+						try: () =>
+							api.queryMarkdown(block.content, originFile, { allowHtml: false }),
+						catch: (error) =>
+							error instanceof Error ? error : new Error(String(error)),
+					}).pipe(
+						Effect.timeout("30 seconds"),
+						Effect.mapError((error) =>
+							error instanceof Error && error.name !== "TimeoutError"
+								? error
+								: new Error("Dataview query exceeded 30 seconds."),
+						),
+					);
+					if (!result.successful) return yield* Effect.fail(new Error(result.error));
+					return result.value;
+				}).pipe(
+					Effect.mapError(
+						(error) =>
+							new Error(
+								`Dataview in ${context.sourcePath} (line ${block.line}): ${error.message}`,
+							),
+					),
+				),
+			);
+		},
+	};
+}

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -10,6 +10,7 @@ import {
 	MarkdownConfluencePlatform,
 	MarkdownWorkspaceLive,
 	MarkdownWorkspaceService,
+	MarkdownSourceTransformerService,
 	createConfluenceClientConfig,
 	shouldPublishMarkdownFile,
 } from "@markdown-confluence/lib";
@@ -26,9 +27,11 @@ import {
 } from "./ConfluencePerPageForm";
 import { ObsidianPlatformLive } from "./effects/ObsidianPlatform";
 import type { Mermaid, MermaidConfig } from "mermaid";
+import { createDataviewTransformer } from "./DataviewTransformer";
 
 export interface ObsidianPluginSettings extends ConfluenceUploadSettings.ConfluenceSettings {
 	showPublishResultsModal: boolean;
+	renderDataview: boolean;
 	mermaidTheme:
 		| "match-obsidian"
 		| "light-obsidian"
@@ -381,7 +384,11 @@ export default class ConfluencePlugin extends Plugin {
 		this.settings = Object.assign(
 			{},
 			ConfluenceUploadSettings.DEFAULT_SETTINGS,
-			{ mermaidTheme: "match-obsidian", showPublishResultsModal: true },
+			{
+				mermaidTheme: "match-obsidian",
+				showPublishResultsModal: true,
+				renderDataview: false,
+			},
 			loaded,
 			{
 				// Deep-merge the nested plantuml object so a persisted partial (or
@@ -405,6 +412,10 @@ export default class ConfluencePlugin extends Plugin {
 		return Effect.runPromise(
 			effect.pipe(
 				Effect.provide(MarkdownWorkspaceLive),
+				Effect.provideService(
+					MarkdownSourceTransformerService,
+					createDataviewTransformer(this.app, this.settings),
+				),
 				Effect.provide(this.settingsLayer),
 				Effect.provide(this.platform),
 				Effect.mapError(toError),

--- a/scripts/integration-dataview.js
+++ b/scripts/integration-dataview.js
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { Effect } from "effect";
+
+const bibliographyPath = "Dataview Tests/Bibliography.md";
+const paperPath = "Dataview Tests/Papers/Paper.md";
+const contextPath = "Dataview Test Support/Context.md";
+const markerField = "connie-dataview-test: true";
+
+/** Invoked only by the explicit --dataview desktop profile, in its guarded test vault. */
+export function runDataviewIntegration({ evaluate, get, prefix = `Desktop ${Date.now()} ` }) {
+	return Effect.gen(function* () {
+		const originalSettings = yield* evaluate(`
+			const plugin = app.plugins.plugins['confluence-integration'];
+			if (!app.plugins.plugins.dataview?.api?.queryMarkdown) throw Error('Install and enable Dataview in the dedicated test vault for --dataview');
+			return JSON.stringify({renderDataview:plugin.settings.renderDataview,ignoredCodeBlockLanguages:plugin.settings.ignoredCodeBlockLanguages});
+		`);
+		const fixtures = {
+			[bibliographyPath]: `---\n${markerField}\nconnie-publish: true\nconnie-title: ${prefix}Dataview bibliography\n---\n# Bibliography\n\n[[${paperPath}|Referenced paper]]\n\n\`\`\`dataview\nTABLE authors AS Authors\nFROM "Dataview Tests/Papers"\nWHERE contains(this.file.outlinks, file.link)\n\`\`\`\n\n\`\`\`dataview\nLIST FROM "Dataview Tests/Papers"\n\`\`\`\n\n\`\`\`dataview\nTASK FROM "Dataview Tests/Papers"\n\`\`\`\n\n![[${contextPath}#Context]]\n`,
+			[paperPath]: `---\n${markerField}\nconnie-publish: true\nconnie-title: ${prefix}Dataview paper\nauthors: [Ada, Katherine]\n---\n# Paper\n\n- [ ] Read the paper\n- [x] Collect citation\n`,
+			[contextPath]: `---\n${markerField}\nconnie-publish: false\nlabel: Embedded source context\n---\n# Context\n\n\`\`\`dataview\nTABLE WITHOUT ID this.label AS Context\nWHERE file.path = this.file.path\n\`\`\`\n\n# Excluded section\n\`\`\`dataview\nTHIS IS AN INVALID QUERY THAT MUST NEVER RUN\n\`\`\`\n`,
+		};
+		for (const [filename, markdown] of Object.entries(fixtures)) {
+			yield* evaluate(`
+				const filename = ${JSON.stringify(filename)};
+				const existing = app.vault.getAbstractFileByPath(filename);
+				if (existing) {
+					if (!(await app.vault.read(existing)).includes(${JSON.stringify(markerField)})) throw Error('Refusing to replace an unowned Dataview fixture');
+				} else {
+					const parts = filename.split('/'); parts.pop(); let folder = '';
+					for (const part of parts) { folder += (folder ? '/' : '') + part; if (!app.vault.getAbstractFileByPath(folder)) await app.vault.createFolder(folder); }
+					await app.vault.create(filename, ${JSON.stringify(markdown)});
+				}
+				return JSON.stringify({ready:true});
+			`);
+		}
+		const read = (filename) =>
+			evaluate(
+				`return JSON.stringify(await app.vault.read(app.vault.getAbstractFileByPath(${JSON.stringify(filename)})));`,
+			);
+		const write = (filename, markdown) =>
+			evaluate(
+				`await app.vault.modify(app.vault.getAbstractFileByPath(${JSON.stringify(filename)}), ${JSON.stringify(markdown)}); return JSON.stringify({modified:true});`,
+			);
+		const publish = (filename) =>
+			evaluate(`
+			const result = await app.plugins.plugins['confluence-integration'].doPublish(${JSON.stringify(filename)});
+			if (result.errorMessage || result.failedFiles.length || result.filesUploadResult.length !== 1) throw Error('Dataview desktop publication failed');
+			return JSON.stringify({published:true});
+		`);
+		const page = (filename) =>
+			Effect.gen(function* () {
+				const source = yield* read(filename);
+				const pageId = source.match(/^connie-page-id:\s*['"]?(\d+)/m)?.[1];
+				assert.ok(pageId, `Missing Confluence ID in ${filename}`);
+				const remote = yield* get(
+					`content/${pageId}?expand=version,body.atlas_doc_format,space`,
+				);
+				return {
+					id: pageId,
+					version: remote.version.number,
+					// Confluence refreshes resolved link titles asynchronously, without a page edit.
+					body: JSON.parse(remote.body.atlas_doc_format.value, (key, value) =>
+						key === "__confluenceMetadata" ? undefined : value,
+					),
+					spaceKey: remote.space.key,
+				};
+			});
+		const result = yield* Effect.gen(function* () {
+			yield* evaluate(`
+				const plugin = app.plugins.plugins['confluence-integration'];
+				plugin.settings.renderDataview = true;
+				plugin.settings.ignoredCodeBlockLanguages = (plugin.settings.ignoredCodeBlockLanguages || []).filter(value => value.trim().toLowerCase() !== 'dataview');
+				await plugin.saveSettings(); return JSON.stringify({enabled:true});
+			`);
+			yield* publish(paperPath);
+			yield* publish(bibliographyPath);
+			const first = yield* page(bibliographyPath);
+			const paper = yield* page(paperPath);
+			const walk = (node) => [node, ...(node.content ?? []).flatMap(walk)];
+			const nodes = walk(first.body);
+			assert.equal(nodes.filter((node) => node.type === "table").length, 2);
+			assert.ok(nodes.some((node) => node.type === "bulletList"));
+			assert.ok(
+				nodes.some((node) => node.type === "taskItem" && node.attrs.state === "TODO"),
+			);
+			assert.ok(
+				nodes.some((node) => node.type === "taskItem" && node.attrs.state === "DONE"),
+			);
+			const serialized = JSON.stringify(first.body);
+			for (const text of ["Ada", "Katherine", "Embedded source context"])
+				assert.ok(serialized.includes(text), `Missing ${text}`);
+			assert.ok(!serialized.includes("wikilinks:"));
+			assert.ok(!serialized.includes("<ul>"));
+			assert.ok(
+				!nodes.some(
+					(node) => node.type === "codeBlock" && node.attrs?.language === "dataview",
+				),
+			);
+			assert.ok(
+				nodes.some((node) =>
+					(
+						node.attrs?.url ??
+						node.marks?.find((mark) => mark?.type === "link")?.attrs.href ??
+						""
+					).includes(`/pages/${paper.id}`),
+				),
+			);
+			const bibliographySource = yield* read(bibliographyPath);
+			const paperSource = yield* read(paperPath);
+			assert.ok(bibliographySource.includes("```dataview"));
+			assert.ok(bibliographySource.includes("contains(this.file.outlinks, file.link)"));
+			yield* publish(bibliographyPath);
+			assert.deepEqual(
+				yield* page(bibliographyPath),
+				first,
+				"Unchanged Dataview results changed the remote page",
+			);
+			let updated;
+			yield* Effect.gen(function* () {
+				assert.ok(
+					paperSource.includes("Ada"),
+					"Dataview fixture needs its original author restored",
+				);
+				yield* write(paperPath, paperSource.replace("Ada", "Grace"));
+				// No delay: publication must wait for Dataview's asynchronous dependency indexing.
+				yield* publish(bibliographyPath);
+				updated = yield* page(bibliographyPath);
+				assert.equal(updated.version, first.version + 1);
+				assert.ok(JSON.stringify(updated.body).includes("Grace"));
+				assert.ok(!JSON.stringify(updated.body).includes('"Ada"'));
+				yield* write(
+					bibliographyPath,
+					bibliographySource + "\n```dataview\nINVALID QUERY\n```\n",
+				);
+				const failure = yield* evaluate(`
+					try { await app.plugins.plugins['confluence-integration'].doPublish(${JSON.stringify(bibliographyPath)}); return JSON.stringify({failed:false}); }
+					catch (error) { return JSON.stringify({failed:true, hasSource:String(error.message).includes(${JSON.stringify(bibliographyPath)})}); }
+				`);
+				assert.deepEqual(failure, { failed: true, hasSource: true });
+				assert.deepEqual(
+					yield* page(bibliographyPath),
+					updated,
+					"Invalid query changed the remote page",
+				);
+			}).pipe(
+				Effect.ensuring(
+					Effect.gen(function* () {
+						yield* write(bibliographyPath, bibliographySource);
+						yield* write(paperPath, paperSource);
+						yield* publish(bibliographyPath);
+					}),
+				),
+			);
+			return {
+				status: "passed",
+				bibliographyId: first.id,
+				paperId: paper.id,
+				spaceKey: first.spaceKey,
+				checks: [
+					"native-table-list-task",
+					"outgoing-paper-links",
+					"embedded-source-context",
+					"source-preserved",
+					"unchanged",
+					"dependency-update",
+					"query-error-no-remote-update",
+				],
+			};
+		}).pipe(
+			Effect.ensuring(
+				evaluate(`
+			const plugin = app.plugins.plugins['confluence-integration']; Object.assign(plugin.settings, ${JSON.stringify(originalSettings)});
+			await plugin.saveSettings(); return JSON.stringify({settingsRestored:true});
+		`),
+			),
+		);
+		return result;
+	});
+}

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -5,6 +5,7 @@ import { FileSystem } from "effect/FileSystem";
 import { Path } from "effect/Path";
 import { RuntimeEnvironmentService } from "../packages/lib/src/effects/index.ts";
 import { vaultMarker } from "./integration-vault.js";
+import { runDataviewIntegration } from "./integration-dataview.js";
 
 const publishedNotes = [
 	"Release Tests/Release Tests.md",
@@ -26,7 +27,12 @@ export function parseObsidianOutput(output) {
 }
 
 /** Test the installed plugin in the real Electron/Obsidian runtime, without a UI mock. */
-export function runObsidianIntegration({ vaultPath, environment, reportDirectory }) {
+export function runObsidianIntegration({
+	vaultPath,
+	environment,
+	reportDirectory,
+	dataview = false,
+}) {
 	return Effect.gen(function* () {
 		const fs = yield* FileSystem;
 		const path = yield* Path;
@@ -197,6 +203,14 @@ export function runObsidianIntegration({ vaultPath, environment, reportDirectory
 		);
 		// Restore the remote fixture too, so the next run starts from the same note.
 		yield* publish();
+		if (dataview) {
+			const result = yield* runDataviewIntegration({ evaluate, get, prefix: marker.prefix });
+			yield* fs.writeFileString(
+				path.join(reportDirectory, "dataview.json"),
+				JSON.stringify(result, null, 2),
+			);
+		}
+
 		yield* fs.writeFileString(
 			path.join(reportDirectory, "obsidian.json"),
 			JSON.stringify(

--- a/scripts/integration-options.js
+++ b/scripts/integration-options.js
@@ -11,6 +11,7 @@ export function parseIntegrationOptions(argv) {
 		const argument = args.shift();
 		if (argument === "--") continue;
 		if (argument === "--skip-build") options.skipBuild = true;
+		else if (argument === "--dataview") options.dataview = true;
 		else if (argument === "--help") options.help = true;
 		else if (valueOptions[argument]) {
 			const value = args.shift();
@@ -18,6 +19,8 @@ export function parseIntegrationOptions(argv) {
 			options[valueOptions[argument]] = value;
 		} else throw new Error(`Unknown integration option: ${argument}`);
 	}
+	if (options.dataview && options.profile !== "obsidian")
+		throw new Error("--dataview requires the obsidian profile");
 	return options;
 }
 

--- a/scripts/integration-options.test.js
+++ b/scripts/integration-options.test.js
@@ -56,3 +56,10 @@ test("rejects ambiguous or credential-bearing test destinations", () => {
 		validateLiveEnvironment({ ...configured, CONFLUENCE_E2E_PARENT_ID: "not-a-page" }),
 	).toThrow("numeric page ID");
 });
+
+test("Dataview integration is explicitly limited to the desktop profile", () => {
+	expect(parseIntegrationOptions(["obsidian", "--dataview"]).dataview).toBe(true);
+	expect(() => parseIntegrationOptions(["live", "--dataview"])).toThrow(
+		"requires the obsidian profile",
+	);
+});

--- a/scripts/integration-tests.js
+++ b/scripts/integration-tests.js
@@ -22,6 +22,7 @@ const help = `Integration profiles (vp run test:integration [profile] [options])
   vault      Create a dedicated Obsidian fixture vault, or refresh only its plugin build.
   obsidian   Run the desktop plugin test in the prepared, open vault via Obsidian CLI.
 
+  --dataview            Also test Dataview in the obsidian profile (requires Dataview installed).
   --skip-build          Reuse the current build (CI/watch mode; does not check freshness).
   --vault PATH          Dedicated vault path; defaults to ../markdown-confluence-integration-vault.
   --settings-from PATH  Read test credentials from an existing plugin data.json.
@@ -306,6 +307,7 @@ function runIntegration() {
 					yield* step(
 						"Desktop plugin create/unchanged/update verification",
 						runObsidianIntegration({
+							dataview: options.dataview,
 							vaultPath,
 							environment,
 							reportDirectory,


### PR DESCRIPTION
Fenced Dataview queries currently publish as code or are omitted. This adds an optional **Publish Dataview results** setting that evaluates TABLE, LIST and TASK queries in Obsidian and feeds the resulting Markdown into the normal ADF, link and attachment pipeline.

The reusable asynchronous source hook runs during publication loading, including embedded sections with their original note context. Raw reads and frontmatter write-back preserve the saved queries. Single-note publication avoids evaluating other notes' queries while retaining their ordinary embeds and page mapping. Indexing and query waits are bounded, failures identify the source note, and explicitly ignored languages remain omitted.

Adds `vp run test:integration obsidian --dataview` and setup/extension documentation. DataviewJS, inline queries and calendar output are outside this first scope; DataviewJS/calendar blocks report unsupported output when rendering is enabled.

Validation:

- `vp run check`, `vp run fmt:check`, and the full workspace build passed.
- `vp test run`: 265 passed, one existing opt-in integration test skipped.
- Quick integration passed: CLI/library fixture parity, file/stdin/output conversion and Chromium diagram rendering.
- The final build passed the real Obsidian + Dataview 0.5.68 + Confluence desktop test: native tables/lists/tasks, outgoing paper links, embedded context, preserved queries, unchanged versions, immediate dependency-only updates and query errors without a remote update.

Related to #449. This PR does not attempt arbitrary DataviewJS DOM rendering.
