### PR TITLE
feat: publish inline and display LaTeX equations

### DIFF
--- a/documentation/LATEX.md
+++ b/documentation/LATEX.md
@@ -1,0 +1,39 @@
+# LaTeX equations
+
+Obsidian, the CLI and the Docker image automatically render LaTeX math during publication:
+
+```markdown
+Inline energy $E=mc^2$ stays in this sentence.
+
+$$
+\begin{aligned}
+a &= \frac{1}{2} \\
+b &= \sqrt{x^2+y^2}
+\end{aligned}
+$$
+```
+
+Inline equations become Confluence inline images; display equations become centered image blocks. Inline math also works in lists and table cells. Put `$$` on its own lines for multiline equations, or write a single-line display equation as `$$x^2$$`. Use display math for tall fractions and matrices: Confluence fits inline images to the surrounding line height.
+
+Rendering uses bundled MathJax 4 and TeX fonts locally, then uploads PNG attachments through the same authenticated client as other images. No Confluence Marketplace app, TeX installation, rendering server or extra credentials are needed. OAuth, scoped API tokens and unscoped API tokens use the existing publishing configuration. The source Markdown is not replaced with images on disk.
+
+Repeated expressions share an attachment within a page. Filenames include the source, display mode and rendering revision; PNG output is deterministic so unchanged equations do not cause attachment or page updates.
+
+The supported syntax is MathJax's TeX mathematics, including AMS environments and expression-local `\newcommand`. Full LaTeX documents, external files, HTML/URL macros, dynamically loaded extensions and document-wide macro definitions are not supported. Invalid equations fail the affected page's publication with an error instead of silently disappearing. Expressions are limited to 16,384 characters and rendered dimensions of 4096 pixels per side.
+
+Escaped dollars and dollar signs inside inline/fenced/indented code remain literal. Dollar delimiters must touch the equation (`$x$`, not `$ x $`); escape currency dollars when mixed with mathematics to avoid ambiguous delimiters.
+
+The file conversion commands preserve equation source as math extension nodes before publication and restore `$…$`/`$$…$$` on Markdown export. Published Confluence pages contain images: lossless export preserves those image nodes, not editable TeX. Confluence currently strips uploaded image alt text, so the original Markdown remains the source of truth.
+
+## Library integrations
+
+Register `new MathRendererPlugin(new PuppeteerMathRenderer())` with `Publisher`, alongside any other rendering plugins. `MathRendererPlugin`, `MathExpression` and `MathRenderer` are exported by `@markdown-confluence/lib`; `PuppeteerMathRenderer` and `ElectronMathRenderer` are exported by the existing Puppeteer and Electron renderer packages respectively. A custom renderer must return deterministic PNG buffers at twice the logical display size.
+
+## Verification
+
+- `vp test run`: math parsing, literal syntax, AMS rendering, invalid input, macro isolation, deduplication, placement and conversion round trips.
+- `vp run test:integration quick`: real Chromium equation rendering and identical PNG output across render sessions.
+- `vp run test:integration live`: real equation attachments, unchanged library/CLI republishing, updates, recovery and inline-comment preservation in the dedicated test space.
+- `vp run test:integration obsidian --vault /path/to/test-vault --dataview`: the built plugin's Electron renderer, unchanged pages/attachments and comments after edits elsewhere.
+
+See [Testing](TESTING.md) for the test vault and authentication setup. Live profiles require an explicitly configured test destination.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -320,3 +320,7 @@ Use `ignoredCodeBlockLanguages` to drop source-only Obsidian plugin blocks from 
   "ignoredCodeBlockLanguages": ["dataview", "button"]
 }
 ```
+
+## LaTeX equations
+
+Inline `$…$` and display `$$…$$` math are rendered locally to PNG attachments when publishing. No extra setup is required. See [LaTeX support](../../documentation/LATEX.md) for syntax, limitations and testing.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,12 +12,16 @@ import {
 	MarkdownConfluencePlatformLive,
 	Publisher,
 	MermaidRendererPlugin,
+	MathRendererPlugin,
 	PlantumlRendererPlugin,
 	RuntimeEnvironmentService,
 	createAuthenticatedConfluenceClient,
 	StandardInputLive,
 } from "@markdown-confluence/lib";
-import { PuppeteerMermaidRenderer } from "@markdown-confluence/mermaid-puppeteer-renderer";
+import {
+	PuppeteerMermaidRenderer,
+	PuppeteerMathRenderer,
+} from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { getErrorMessage } from "./errorMessage";
 import { convertDocument } from "./convert";
 import { HttpPlantumlRenderer } from "@markdown-confluence/plantuml-renderer";
@@ -31,6 +35,7 @@ const program = Effect.gen(function* () {
 	const confluenceClient = yield* createAuthenticatedConfluenceClient(settings);
 
 	const plugins: ADFProcessingPlugin<unknown, unknown>[] = [
+		new MathRendererPlugin(new PuppeteerMathRenderer()),
 		new MermaidRendererPlugin(
 			new PuppeteerMermaidRenderer({ protocolTimeout: settings.mermaidProtocolTimeout }),
 		),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -59,6 +59,8 @@
 		"@atlaskit/editor-json-transformer": "^9.8.0",
 		"@atlaskit/editor-prosemirror": "^8.0.3",
 		"@effect/platform-node": "4.0.0-rc.112",
+		"@mathjax/mathjax-tex-font": "^4.1.3",
+		"@mathjax/src": "^4.1.3",
 		"confluence.js": "^3.2.0",
 		"effect": "4.0.0-rc.112",
 		"glob": "^13.0.6",

--- a/packages/lib/src/ADFProcessingPlugins/MathRendererPlugin.ts
+++ b/packages/lib/src/ADFProcessingPlugins/MathRendererPlugin.ts
@@ -1,0 +1,81 @@
+import { filter, traverse } from "@atlaskit/adf-utils/traverse";
+import type { ADFEntity } from "@atlaskit/adf-utils/types";
+import type { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import SparkMD5 from "spark-md5";
+import type { UploadedImageData } from "../Attachments";
+import type { MathExpression, MathRenderer } from "../MathRenderer";
+import type { ADFProcessingPlugin, PublisherFunctions } from "./types";
+
+export function readMathExpression(node: ADFEntity): MathExpression | undefined {
+	if (
+		!["inlineExtension", "extension"].includes(node.type) ||
+		node.attrs?.["extensionType"] !== "markdown-confluence" ||
+		node.attrs?.["extensionKey"] !== "math"
+	)
+		return;
+	const parameters = node.attrs["parameters"];
+	if (typeof parameters?.source !== "string") return;
+	const display = node.type === "extension";
+	const source = parameters.source;
+	return {
+		source,
+		display,
+		name: `RenderedMath-${SparkMD5.hash(JSON.stringify(["mathjax4-tex-png-2x-v1", source, display]))}.png`,
+	};
+}
+
+export class MathRendererPlugin implements ADFProcessingPlugin<
+	MathExpression[],
+	Map<string, UploadedImageData>
+> {
+	constructor(private renderer: MathRenderer) {}
+	extract(adf: JSONDocNode): MathExpression[] {
+		const expressions = filter(adf, (node) => !!readMathExpression(node)).map(
+			(node) => readMathExpression(node)!,
+		);
+		return [
+			...new Map(expressions.map((expression) => [expression.name, expression])).values(),
+		];
+	}
+	async transform(expressions: MathExpression[], support: PublisherFunctions) {
+		const images = await this.renderer.captureMath(expressions);
+		const uploaded = new Map<string, UploadedImageData>();
+		for (const expression of expressions) {
+			const image = images.get(expression.name);
+			if (!image) throw new Error(`Math renderer did not produce ${expression.name}`);
+			const attachment = await support.uploadBuffer(expression.name, image, "image/png");
+			if (!attachment) throw new Error(`Math upload failed: ${expression.name}`);
+			uploaded.set(expression.name, attachment);
+		}
+		return uploaded;
+	}
+	load(adf: JSONDocNode, images: Map<string, UploadedImageData>): JSONDocNode {
+		const replace = (node: ADFEntity) => {
+			const expression = readMathExpression(node);
+			if (!expression) return;
+			const image = images.get(expression.name);
+			if (!image) throw new Error(`Missing rendered equation: ${expression.name}`);
+			const attrs = {
+				type: expression.display ? "file" : "image",
+				id: image.id,
+				collection: image.collection,
+				width: image.width / 2,
+				height: image.height / 2,
+			};
+			return expression.display
+				? {
+						type: "mediaSingle",
+						attrs: { layout: "center" },
+						content: [{ type: "media", attrs }],
+					}
+				: {
+						type: "mediaInline",
+						attrs,
+						...(node.marks?.some((mark) => mark.type === "link")
+							? { marks: node.marks.filter((mark) => mark.type === "link") }
+							: {}),
+					};
+		};
+		return traverse(adf, { extension: replace, inlineExtension: replace }) as JSONDocNode;
+	}
+}

--- a/packages/lib/src/ADFProcessingPlugins/types.ts
+++ b/packages/lib/src/ADFProcessingPlugins/types.ts
@@ -1,4 +1,6 @@
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import { filter } from "@atlaskit/adf-utils/traverse";
+import { readMathExpression } from "./MathRendererPlugin";
 import { Effect } from "effect";
 import {
 	CurrentAttachments,
@@ -160,6 +162,11 @@ export function executeADFProcessingPipelineEffect(
 		const finalADF = plugins.reduce((accADF, plugin, index) => {
 			return plugin.load(accADF, transformedData[index], supportFunctions);
 		}, adf);
+		if (filter(finalADF, (node) => !!readMathExpression(node)).length) {
+			return yield* Effect.fail(
+				new Error("LaTeX equations require MathRendererPlugin with a math renderer"),
+			);
+		}
 
 		return finalADF;
 	});

--- a/packages/lib/src/ADFToMarkdown.ts
+++ b/packages/lib/src/ADFToMarkdown.ts
@@ -1,3 +1,4 @@
+import { readMathExpression } from "./ADFProcessingPlugins/MathRendererPlugin";
 import { ADFEntity } from "@atlaskit/adf-utils/dist/types/types";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { fencedCode } from "./AdfDocument";
@@ -98,6 +99,8 @@ function renderADFContent(
 		return renderChildrenResult;
 	}
 
+	const math = readMathExpression(element);
+	if (math) return math.display ? `$$\n${math.source}\n$$` : `$${math.source}$`;
 	switch (element.type) {
 		case "doc": {
 			return new Error("Call renderADFDoc");

--- a/packages/lib/src/MarkdownTransformer/index.ts
+++ b/packages/lib/src/MarkdownTransformer/index.ts
@@ -10,6 +10,7 @@ import myTokenizer from "./callout";
 import wikilinksPlugin from "./wikilinks";
 import highlightPlugin from "./highlight";
 import formattingPlugin from "./formatting";
+import mathPlugin, { mathAttributes } from "./math";
 
 interface Transformer<T> {
 	encode(node: PMNode): T;
@@ -57,6 +58,8 @@ const pmSchemaToMdMapping: SchemaMapping = {
 };
 
 const mdToPmMapping = {
+	math_inline: { node: "inlineExtension", attrs: mathAttributes },
+	math_block: { node: "extension", attrs: mathAttributes },
 	alignment: { mark: "alignment", attrs: (token: any) => ({ align: token.attrGet("align") }) },
 	underline: { mark: "underline" },
 	subsup: { mark: "subsup", attrs: (token: any) => ({ type: token.attrGet("type") }) },
@@ -176,6 +179,7 @@ export class MarkdownTransformer implements Transformer<Markdown> {
 		tokenizer.use(wikilinksPlugin);
 		tokenizer.use(highlightPlugin);
 		tokenizer.use(formattingPlugin);
+		tokenizer.use(mathPlugin);
 
 		(["nodes", "marks"] as (keyof SchemaMapping)[]).forEach((key) => {
 			for (const idx in pmSchemaToMdMapping[key]) {

--- a/packages/lib/src/MarkdownTransformer/math.ts
+++ b/packages/lib/src/MarkdownTransformer/math.ts
@@ -1,0 +1,73 @@
+import type MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
+
+export function mathAttributes(token: Token) {
+	return {
+		extensionType: "markdown-confluence",
+		extensionKey: "math",
+		parameters: { source: token.content, display: token.type === "math_block" },
+	};
+}
+
+function closingDollar(source: string, start: number, delimiter: string): number {
+	for (let position = start; position < source.length; position++) {
+		if (source[position] === "\\") {
+			position++;
+			continue;
+		}
+		if (source.startsWith(delimiter, position)) return position;
+	}
+	return -1;
+}
+
+/** Tokenize before Markdown interprets underscores/backslashes in TeX. */
+export default function mathPlugin(md: MarkdownIt): void {
+	md.inline.ruler.before("escape", "math_inline", (state, silent) => {
+		if (
+			state.src[state.pos] !== "$" ||
+			state.src[state.pos - 1] === "$" ||
+			state.src[state.pos + 1] === "$" ||
+			/\s/.test(state.src[state.pos + 1] ?? " ")
+		)
+			return false;
+		const end = closingDollar(state.src.slice(0, state.posMax), state.pos + 1, "$");
+		if (end < 0 || /\s/.test(state.src[end - 1]!) || /\d/.test(state.src[end + 1] ?? ""))
+			return false;
+		const source = state.src.slice(state.pos + 1, end);
+		if (source.includes("\n")) return false;
+		if (!silent) state.push("math_inline", "", 0).content = source;
+		state.pos = end + 1;
+		return true;
+	});
+	md.block.ruler.before(
+		"fence",
+		"math_block",
+		(state, startLine, endLine, silent) => {
+			if (state.sCount[startLine]! - state.blkIndent >= 4) return false;
+			const start = state.bMarks[startLine]! + state.tShift[startLine]!;
+			if (!state.src.startsWith("$$", start)) return false;
+			const limit = state.bMarks[endLine] ?? state.src.length;
+			const end = closingDollar(state.src.slice(0, limit), start + 2, "$$");
+			if (end < 0) return false;
+			let lastLine = startLine;
+			while (lastLine + 1 < endLine && state.bMarks[lastLine + 1]! <= end) lastLine++;
+			if (state.src.slice(end + 2, state.eMarks[lastLine]).trim()) return false;
+			if (silent) return true;
+			const token = state.push("math_block", "", 0);
+			const lines: string[] = [];
+			for (let line = startLine; line <= lastLine; line++) {
+				lines.push(
+					state.src.slice(
+						line === startLine ? start + 2 : state.bMarks[line]! + state.tShift[line]!,
+						line === lastLine ? end : state.eMarks[line],
+					),
+				);
+			}
+			token.content = lines.join("\n").trim();
+			token.map = [startLine, lastLine + 1];
+			state.line = lastLine + 1;
+			return true;
+		},
+		{ alt: ["paragraph", "reference", "blockquote", "list"] },
+	);
+}

--- a/packages/lib/src/Math.test.ts
+++ b/packages/lib/src/Math.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import { filter } from "@atlaskit/adf-utils/traverse";
+import { convertADFToMarkdown } from "./AdfConversion";
+import { parseMarkdownToADF } from "./MdToADF";
+import { renderMathSvg } from "./MathRenderer";
+import { MathRendererPlugin, readMathExpression } from "./ADFProcessingPlugins/MathRendererPlugin";
+import { executeADFProcessingPipeline } from "./ADFProcessingPlugins/types";
+import type { PublisherFunctions } from "./ADFProcessingPlugins/types";
+
+const parse = (source: string) => parseMarkdownToADF(source, "https://example.atlassian.net");
+const expressions = (source: string) =>
+	filter(parse(source), (node) => !!readMathExpression(node)).map(
+		(node) => readMathExpression(node)!,
+	);
+
+describe("math parsing", () => {
+	it("keeps TeX intact and distinguishes inline/display layout", () => {
+		const result = expressions(String.raw`Before $x_i^2 + \frac{1}{2}$ after.
+
+$$
+\begin{pmatrix}1 & 2 \\ 3 & 4\end{pmatrix}
+$$`);
+		expect(result.map((item) => [item.source, item.display])).toEqual([
+			[String.raw`x_i^2 + \frac{1}{2}`, false],
+			[String.raw`\begin{pmatrix}1 & 2 \\ 3 & 4\end{pmatrix}`, true],
+		]);
+	});
+	it("leaves currency, escaped dollars and code unchanged", () => {
+		for (const source of [
+			"Cost $5 and $10.",
+			"\\$x$",
+			"`$x$`",
+			"```tex\n$x$\n```",
+			"    $x$",
+			"Unclosed $x",
+		])
+			expect(expressions(source)).toEqual([]);
+	});
+	it("strips Markdown containers from multiline display math", () => {
+		expect(expressions("> $$\n> x+1\n> $$")[0]!.source).toBe("x+1");
+		expect(expressions("- $$\n  x+1\n  $$")[0]!.source).toBe("x+1");
+	});
+	it("supports lists, tables and escaped dollar signs in equations", () => {
+		expect(
+			expressions("- $x$\n\n| Value |\n| --- |\n| $y$ |\n\n$\\text{\\$5}$").map(
+				(item) => item.source,
+			),
+		).toEqual(["x", "y", String.raw`\text{\$5}`]);
+	});
+});
+
+describe("local rendering", () => {
+	it("renders the entire inline expression as one SVG", () => {
+		const svg = renderMathSvg({ source: "E=mc^2", display: false });
+		expect(svg.match(/<svg /g)).toHaveLength(1);
+		expect(svg).toContain('data-c="1D438"');
+		expect(svg).toContain('data-c="32"');
+	});
+	it.each([
+		String.raw`x_i^2+\frac{1}{2}`,
+		String.raw`\begin{pmatrix}1 & 2\\3 & 4\end{pmatrix}`,
+		String.raw`\begin{aligned}a&=b+c\\d&=e\end{aligned}`,
+	])("renders %s with self-contained paths", (source) => {
+		const svg = renderMathSvg({ source, display: true });
+		expect(svg).toContain("<path");
+		expect(svg).not.toContain("<merror");
+		expect(svg).not.toContain("<use");
+		expect(renderMathSvg({ source, display: true })).toBe(svg);
+	});
+	it("rejects invalid TeX, remote resources and excessive input", () => {
+		for (const source of [
+			String.raw`\frac{`,
+			String.raw`\href{https://example.com}{x}`,
+			String.raw`\require{html}`,
+			"x".repeat(16385),
+		])
+			expect(() => renderMathSvg({ source, display: false })).toThrow();
+	});
+	it("isolates custom macros between expressions", () => {
+		renderMathSvg({ source: String.raw`\newcommand{\custom}{x}\custom`, display: false });
+		expect(() => renderMathSvg({ source: String.raw`\custom`, display: false })).toThrow();
+	});
+});
+
+it("deduplicates attachments while preserving inline position and display blocks", async () => {
+	const captureMath = vi.fn(
+		async (items) =>
+			new Map(items.map((item: { name: string }) => [item.name, Buffer.from("png")])),
+	);
+	const plugin = new MathRendererPlugin({ captureMath });
+	const adf = parse("Before $x$ middle $x$ after.\n\n$$x$$");
+	const uploadBuffer = vi.fn(async (filename) => ({
+		filename,
+		id: filename,
+		collection: "test",
+		width: 20,
+		height: 16,
+		status: "uploaded",
+	}));
+	const items = plugin.extract(adf);
+	expect(items).toHaveLength(2);
+	const images = await plugin.transform(items, { uploadBuffer } as unknown as PublisherFunctions);
+	const output = plugin.load(adf, images);
+	expect(uploadBuffer).toHaveBeenCalledTimes(2);
+	expect(output.content![0]!.content!.map((node) => node.type)).toEqual([
+		"text",
+		"mediaInline",
+		"text",
+		"mediaInline",
+		"text",
+	]);
+	expect(output.content![1]!.type).toBe("mediaSingle");
+	expect(output.content![0]!.content![1]!.attrs).toMatchObject({
+		type: "image",
+		width: 10,
+		height: 8,
+	});
+});
+
+it("fails instead of silently dropping equations when a renderer returns no image", async () => {
+	const plugin = new MathRendererPlugin({ captureMath: async () => new Map() });
+	await expect(
+		plugin.transform(plugin.extract(parse("$x$")), {} as PublisherFunctions),
+	).rejects.toThrow("did not produce");
+});
+
+it("round trips equation source through the file conversion APIs", () => {
+	const document = parse("Before $x_i^2$ after.\n\n$$\\frac{1}{2}$$");
+	const markdown = convertADFToMarkdown(document);
+	expect(markdown).toContain("$x_i^2$");
+	expect(markdown).toContain(String.raw`\frac{1}{2}`);
+	expect(parse(markdown)).toEqual(document);
+});
+
+it("reports missing library renderer configuration before uploading unsupported ADF", async () => {
+	await expect(
+		executeADFProcessingPipeline([], parse("$x$"), {} as PublisherFunctions),
+	).rejects.toThrow("require MathRendererPlugin");
+});

--- a/packages/lib/src/MathRenderer.ts
+++ b/packages/lib/src/MathRenderer.ts
@@ -1,0 +1,82 @@
+import { mathjax } from "@mathjax/src/js/mathjax.js";
+import { TeX } from "@mathjax/src/js/input/tex.js";
+import { SVG } from "@mathjax/src/js/output/svg.js";
+import { liteAdaptor } from "@mathjax/src/js/adaptors/liteAdaptor.js";
+import { RegisterHTMLHandler } from "@mathjax/src/js/handlers/html.js";
+import { MathJaxTexFont } from "@mathjax/mathjax-tex-font/js/svg.js";
+import "@mathjax/src/js/input/tex/base/BaseConfiguration.js";
+import "@mathjax/src/js/input/tex/ams/AmsConfiguration.js";
+import "@mathjax/src/js/input/tex/newcommand/NewcommandConfiguration.js";
+
+export interface MathExpression {
+	name: string;
+	source: string;
+	display: boolean;
+}
+export interface MathRenderer {
+	captureMath(expressions: MathExpression[]): Promise<Map<string, Buffer>>;
+}
+
+const adaptor = liteAdaptor();
+RegisterHTMLHandler(adaptor);
+
+/** Fully local, path-based SVG: no font downloads, HTML, URLs or TeX file access. */
+export function renderMathSvg(expression: Pick<MathExpression, "source" | "display">): string {
+	if (!expression.source.trim() || expression.source.length > 16384)
+		throw new Error("Math expression must contain 1–16384 characters");
+	// A fresh input jax isolates user macros and equation numbering between expressions.
+	const tex = new TeX({
+		packages: ["base", "ams", "newcommand"],
+		maxBuffer: 16384,
+		maxMacros: 1000,
+		formatError: (_jax: unknown, error: Error) => {
+			throw new Error(`Invalid LaTeX: ${error.message}`);
+		},
+	});
+	const document = mathjax.document("", {
+		InputJax: tex,
+		OutputJax: new SVG({
+			fontCache: "none",
+			fontData: MathJaxTexFont,
+			linebreaks: { inline: false },
+		}),
+	});
+	const result = document.convert(expression.source, {
+		display: expression.display,
+		em: 16,
+		ex: 8,
+		containerWidth: 1024,
+	});
+	return adaptor.innerHTML(result);
+}
+
+/** Rasterizers load only this generated document, with network/script access disabled. */
+export function mathImageHtml(expression: Pick<MathExpression, "source" | "display">): string {
+	return `<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'"><style>html,body{margin:0;background:white;color:black}body{font-size:16px}#math{display:inline-block;padding:2px}svg{vertical-align:middle}</style></head><body><div id="math">${renderMathSvg(expression)}</div></body></html>`;
+}
+
+/** Runs in an isolated browser page. Canvas avoids compositor-dependent screenshot bytes. */
+export async function rasterizeMathImage(): Promise<string> {
+	const svg = document.querySelector("#math svg");
+	if (!svg) throw new Error("Math renderer produced no SVG");
+	const bounds = svg.getBoundingClientRect();
+	const width = Math.ceil(bounds.width) + 4;
+	const height = Math.ceil(bounds.height) + 4;
+	if (width < 1 || height < 1 || width > 4096 || height > 4096)
+		throw new Error("Rendered equation exceeds the 4096 pixel size limit");
+	svg.setAttribute("width", String(bounds.width));
+	svg.setAttribute("height", String(bounds.height));
+	svg.setAttribute("color", "black");
+	const image = new Image();
+	image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(new XMLSerializer().serializeToString(svg))}`;
+	await image.decode();
+	const canvas = document.createElement("canvas");
+	canvas.width = width * 2;
+	canvas.height = height * 2;
+	const context = canvas.getContext("2d");
+	if (!context) throw new Error("Math renderer could not create a canvas");
+	context.fillStyle = "white";
+	context.fillRect(0, 0, canvas.width, canvas.height);
+	context.drawImage(image, 4, 4, bounds.width * 2, bounds.height * 2);
+	return canvas.toDataURL("image/png");
+}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,4 @@
+import { normalizeAdfForComparison } from "./AdfEqual";
 import {
 	MarkdownSourceTransformerService,
 	type MarkdownSourceTransformer,
@@ -92,6 +93,7 @@ import {
 } from "./SettingsConfig";
 
 export {
+	normalizeAdfForComparison,
 	type ConfluenceFetch,
 	MarkdownSourceTransformerService,
 	type MarkdownSourceTransformer,
@@ -172,4 +174,23 @@ export {
 	type RequiredConfluenceClient,
 	type RuntimeEnvironment,
 	type UploadAdfFileResult,
+};
+
+import { MathRendererPlugin, readMathExpression } from "./ADFProcessingPlugins/MathRendererPlugin";
+import {
+	renderMathSvg,
+	mathImageHtml,
+	rasterizeMathImage,
+	type MathExpression,
+	type MathRenderer,
+} from "./MathRenderer";
+
+export {
+	MathRendererPlugin,
+	readMathExpression,
+	renderMathSvg,
+	mathImageHtml,
+	rasterizeMathImage,
+	type MathExpression,
+	type MathRenderer,
 };

--- a/packages/mermaid-electron-renderer/src/ElectronMathRenderer.ts
+++ b/packages/mermaid-electron-renderer/src/ElectronMathRenderer.ts
@@ -1,0 +1,40 @@
+import { BrowserWindow } from "@electron/remote";
+import {
+	mathImageHtml,
+	rasterizeMathImage,
+	type MathExpression,
+	type MathRenderer,
+} from "@markdown-confluence/lib";
+
+export class ElectronMathRenderer implements MathRenderer {
+	async captureMath(expressions: MathExpression[]): Promise<Map<string, Buffer>> {
+		const images = new Map<string, Buffer>();
+		if (!expressions.length) return images;
+		const window = new BrowserWindow({
+			width: 2048,
+			height: 1024,
+			show: false,
+			frame: false,
+			webPreferences: {
+				nodeIntegration: false,
+				contextIsolation: true,
+				sandbox: true,
+				backgroundThrottling: false,
+			},
+		});
+		try {
+			for (const expression of expressions) {
+				await window.loadURL(
+					`data:text/html;charset=utf-8,${encodeURIComponent(mathImageHtml(expression))}`,
+				);
+				const png: string = await window.webContents.executeJavaScript(
+					`(${rasterizeMathImage.toString()})()`,
+				);
+				images.set(expression.name, Buffer.from(png.split(",")[1]!, "base64"));
+			}
+		} finally {
+			window.close();
+		}
+		return images;
+	}
+}

--- a/packages/mermaid-electron-renderer/src/index.ts
+++ b/packages/mermaid-electron-renderer/src/index.ts
@@ -122,3 +122,7 @@ export class ElectronMermaidRenderer implements MermaidRenderer {
 		return new Blob([fileContents], { type: "text/html" });
 	}
 }
+
+import { ElectronMathRenderer } from "./ElectronMathRenderer";
+
+export { ElectronMathRenderer };

--- a/packages/mermaid-puppeteer-renderer/src/PuppeteerMathRenderer.ts
+++ b/packages/mermaid-puppeteer-renderer/src/PuppeteerMathRenderer.ts
@@ -1,0 +1,33 @@
+import puppeteer from "puppeteer";
+import { downloadBrowsers } from "puppeteer/lib/puppeteer/node/install.js";
+import {
+	mathImageHtml,
+	rasterizeMathImage,
+	type MathExpression,
+	type MathRenderer,
+} from "@markdown-confluence/lib";
+
+export class PuppeteerMathRenderer implements MathRenderer {
+	async captureMath(expressions: MathExpression[]): Promise<Map<string, Buffer>> {
+		const images = new Map<string, Buffer>();
+		if (!expressions.length) return images;
+		await downloadBrowsers();
+		const browser = await puppeteer.launch({
+			headless: true,
+			args: ["--no-sandbox", "--disable-setuid-sandbox"],
+		});
+		try {
+			const page = await browser.newPage();
+			await page.setJavaScriptEnabled(false);
+			await page.setViewport({ width: 2048, height: 1024, deviceScaleFactor: 2 });
+			for (const expression of expressions) {
+				await page.setContent(mathImageHtml(expression));
+				const png = await page.evaluate(rasterizeMathImage);
+				images.set(expression.name, Buffer.from(png.split(",")[1]!, "base64"));
+			}
+		} finally {
+			await browser.close();
+		}
+		return images;
+	}
+}

--- a/packages/mermaid-puppeteer-renderer/src/index.ts
+++ b/packages/mermaid-puppeteer-renderer/src/index.ts
@@ -108,3 +108,7 @@ export class PuppeteerMermaidRenderer implements MermaidRenderer {
 		return capturedCharts;
 	}
 }
+
+import { PuppeteerMathRenderer } from "./PuppeteerMathRenderer";
+
+export { PuppeteerMathRenderer };

--- a/packages/obsidian/README.md
+++ b/packages/obsidian/README.md
@@ -109,3 +109,7 @@ This project is licensed under the [Apache 2.0](https://github.com/markdown-conf
 
 ## Disclaimer:
 The Apache license is only applicable to the Obsidian Confluence Integration (“Integration“), not to any third parties' services, websites, content or platforms that this Integration may enable you to connect with.  In another word, there is no license granted to you by the above identified licensor(s) to access any third-party services, websites, content, or platforms.  You are solely responsible for obtaining licenses from such third parties to use and access their services and to comply with their license terms. Please do not disclose any passwords, credentials, or tokens to any third-party service in your contribution to this Obsidian Confluence Integration project.”
+
+## LaTeX equations
+
+Inline `$…$` and display `$$…$$` math are rendered locally to PNG attachments when publishing. No extra setup is required. See [LaTeX support](../../documentation/LATEX.md) for syntax, limitations and testing.

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -414,6 +414,12 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("LaTeX equations")
+			.setDesc(
+				"Inline $...$ and display $$...$$ equations are rendered locally as images when publishing. Your Markdown source stays unchanged. No additional server or setup is required.",
+			);
+
+		new Setting(containerEl)
 			.setName("Mermaid Diagram Theme")
 			.setDesc("Pick the theme to apply to mermaid diagrams")
 			.addDropdown((dropdown) => {

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -5,6 +5,7 @@ import {
 	Publisher,
 	ConfluencePageConfig,
 	MermaidRendererPlugin,
+	MathRendererPlugin,
 	PlantumlRendererPlugin,
 	UploadAdfFileResult,
 	MarkdownConfluencePlatform,
@@ -14,7 +15,10 @@ import {
 	shouldPublishMarkdownFile,
 } from "@markdown-confluence/lib";
 import { Effect, Layer } from "effect";
-import { ElectronMermaidRenderer } from "@markdown-confluence/mermaid-electron-renderer";
+import {
+	ElectronMermaidRenderer,
+	ElectronMathRenderer,
+} from "@markdown-confluence/mermaid-electron-renderer";
 import { HttpPlantumlRenderer } from "@markdown-confluence/plantuml-renderer";
 import { ConfluenceSettingTab } from "./ConfluenceSettingTab";
 import { CompletedModal } from "./CompletedModal";
@@ -136,6 +140,7 @@ export default class ConfluencePlugin extends Plugin {
 		);
 
 		const plugins: ADFProcessingPlugin<unknown, unknown>[] = [
+			new MathRendererPlugin(new ElectronMathRenderer()),
 			new MermaidRendererPlugin(mermaidRenderer),
 		];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,12 @@ importers:
       '@effect/platform-node':
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      '@mathjax/mathjax-tex-font':
+        specifier: ^4.1.3
+        version: 4.1.3
+      '@mathjax/src':
+        specifier: ^4.1.3
+        version: 4.1.3
       confluence.js:
         specifier: ^3.2.0
         version: 3.2.0
@@ -676,6 +682,15 @@ packages:
 
   '@marijn/find-cluster-break@1.0.4':
     resolution: {integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==}
+
+  '@mathjax/mathjax-newcm-font@4.1.3':
+    resolution: {integrity: sha512-gzAB3dFHilHX1l5x2xUqRL+1jDQt3Fyza1DkEMVXWC4E8SvsGdlgEza47HYi2WhVcgfkvf4zgUGzuhbq3Pjlew==}
+
+  '@mathjax/mathjax-tex-font@4.1.3':
+    resolution: {integrity: sha512-9B78brBEmmAwyumaREIyM1gF2HgDamDIXA36UyeXWxX7XrpLdmoSB5NLIf/c6tEA4L6xNrIdMxfgY6YX/kcSNw==}
+
+  '@mathjax/src@4.1.3':
+    resolution: {integrity: sha512-rIrWquuBSoJuoMBdC/1qD+AUHTorlccPicoVy6P2xbUgnuDBpCcpbHtOAsB8L3hdCHtNBg92lF8e3Fz+pkcQbw==}
 
   '@mermaid-js/parser@1.2.1':
     resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
@@ -1532,6 +1547,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
+    engines: {node: '>=14.6'}
+
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -2241,6 +2260,9 @@ packages:
   mermaid@11.17.2:
     resolution: {integrity: sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==}
 
+  mhchemparser@4.2.1:
+    resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -2267,6 +2289,9 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mj-context-menu@1.0.0:
+    resolution: {integrity: sha512-OSgBFQRCVhrZwRa9lhqnKcJU92dd/YXgBjup0uyeuj9bOaVsf4myOyrjU4PfhYkdDk6AqVUTov7v5uFMvIbduA==}
 
   modern-tar@0.8.4:
     resolution: {integrity: sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==}
@@ -2385,6 +2410,9 @@ packages:
         optional: true
       vite-plus:
         optional: true
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
@@ -2521,6 +2549,11 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -2605,6 +2638,10 @@ packages:
 
   spark-md5@3.0.2:
     resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
+
+  speech-rule-engine@5.0.0-rc.4:
+    resolution: {integrity: sha512-3dFcH2QtQNhtvUUc09TxoaEK4WG03B9Z57krFG9jocrKykKGu35BhIkWr0vgEAxZZomEWkeluff69y/EbYzP4Q==}
+    hasBin: true
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -2771,6 +2808,9 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  wicked-good-xpath@1.3.0:
+    resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
@@ -3459,6 +3499,17 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.4': {}
 
+  '@mathjax/mathjax-newcm-font@4.1.3': {}
+
+  '@mathjax/mathjax-tex-font@4.1.3': {}
+
+  '@mathjax/src@4.1.3':
+    dependencies:
+      '@mathjax/mathjax-newcm-font': 4.1.3
+      mhchemparser: 4.2.1
+      mj-context-menu: 1.0.0
+      speech-rule-engine: 5.0.0-rc.4
+
   '@mermaid-js/parser@1.2.1':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -4069,6 +4120,8 @@ snapshots:
 
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.24':
     optional: true
+
+  '@xmldom/xmldom@0.9.12': {}
 
   ajv@8.18.0:
     dependencies:
@@ -4735,6 +4788,8 @@ snapshots:
       ts-dedent: 2.3.0
       uuid: 14.0.2
 
+  mhchemparser@4.2.1: {}
+
   mime-db@1.54.0: {}
 
   mime-types@3.0.2:
@@ -4752,6 +4807,10 @@ snapshots:
   minipass@7.1.3: {}
 
   mitt@3.0.1: {}
+
+  mj-context-menu@1.0.0:
+    dependencies:
+      rimraf: 6.1.3
 
   modern-tar@0.8.4: {}
 
@@ -4904,6 +4963,8 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.5)(typescript@6.0.3)(yaml@2.9.0))(typescript@6.0.3)(yaml@2.9.0)
+
+  package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.8.0: {}
 
@@ -5069,6 +5130,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
+
   robust-predicates@3.0.3: {}
 
   rope-sequence@1.3.4: {}
@@ -5149,6 +5215,12 @@ snapshots:
   source-map@0.7.6: {}
 
   spark-md5@3.0.2: {}
+
+  speech-rule-engine@5.0.0-rc.4:
+    dependencies:
+      '@xmldom/xmldom': 0.9.12
+      commander: 14.0.3
+      wicked-good-xpath: 1.3.0
 
   std-env@4.2.0: {}
 
@@ -5320,6 +5392,8 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wicked-good-xpath@1.3.0: {}
 
   widest-line@5.0.0:
     dependencies:

--- a/scripts/confluence-release-e2e.js
+++ b/scripts/confluence-release-e2e.js
@@ -14,13 +14,17 @@ import {
 	ConfluenceUploadSettings,
 	MarkdownConfluencePlatformLive,
 	MermaidRendererPlugin,
+	MathRendererPlugin,
 	PlantumlRendererPlugin,
 	Publisher,
 	RuntimeEnvironmentService,
 	createAuthenticatedConfluenceClient,
 	parseMarkdownToADF,
 } from "../packages/lib/dist/index.js";
-import { PuppeteerMermaidRenderer } from "../packages/mermaid-puppeteer-renderer/dist/index.js";
+import {
+	PuppeteerMermaidRenderer,
+	PuppeteerMathRenderer,
+} from "../packages/mermaid-puppeteer-renderer/dist/index.js";
 import { HttpPlantumlRenderer } from "../packages/plantuml-renderer/dist/index.js";
 import { liveConnectionSettings } from "./integration-options.js";
 
@@ -128,6 +132,7 @@ const program = Effect.scoped(
 			return updateContent(parameters);
 		};
 		const publisher = new Publisher(settings, client, [
+			new MathRendererPlugin(new PuppeteerMathRenderer()),
 			new MermaidRendererPlugin(
 				new PuppeteerMermaidRenderer({ protocolTimeout: settings.mermaidProtocolTimeout }),
 			),
@@ -198,6 +203,7 @@ const program = Effect.scoped(
 			JSON.parse(formattingPage.body.atlas_doc_format.value),
 		);
 		for (const expected of [
+			'"type":"mediaInline"',
 			'"type":"strong"',
 			'"type":"panel"',
 			'"extensionKey":"toc"',

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -69,8 +69,11 @@ export function runObsidianIntegration({
 						);
 					}),
 			);
-		const { createAuthenticatedConfluenceClient, ConfluenceUploadSettings } =
-			yield* Effect.tryPromise(() => import("../packages/lib/dist/index.js"));
+		const {
+			createAuthenticatedConfluenceClient,
+			ConfluenceUploadSettings,
+			normalizeAdfForComparison,
+		} = yield* Effect.tryPromise(() => import("../packages/lib/dist/index.js"));
 		const parentId = environment.CONFLUENCE_E2E_PARENT_ID;
 		const connection = liveConnectionSettings(environment);
 		const client = yield* createAuthenticatedConfluenceClient({
@@ -214,15 +217,8 @@ export function runObsidianIntegration({
 					pages[filename] = {
 						id: pageId,
 						version: page.version.number,
-						body: JSON.parse(page.body.atlas_doc_format.value, (key, value) =>
-							[
-								"__fileName",
-								"__fileSize",
-								"__fileMimeType",
-								"__confluenceMetadata",
-							].includes(key)
-								? undefined
-								: value,
+						body: normalizeAdfForComparison(
+							JSON.parse(page.body.atlas_doc_format.value),
 						),
 						ancestors: page.ancestors.map((ancestor) => ancestor.id),
 						attachments: Object.fromEntries(
@@ -270,8 +266,25 @@ export function runObsidianIntegration({
 			`const file=app.vault.getAbstractFileByPath('Release Tests/Formatting.md'); const text=await app.vault.read(file); if(!text.includes(${JSON.stringify(inlineCommentSelection)})) await app.vault.modify(file,text+${JSON.stringify("\n\n" + inlineCommentSelection + "\n")}); return JSON.stringify({fixtureReady:true});`,
 		);
 
+		const mathFixture =
+			"\n\n## LaTeX integration\n\nInline energy $E=mc^2$ stays in this sentence.\n\n$$\\frac{1}{2}$$\n";
+		yield* evaluate(
+			`const file=app.vault.getAbstractFileByPath('Release Tests/Formatting.md'); const text=await app.vault.read(file); if(!text.includes('Inline energy $E=mc^2$')) await app.vault.modify(file,text+${JSON.stringify(mathFixture)}); return JSON.stringify({mathFixtureReady:true});`,
+		);
 		yield* publish();
 		let first = yield* snapshot();
+		assert.ok(
+			JSON.stringify(first["Release Tests/Formatting.md"].body).includes(
+				'"type":"mediaInline"',
+			),
+			"Desktop math must remain inline",
+		);
+		assert.ok(
+			Object.keys(first["Release Tests/Formatting.md"].attachments).some((name) =>
+				name.startsWith("RenderedMath-"),
+			),
+			"Desktop math PNG attachments must exist",
+		);
 		yield* publish();
 		assert.deepEqual(
 			yield* snapshot(),

--- a/scripts/integration-package-smoke.js
+++ b/scripts/integration-package-smoke.js
@@ -5,7 +5,9 @@ export async function verifyPackageImports(resolvePackage) {
 	const libraryUrl = resolvePackage("lib");
 	const library = await import(libraryUrl);
 	const { HttpPlantumlRenderer } = await import(resolvePackage("plantuml-renderer"));
-	const { PuppeteerMermaidRenderer } = await import(resolvePackage("mermaid-puppeteer-renderer"));
+	const { PuppeteerMermaidRenderer, PuppeteerMathRenderer } = await import(
+		resolvePackage("mermaid-puppeteer-renderer")
+	);
 	const adf = library.parseMarkdownToADF(
 		"# Integration check\n\n中文 café ✓\n\n```toc\n```\n\n**Bold** and [link](https://example.com).",
 		"https://example.atlassian.net",
@@ -37,7 +39,16 @@ export async function verifyPackageImports(resolvePackage) {
 		[137, 80, 78, 71, 13, 10, 26, 10],
 	);
 	assert.ok(images.get("integration.png").length > 100);
+	const math = new PuppeteerMathRenderer();
+	const equation = [{ name: "equation.png", source: String.raw`\frac{1}{2}`, display: true }];
+	const firstMath = (await math.captureMath(equation)).get("equation.png");
+	assert.deepEqual([...firstMath.subarray(0, 8)], [137, 80, 78, 71, 13, 10, 26, 10]);
+	assert.deepEqual(
+		(await math.captureMath(equation)).get("equation.png"),
+		firstMath,
+		"Math PNGs must be deterministic across render sessions",
+	);
 	console.log(
-		"Package imports, Markdown/TOC, PlantUML contract and real Chromium rendering passed.",
+		"Package imports, Markdown/TOC, PlantUML contract and real Chromium Mermaid/LaTeX rendering passed.",
 	);
 }

--- a/scripts/integration-regressions.js
+++ b/scripts/integration-regressions.js
@@ -301,6 +301,8 @@ await runEffect(
 								: `docs/Note ${String(index).padStart(3, "0")}.md`;
 						files.push(filename);
 						let body = `---\nconnie-title: ${prefix} ${index === 0 ? "Root" : `Note ${index}`}\n---\n# Synthetic note ${index}\n\nVerification for publish-action #4 and #3.\n`;
+						if (index === 0)
+							body += "\nInline $E=mc^2$ remains inline.\n\n$$\\frac{1}{2}$$\n";
 						if (index % 10 === 0)
 							body += `\n\`\`\`mermaid\nflowchart LR\n  A[Note ${index}] --> B[Rendered] --> C[Published]\n\`\`\`\n`;
 						if (index === 1)
@@ -332,6 +334,19 @@ await runEffect(
 					);
 					const before = await snapshot(files);
 					assert.equal(Object.keys(before).length, noteCount);
+					const rootMath = before["docs/docs.md"];
+					assert.equal(
+						nodes(rootMath.adf, "mediaInline").length,
+						1,
+						"Container math must stay inline",
+					);
+					assert.equal(
+						rootMath.attachments.filter((item) =>
+							item.title.startsWith("RenderedMath-"),
+						).length,
+						2,
+						"Container must upload inline and display equation PNGs",
+					);
 					const media = before["docs/Note 001.md"];
 					assert.equal(
 						nodes(media.adf, "media").filter((node) => node.attrs.type === "file")
@@ -444,6 +459,21 @@ await runEffect(
 						recovered.version.number,
 					);
 					await publish("timeout-recovery", "failure");
+					assert.equal(
+						(await pageFor("failure/failure.md")).version.number,
+						recovered.version.number,
+					);
+					const validSource = await readFile(failureFile);
+					await writeFile(failureFile, validSource + "\n\n$\\frac{$\n");
+					const invalidMath = await publish("invalid-math", "failure", "180000", 1);
+					assert.match(invalidMath, /Invalid LaTeX/);
+					assert.equal(
+						(await pageFor("failure/failure.md")).version.number,
+						recovered.version.number,
+						"Invalid math must leave the remote page unchanged",
+					);
+					await writeFile(failureFile, validSource);
+					await publish("math-recovery", "failure");
 					assert.equal(
 						(await pageFor("failure/failure.md")).version.number,
 						recovered.version.number,

--- a/test-fixtures/release-vault/Release Tests/Formatting.md
+++ b/test-fixtures/release-vault/Release Tests/Formatting.md
@@ -29,3 +29,18 @@ THIS BLOCK MUST NOT BE PUBLISHED
 [[#Local heading|Jump within this page]]
 
 Inline comment anchor stays here.
+
+## Equations
+
+Inline energy $E=mc^2$ stays in this sentence.
+
+$$
+\begin{aligned}
+a &= \frac{1}{2} \\
+b &= \sqrt{x^2+y^2}
+\end{aligned}
+$$
+
+| Equation | Meaning |
+| --- | --- |
+| $x_i^2$ | A squared component |


### PR DESCRIPTION
Publish `$…$` equations as inline Confluence images and `$$…$$` equations as centered image blocks, using local MathJax 4 rendering in Obsidian, the CLI and Docker. This adds the missing math tokenizer, shared rendering/upload plugin, bundled TeX fonts, and deterministic PNG generation. Original Markdown remains editable on disk.

The integration fixtures now cover equations in paragraphs, display blocks and tables, unchanged attachments and page versions, and inline comments remaining anchored after other page content changes. The desktop harness uses the publisher's existing ADF normalization to ignore Confluence's transient TOC metadata.

Validation:
- 345 unit tests passed; 1 existing skipped test. Workspace build, format and lint checks passed.
- Live library and built CLI publishing passed with OAuth, scoped API tokens and unscoped API tokens, including unchanged republishing, updates, CLI file exports and inline-comment preservation.
- Real Obsidian LaTeX publishing, unchanged publishing, comment preservation and Dataview integration passed with native browser OAuth, scoped API tokens and unscoped API tokens. Real OAuth refresh passed; token-test settings were restored afterwards.
- Isolated npm package consumer tests passed, including real Chromium math PNGs and deterministic output across render sessions.
- Built Docker image passed live math publishing, unchanged versions, invalid-LaTeX failure without modifying the remote page, and recovery.
- Visually verified inline, multiline and table equations alongside the preserved inline comment on the [test page](https://markdown-confluence.atlassian.net/wiki/spaces/MCRT20260907/pages/989855824).

See `documentation/LATEX.md` for supported syntax and reusable test commands. This supports MathJax TeX mathematics, not full LaTeX documents or external packages. Confluence strips image alt text; published-page exports preserve image ADF while original TeX remains in source notes.

This PR follows the merged Cloud API and OAuth migration in #913. It contains only the LaTeX changes.

Closes #498

