### PR TITLE
test: prevent image-adjacent text loss regressions

### DIFF
--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -785,3 +785,37 @@ test("does not interpret image syntax inside another image title", () => {
 	);
 	expect(collectMediaAttrs(adf)).toEqual([expect.objectContaining({ url: "file://image.png" })]);
 });
+
+// Issue #647: later images must not discard text emitted after earlier images.
+for (const image of ["![](image.png)", "![[image.png]]"]) {
+	for (const newline of ["\n", "\r\n"]) {
+		for (const blankBeforeImage of [false, true]) {
+			test(`preserves text around repeated ${image} with ${JSON.stringify(newline)} and blank=${blankBeforeImage}`, () => {
+				const markers = [
+					"BEFORE",
+					"AFTER_FIRST_IMAGE",
+					"MIDDLE",
+					"AFTER_SECOND_IMAGE",
+					"END",
+				];
+				const markdown = [
+					markers[0],
+					...(blankBeforeImage ? [""] : []),
+					image,
+					markers[1],
+					"",
+					markers[2],
+					...(blankBeforeImage ? [""] : []),
+					image,
+					markers[3],
+					"",
+					markers[4],
+				].join(newline);
+				const document = parseMarkdownToADF(markdown, testSettings.confluenceBaseUrl);
+				const serialized = JSON.stringify(document);
+				for (const marker of markers) expect(serialized).toContain(marker);
+				expect(collectMediaAttrs(document)).toHaveLength(2);
+			});
+		}
+	}
+}

--- a/scripts/confluence-release-e2e.js
+++ b/scripts/confluence-release-e2e.js
@@ -231,6 +231,11 @@ const program = Effect.scoped(
 			"Before the first image.",
 			"Between images.",
 			"After the images.",
+			"Before adjacent image one.",
+			"After adjacent image one.",
+			"Before adjacent image two.",
+			"After adjacent image two.",
+			"End of adjacent image regression.",
 			"Final list item",
 		]) {
 			assert.ok(

--- a/test-fixtures/release-vault/Release Tests/Media.md
+++ b/test-fixtures/release-vault/Release Tests/Media.md
@@ -34,3 +34,15 @@ Bob --> Alice: Ready
 ```
 
 ![[assets/sequence.puml]]
+
+## Adjacent images regression (#647)
+
+Before adjacent image one.
+![[assets/blue.png|80]]
+After adjacent image one.
+
+Before adjacent image two.
+![Green rectangle](../assets/green.svg)
+After adjacent image two.
+
+End of adjacent image regression.


### PR DESCRIPTION
Image-adjacent text could disappear in v5.5.2 when processing a later image without a preceding blank line. Running the historical media rule reproduces the loss of text after the first image; the current parser preserves it following the fix released in v6 via #893.

This PR adds eight regression cases covering Markdown and Obsidian image syntax, LF/CRLF line endings, and images with/without preceding blank lines. It also adds the reproducer to the permanent live publishing fixture and asserts that all surrounding text survives Confluence readback. No additional production-parser change is needed.

Validation: all 51 parser tests pass; `vp run check`, `vp run fmt:check`, and the live API-token publishing integration pass. Live checks cover create/update/unchanged publishing, attachments and labels, failure/version-conflict recovery, and inline-comment preservation.

Live fixture: https://markdown-confluence.atlassian.net/wiki/spaces/MCRT20260907/pages/989496302/

Related: #647. The issue will be closed with reproduction details and upgrade guidance after merging.
