### PR TITLE
feat: restrict published page editing to the publishing account

### DIFF
--- a/documentation/PAGE_EDIT_LOCKS.md
+++ b/documentation/PAGE_EDIT_LOCKS.md
@@ -1,0 +1,29 @@
+# Restrict editing of published pages
+
+Enable **Restrict editing to the publishing account** in Obsidian's Confluence settings, set `lockPublishedPages: true` in CLI configuration, pass `--lockPublishedPages`, or set `CONFLUENCE_LOCK_PUBLISHED_PAGES=true`.
+
+Override the global setting on an individual note:
+
+```yaml
+connie-lock: true
+```
+
+Use `connie-lock: false` to stop managing that note's restrictions. Turning locking off does not unlock previously locked pages; remove edit restrictions explicitly in Confluence.
+
+The publisher permits only its authenticated account to edit each published page. Existing viewing restrictions are preserved. It checks locks even when content is unchanged, and reports permission failures separately from content publishing. A failed change can leave a partially applied edit restriction; retry after resolving permissions. Content creation and restriction changes are separate requests, so this is not an atomic private-publication mechanism.
+
+Use a dedicated publishing account if people should not manually edit these pages: anyone using that same account retains edit access. Administrators can change restrictions. Edit restrictions do not inherit to children, so each published page is managed individually. Generated hierarchy pages without a published source note are not covered by this setting.
+
+The account needs permission to edit the page and manage restrictions. Scoped credentials need the content-restriction read/write scopes, plus the existing publishing scopes. OAuth classic scopes may cover these operations; granular scopes are `read:content.restriction:confluence` and `write:content.restriction:confluence`. Unscoped tokens still obey the account's permissions.
+
+This uses the supported Cloud REST v1 content-restriction endpoints alongside v2 page APIs. It never replaces or deletes read restrictions.
+
+After enabling this feature for OAuth, add the restriction scopes to your Atlassian OAuth app and reconnect if the existing grant lacks them. Existing scoped API tokens may need replacement with tokens that include the restriction scopes.
+
+Run the dedicated live test with the existing integration settings/credential setup:
+
+```sh
+vp run test:integration edit-lock --settings-from /path/to/test-vault/.obsidian/plugins/confluence-integration/data.json
+```
+
+The test leaves a named fixture page in the dedicated test space and verifies locking, repeated locking, unchanged viewing restrictions and publisher updates. A second-user UI check is still needed to verify the reader experience end to end.

--- a/packages/lib/src/PageEditLock.test.ts
+++ b/packages/lib/src/PageEditLock.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@effect/vitest";
+import type { Client } from "confluence.js/core";
+import { lockPageEditing } from "./PageEditLock";
+
+function fixture(initialUsers: string[], initialGroups: string[], failRemove = false) {
+	const users = new Set(initialUsers),
+		groups = new Set(initialGroups);
+	const writes: string[] = [];
+	const client: Client = {
+		async sendRequest<T>(request): Promise<T> {
+			expect(request.url).toContain("/byOperation/update");
+			if (request.method === "GET") {
+				const kind =
+					request.searchParams?.expand === "restrictions.user" ? "user" : "group";
+				const all = [...(kind === "user" ? users : groups)];
+				const start = Number(request.searchParams?.start ?? 0);
+				return {
+					restrictions: {
+						[kind]: {
+							results: all
+								.slice(start, start + 100)
+								.map((value) =>
+									kind === "user" ? { accountId: value } : { id: value },
+								),
+							limit: 100,
+						},
+					},
+				} as T;
+			}
+			writes.push(`${request.method} ${request.url}`);
+			if (request.method === "PUT") users.add(String(request.searchParams?.accountId));
+			else {
+				expect(users.has("publisher")).toBe(true);
+				if (failRemove) throw Error("forbidden");
+				if (request.url.includes("/byGroupId/"))
+					groups.delete(request.url.split("/").at(-1)!);
+				else users.delete(String(request.searchParams?.accountId));
+			}
+			return undefined as T;
+		},
+	};
+	return { client, users, groups, writes };
+}
+
+test("locks unrestricted pages and does not write on repeated publication", async () => {
+	const f = fixture([], []);
+	expect(await lockPageEditing(f.client, "123", "publisher")).toBe("updated");
+	expect([...f.users]).toEqual(["publisher"]);
+	expect(await lockPageEditing(f.client, "123", "publisher")).toBe("same");
+	expect(f.writes).toHaveLength(1);
+});
+test("removes all other editors across pagination without touching read restrictions", async () => {
+	const f = fixture(
+		Array.from({ length: 102 }, (_, i) => `user-${i}`),
+		["editors"],
+	);
+	await lockPageEditing(f.client, "123", "publisher");
+	expect([...f.users]).toEqual(["publisher"]);
+	expect([...f.groups]).toEqual([]);
+	expect(f.writes[0]).toMatch(/^PUT/);
+});
+test("retains publisher access and reports a failed restriction change", async () => {
+	const f = fixture(["other"], [], true);
+	await expect(lockPageEditing(f.client, "123", "publisher")).rejects.toThrow("forbidden");
+	expect(f.users.has("publisher")).toBe(true);
+});

--- a/packages/lib/src/PageEditLock.ts
+++ b/packages/lib/src/PageEditLock.ts
@@ -1,0 +1,68 @@
+import type { Client } from "confluence.js/core";
+import { createV1Client } from "confluence.js";
+
+type Principal = { accountId?: string; id?: string };
+type RestrictionPage = {
+	restrictions?: Partial<
+		Record<
+			"user" | "group",
+			{ results: Principal[]; size?: number; limit?: number; _links?: { next?: string } }
+		>
+	>;
+};
+
+/** Read each collection independently: restrictions paginate users and groups separately. */
+async function editors(client: Client, id: string, kind: "user" | "group") {
+	const values: string[] = [];
+	for (let start = 0; ; ) {
+		const page = await client.sendRequest<RestrictionPage>({
+			method: "GET",
+			url: `/wiki/rest/api/content/${encodeURIComponent(id)}/restriction/byOperation/update`,
+			searchParams: { expand: `restrictions.${kind}`, start, limit: 100 },
+		});
+		const collection = page.restrictions?.[kind];
+		if (!collection || !Array.isArray(collection.results))
+			throw new Error("Confluence returned incomplete edit restrictions");
+		for (const principal of collection.results) {
+			const value = kind === "user" ? principal.accountId : principal.id;
+			if (!value) throw new Error("Confluence returned an editor without an ID");
+			values.push(value);
+		}
+		if (!collection._links?.next && collection.results.length < (collection.limit ?? 100))
+			return values;
+		if (!collection.results.length)
+			throw new Error("Confluence restriction pagination did not advance");
+		start += collection.results.length;
+	}
+}
+
+/** Only update restrictions are touched. Never remove the publishing account. */
+export async function lockPageEditing(
+	client: Client,
+	id: string,
+	accountId: string,
+): Promise<"same" | "updated"> {
+	if (!accountId) throw new Error("Cannot lock a page without the publishing account ID");
+	const users = await editors(client, id, "user");
+	const groups = await editors(client, id, "group");
+	if (users.length === 1 && users[0] === accountId && groups.length === 0) return "same";
+	const api = createV1Client(client).contentRestrictions;
+	// Establish a surviving editor before removing any existing grants.
+	await api.addUserToContentRestriction({ id, operationKey: "update", accountId });
+	for (const user of users)
+		if (user !== accountId)
+			await api.removeUserFromContentRestriction({
+				id,
+				operationKey: "update",
+				accountId: user,
+			});
+	for (const groupId of groups)
+		await api.removeGroupFromContentRestriction({ id, operationKey: "update", groupId });
+	const remainingUsers = await editors(client, id, "user");
+	const remainingGroups = await editors(client, id, "group");
+	if (remainingUsers.length !== 1 || remainingUsers[0] !== accountId || remainingGroups.length)
+		throw new Error(
+			"Confluence edit restrictions did not match the requested lock; retry publishing",
+		);
+	return "updated";
+}

--- a/packages/lib/src/Publisher.test.ts
+++ b/packages/lib/src/Publisher.test.ts
@@ -596,6 +596,8 @@ type UpdateContentRequest = {
 
 async function publishSinglePage({
 	settings = testPublishSettings,
+	lock,
+	sendRequest,
 	markdown = "Hello",
 	existingAdf = parseMarkdownToADF(markdown, settings.confluenceBaseUrl),
 	lastUpdatedBy = "current-user",
@@ -610,6 +612,8 @@ async function publishSinglePage({
 	updateContent = async (request) => request,
 }: {
 	settings?: ConfluenceSettings;
+	lock?: boolean;
+	sendRequest?: RequiredConfluenceClient["sendRequest"];
 	markdown?: string;
 	existingAdf?: JSONDocNode;
 	lastUpdatedBy?: string;
@@ -638,6 +642,7 @@ async function publishSinglePage({
 			return updateContent(request);
 		},
 	});
+	if (sendRequest) confluenceClient.sendRequest = sendRequest;
 	const workspace = new InMemoryMarkdownWorkspace([
 		{
 			folderName: "docs",
@@ -647,6 +652,7 @@ async function publishSinglePage({
 			pageTitle: "Page",
 			frontmatter: {
 				"connie-page-id": "page-id",
+				...(lock === undefined ? {} : { "connie-lock": lock }),
 				"connie-dont-change-parent-page": dontChangeParentPageId,
 			},
 		},
@@ -848,4 +854,43 @@ test("moves a page when its immediate parent differs", async () => {
 	});
 	expect(result[0]?.successfulUploadResult?.contentResult).toBe("updated");
 	expect(updateContentRequests[0]?.ancestors).toEqual([{ id: "parent-id" }]);
+});
+
+test("applies edit locking even when page content is unchanged", async () => {
+	let reads = 0;
+	const { result, updateContentRequests } = await publishSinglePage({
+		lock: true,
+		sendRequest: async <T>(request): Promise<T> => {
+			reads++;
+			const kind = request.searchParams?.expand === "restrictions.user" ? "user" : "group";
+			return {
+				restrictions: {
+					[kind]: { results: kind === "user" ? [{ accountId: "current-user" }] : [] },
+				},
+			} as T;
+		},
+	});
+	expect(reads).toBe(2);
+	expect(updateContentRequests).toEqual([]);
+	expect(result[0]?.successfulUploadResult?.contentResult).toBe("same");
+});
+test("per-note false overrides global locking without removing existing restrictions", async () => {
+	const { result } = await publishSinglePage({
+		settings: { ...testPublishSettings, lockPublishedPages: true },
+		lock: false,
+		sendRequest: async () => {
+			throw Error("must not change restrictions");
+		},
+	});
+	expect(result[0]?.successfulUploadResult).toBeDefined();
+});
+test("reports a lock failure separately after content publishing", async () => {
+	const { result } = await publishSinglePage({
+		lock: true,
+		sendRequest: async () => {
+			throw Error("secret token");
+		},
+	});
+	expect(result[0]?.reason).toContain("Content publishing completed, but edit locking failed");
+	expect(result[0]?.reason).not.toContain("secret token");
 });

--- a/packages/lib/src/Publisher.ts
+++ b/packages/lib/src/Publisher.ts
@@ -1,3 +1,4 @@
+import { lockPageEditing } from "./PageEditLock";
 import { MarkdownPublishFilter } from "./MarkdownSourceTransformer";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { Effect, Layer } from "effect";
@@ -256,6 +257,9 @@ export class Publisher {
 		const getMyAccountId = () => this.myAccountId;
 
 		return Effect.gen(function* () {
+			const lock = adfFile.frontmatter["connie-lock"];
+			if (lock !== undefined && typeof lock !== "boolean")
+				return yield* Effect.fail(new Error("connie-lock must be a boolean"));
 			if (!settings.forceOverwrite && lastUpdatedBy !== getMyAccountId()) {
 				return yield* Effect.fail(
 					createUpdatedByAnotherUserError(getMyAccountId(), lastUpdatedBy),
@@ -427,6 +431,16 @@ export class Publisher {
 				});
 			}
 
+			if (lock ?? settings.lockPublishedPages ?? false) {
+				yield* Effect.tryPromise({
+					try: () =>
+						lockPageEditing(confluenceClient, adfFile.pageId, getMyAccountId() ?? ""),
+					catch: () =>
+						new Error(
+							"Content publishing completed, but edit locking failed. Check restriction permissions and scopes, then retry publishing.",
+						),
+				});
+			}
 			return result;
 		});
 	}

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -26,6 +26,7 @@ export type ConfluenceSettings = {
 	pageFooterMarkdown?: string;
 	ignoredCodeBlockLanguages?: readonly string[];
 	forceOverwrite: boolean;
+	lockPublishedPages?: boolean;
 	plantuml: PlantumlSettings;
 	mermaidProtocolTimeout: number;
 };
@@ -56,6 +57,7 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	contentRoot: ".",
 	firstHeadingPageTitle: false,
 	forceOverwrite: false,
+	lockPublishedPages: false,
 	pageHeaderMarkdown: "",
 	pageFooterMarkdown: "",
 	ignoredCodeBlockLanguages: [],

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -63,6 +63,7 @@ export const confluenceSettingsConfig = Config.all({
 	),
 	contentRoot: Config.string("contentRoot"),
 	firstHeadingPageTitle: Config.boolean("firstHeadingPageTitle"),
+	lockPublishedPages: Config.boolean("lockPublishedPages").pipe(Config.withDefault(false)),
 	forceOverwrite: Config.boolean("forceOverwrite").pipe(
 		Config.withDefault(DEFAULT_SETTINGS.forceOverwrite),
 	),
@@ -217,6 +218,9 @@ function makeEnvironmentProvider(
 		const firstHeadingPageTitle = yield* runtimeEnvironment.getEnv(
 			"CONFLUENCE_FIRST_HEADING_PAGE_TITLE",
 		);
+		const lockPublishedPages = yield* runtimeEnvironment.getEnv(
+			"CONFLUENCE_LOCK_PUBLISHED_PAGES",
+		);
 		const forceOverwrite = yield* runtimeEnvironment.getEnv("CONFLUENCE_FORCE_OVERWRITE");
 		const plantumlEnabled = yield* runtimeEnvironment.getEnv("CONFLUENCE_PLANTUML_ENABLED");
 		const plantumlServerUrl = yield* runtimeEnvironment.getEnv(
@@ -245,6 +249,7 @@ function makeEnvironmentProvider(
 				contentRoot: yield* runtimeEnvironment.getEnv("CONFLUENCE_CONTENT_ROOT"),
 				firstHeadingPageTitle: firstHeadingPageTitle,
 				forceOverwrite,
+				lockPublishedPages,
 				pageHeaderMarkdown: yield* runtimeEnvironment.getEnv(
 					"CONFLUENCE_PAGE_HEADER_MARKDOWN",
 				),
@@ -278,6 +283,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "tagsToPublish", aliases: ["t"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
+		{ name: "lockPublishedPages", type: "boolean" },
 		{ name: "forceOverwrite", aliases: ["fo"], type: "boolean" },
 		{ name: "pageHeaderMarkdown", type: "string" },
 		{ name: "pageFooterMarkdown", type: "string" },
@@ -308,6 +314,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],
 			forceOverwrite: options["forceOverwrite"],
+			lockPublishedPages: options["lockPublishedPages"],
 			pageHeaderMarkdown: options["pageHeaderMarkdown"],
 			pageFooterMarkdown: options["pageFooterMarkdown"],
 		}),

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -194,3 +194,6 @@ export {
 	type MathExpression,
 	type MathRenderer,
 };
+
+import { lockPageEditing } from "./PageEditLock";
+export { lockPageEditing };

--- a/packages/obsidian/src/AtlassianOAuth.ts
+++ b/packages/obsidian/src/AtlassianOAuth.ts
@@ -26,6 +26,8 @@ export const confluenceOAuthScopes = [
 	"offline_access",
 	"read:page:confluence",
 	"write:page:confluence",
+	"read:content.restriction:confluence",
+	"write:content.restriction:confluence",
 	"read:space:confluence",
 	"read:content.metadata:confluence",
 	"read:content-details:confluence",

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -13,6 +13,7 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 	private renderBrowserLogin(containerEl: HTMLElement) {
 		const auth = this.plugin.browserOAuth;
 		const disabled = auth.pending || auth.connected;
+
 		new Setting(containerEl)
 			.setName("Login method")
 			.setDesc(
@@ -375,6 +376,20 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.firstHeadingPageTitle)
 					.onChange(async (value) => {
 						this.plugin.settings.firstHeadingPageTitle = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Restrict editing to the publishing account")
+			.setDesc(
+				"Keep published pages readable while limiting edits to your publishing account. Override per note with connie-lock. Turning this off leaves existing restrictions in place; unlock in Confluence.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.lockPublishedPages ?? false)
+					.onChange(async (value) => {
+						this.plugin.settings.lockPublishedPages = value;
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/scripts/integration-edit-lock.js
+++ b/scripts/integration-edit-lock.js
@@ -1,0 +1,106 @@
+import {
+	RuntimeEnvironmentService,
+	MarkdownConfluencePlatformLive,
+} from "../packages/lib/dist/index.js";
+import { NodeServices } from "@effect/platform-node";
+import assert from "node:assert/strict";
+import { Effect } from "effect";
+import {
+	createAuthenticatedConfluenceClient,
+	lockPageEditing,
+} from "../packages/lib/dist/index.js";
+import { liveConnectionSettings } from "./integration-options.js";
+
+// Uses the same dedicated-site guard and credentials as the existing live suite.
+const environment = await Effect.runPromise(
+	Effect.gen(function* () {
+		const runtime = yield* RuntimeEnvironmentService;
+		const values = {};
+		for (const name of [
+			"ATLASSIAN_USERNAME",
+			"ATLASSIAN_API_TOKEN",
+			"ATLASSIAN_CLIENT_ID",
+			"ATLASSIAN_CLIENT_SECRET",
+			"CONFLUENCE_E2E_AUTH_TYPE",
+			"CONFLUENCE_E2E_API_URL",
+			"CONFLUENCE_E2E_BASE_URL",
+			"CONFLUENCE_E2E_PARENT_ID",
+			"CONFLUENCE_E2E_SPACE_KEY",
+		])
+			values[name] = yield* runtime.getEnv(name);
+		return values;
+	}).pipe(Effect.provide(NodeServices.layer), Effect.provide(MarkdownConfluencePlatformLive)),
+);
+const settings = liveConnectionSettings(environment);
+const client = await Effect.runPromise(createAuthenticatedConfluenceClient(settings));
+const account = await client.users.getCurrentUser();
+const page = await client.content.createContent({
+	type: "page",
+	title: `Edit lock integration ${Date.now()}`,
+	space: { key: environment.CONFLUENCE_E2E_SPACE_KEY },
+	ancestors: [{ id: settings.confluenceParentId }],
+	body: {
+		atlas_doc_format: {
+			representation: "atlas_doc_format",
+			value: JSON.stringify({
+				type: "doc",
+				version: 1,
+				content: [
+					{
+						type: "paragraph",
+						content: [{ type: "text", text: "Edit lock integration fixture" }],
+					},
+				],
+			}),
+		},
+	},
+});
+const path = `/wiki/rest/api/content/${page.id}/restriction/byOperation/read`;
+await client.sendRequest({
+	url: `${path}/user`,
+	method: "PUT",
+	searchParams: { accountId: account.accountId },
+});
+const before = await client.sendRequest({
+	url: path,
+	searchParams: { expand: "restrictions.user,restrictions.group" },
+});
+assert.equal(await lockPageEditing(client, page.id, account.accountId), "updated");
+assert.equal(await lockPageEditing(client, page.id, account.accountId), "same");
+const after = await client.sendRequest({
+	url: path,
+	searchParams: { expand: "restrictions.user,restrictions.group" },
+});
+assert.deepEqual(after.restrictions, before.restrictions);
+const current = await client.content.getContentById({ id: page.id, expand: ["version"] });
+await client.content.updateContent({
+	id: page.id,
+	type: "page",
+	title: page.title,
+	version: { number: current.version.number + 1 },
+	body: {
+		atlas_doc_format: {
+			representation: "atlas_doc_format",
+			value: JSON.stringify({
+				type: "doc",
+				version: 1,
+				content: [
+					{
+						type: "paragraph",
+						content: [{ type: "text", text: "Publisher updated the locked page" }],
+					},
+				],
+			}),
+		},
+	},
+});
+console.log(
+	JSON.stringify({
+		pageId: page.id,
+		authType: settings.confluenceAuthType,
+		locked: true,
+		repeat: "same",
+		readRestrictionsPreserved: true,
+		publisherUpdate: true,
+	}),
+);

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -343,6 +343,54 @@ export function runObsidianIntegration({
 			"A page with an inline comment must remain unchanged on republish",
 		);
 
+		// Exercise the real settings control, then publish an unchanged note with locking enabled.
+		const originalLock = yield* evaluate(
+			`return JSON.stringify(app.plugins.plugins['confluence-integration'].settings.lockPublishedPages ?? false);`,
+		);
+		yield* Effect.acquireRelease(Effect.succeed(undefined), () =>
+			evaluate(
+				`const p=app.plugins.plugins['confluence-integration']; p.settings.lockPublishedPages=${JSON.stringify(originalLock)}; await p.saveSettings(); app.setting.close(); return JSON.stringify({restored:true});`,
+			).pipe(Effect.orDie),
+		);
+		const editLockUi = yield* evaluate(`
+			app.setting.open(); app.setting.openTabById('confluence-integration');
+			const row=[...app.setting.activeTab.containerEl.querySelectorAll('.setting-item')].find(el=>el.querySelector('.setting-item-name')?.textContent==='Restrict editing to the publishing account');
+			if(!row) throw Error('Edit lock setting is missing');
+			const toggle=row.querySelector('.checkbox-container');
+			if(!toggle) throw Error('Edit lock toggle is missing');
+			if(!toggle.classList.contains('is-enabled')) toggle.click();
+			if(!app.plugins.plugins['confluence-integration'].settings.lockPublishedPages) throw Error('Edit lock toggle did not update settings');
+			await app.plugins.plugins['confluence-integration'].saveSettings();
+			return JSON.stringify({visible:true,enabled:true});
+		`);
+		const lockedNote = "Release Tests/Formatting.md";
+		yield* evaluate(
+			`const r=await app.plugins.plugins['confluence-integration'].doPublish(${JSON.stringify("Release Tests/Formatting.md")}); if(r.errorMessage || r.failedFiles.length) throw Error('Locked desktop publish failed'); return JSON.stringify({published:true});`,
+		);
+		const lockedPageId = restored[lockedNote].id;
+		const editor = yield* Effect.tryPromise(() => client.users.getCurrentUser());
+		const restriction = yield* Effect.tryPromise(() =>
+			client.sendRequest({
+				url: `/wiki/rest/api/content/${lockedPageId}/restriction/byOperation/update`,
+				searchParams: { expand: "restrictions.user,restrictions.group" },
+			}),
+		);
+		assert.deepEqual(
+			restriction.restrictions.user.results.map((user) => user.accountId),
+			[editor.accountId],
+		);
+		assert.equal(restriction.restrictions.group.results.length, 0);
+		yield* evaluate(
+			`const p=app.plugins.plugins['confluence-integration']; p.settings.lockPublishedPages=false; await p.saveSettings(); return JSON.stringify({disabled:true});`,
+		);
+		const stillLocked = yield* Effect.tryPromise(() =>
+			client.sendRequest({
+				url: `/wiki/rest/api/content/${lockedPageId}/restriction/byOperation/update`,
+				searchParams: { expand: "restrictions.user,restrictions.group" },
+			}),
+		);
+		assert.deepEqual(stillLocked.restrictions, restriction.restrictions);
+
 		if (dataview) {
 			const result = yield* runDataviewIntegration({ evaluate, get, prefix: marker.prefix });
 			yield* fs.writeFileString(
@@ -356,6 +404,7 @@ export function runObsidianIntegration({
 			JSON.stringify(
 				{
 					status: "passed",
+					editLockUi,
 					inlineComment: inlineCommentEvidence,
 					authentication: connection.confluenceAuthType,
 					oauthMode: runtimeAuthentication.mode,

--- a/scripts/integration-options.js
+++ b/scripts/integration-options.js
@@ -3,6 +3,7 @@ export const integrationProfiles = [
 	"packages",
 	"live",
 	"blogs",
+	"edit-lock",
 	"regressions",
 	"docker",
 	"vault",

--- a/scripts/integration-tests.js
+++ b/scripts/integration-tests.js
@@ -22,6 +22,7 @@ const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 const help = `Integration profiles (vp run test:integration [profile] [options]):
   quick      Build, check all fixture conversions and render real Mermaid PNGs (default).
   packages   Pack all five npm packages, install into a fresh consumer and verify them.
+  edit-lock  Verify page edit locking, read preservation and publisher updates.
   blogs      Publish a blog post; verify attachments, labels, updates and CLI export.
   live       Publish synthetic fixtures to Confluence; verify unchanged/update/recovery.
   regressions Publish 166 notes with Mermaid/images using the released action container.
@@ -283,10 +284,17 @@ function runIntegration() {
 					);
 				});
 			const work = Effect.gen(function* () {
-				const live = ["live", "blogs", "regressions", "obsidian"].includes(options.profile);
-				const environment = ["live", "blogs", "regressions", "obsidian", "vault"].includes(
+				const live = ["live", "blogs", "edit-lock", "regressions", "obsidian"].includes(
 					options.profile,
-				)
+				);
+				const environment = [
+					"live",
+					"blogs",
+					"edit-lock",
+					"regressions",
+					"obsidian",
+					"vault",
+				].includes(options.profile)
 					? yield* readTestEnvironment(options)
 					: {};
 				if (live) validateLiveEnvironment(environment);
@@ -357,6 +365,13 @@ function runIntegration() {
 							},
 							"25 minutes",
 						),
+					);
+					return;
+				}
+				if (options.profile === "edit-lock") {
+					yield* step(
+						"Live edit lock and publisher update",
+						command(node, ["scripts/integration-edit-lock.js"], { env: environment }),
 					);
 					return;
 				}


### PR DESCRIPTION
Adds optional edit restrictions for published Confluence pages (#653). Enable the Obsidian publishing toggle, CLI `--lockPublishedPages`, configuration setting or environment variable; override per note with `connie-lock`.

The publisher keeps its authenticated account as the sole editor, changes only update restrictions, paginates existing editor lists, and verifies the result. Checks run even for unchanged content. Disabling management leaves existing restrictions intact; users unlock explicitly in Confluence. Restriction failures are reported distinctly after content publishing. OAuth requests include restriction scopes.

Validation:
- Full suite: 360 passed, 1 skipped across 43 test files. Workspace build, checks and formatting passed.
- Dedicated Cloud integration with unscoped API token passed: initial lock, idempotent repeat, explicit read restrictions preserved, and subsequent publisher update. Fixture page: 990904321.
- Real Obsidian desktop suite passed: settings control rendered and clicked, note published with lock applied, disabling the setting retained existing restrictions. Existing create/update/unchanged, attachments and inline-comment checks also passed.
- Desktop test report: reports/integration/obsidian-2026-09-08T05-25-12-220Z-05d518ec/summary.json.
- OAuth was attempted and reached restriction writes, then Atlassian rejected missing restriction scopes. Admin UI confirms the existing service credential lacks both scopes. Scoped-token success verification is also pending replacement credentials: the existing token lacks restriction scopes and returned no current account ID. These are not recorded as successful auth-mode tests.

Remaining verification: live OAuth and scoped-token success paths after credential scope updates. A second-user UI test is explicitly excluded from this verification pass at the user's request.

Limitations: content creation and locking are separate requests. Generated hierarchy pages without source notes are not managed. Administrators and people using the publishing account can still edit/change restrictions.
