### PR TITLE
feat: port community publishing features and fixes

### DIFF
--- a/documentation/FORK_PORTS.md
+++ b/documentation/FORK_PORTS.md
@@ -136,6 +136,8 @@ The review's deferred MCP preview and Kroki proposals remain separate future wor
 
 On 8 September 2026, the live feature profile passed with an unscoped API token and OAuth. Both runs covered inline-comment preservation, repeated publishing, rendering, exclusions, cancellation/restart and ordering. OAuth testing found and fixed use of the retired v1 child-page listing endpoint.
 
-The real Obsidian desktop profile also passed with the new feature fixture and settings/command checks. Automated unit tests, formatting, linting and workspace builds passed.
+The real Obsidian desktop profile also passed with the new feature fixture and settings/command checks. Automated unit tests, formatting, linting and workspace builds passed. Browser verification confirmed the generated footnote target and second-reference backlink after republishing. Missing definitions remain literal; nested excerpts have separate footnote namespaces. The highlighted-link companion case already produces a valid inline card and now has regression coverage.
+
+Both integration profiles include a 12-entity ER diagram check for actual PNG resolution and SVG text/custom colors. This caught an Electron initialization issue: sanitized theme variables must be supplied during Mermaid initialization so derived colors are calculated correctly.
 
 Scoped-token verification is pending: the saved test credential returned HTTP 404 when reading the dedicated test parent, before feature execution. This is not recorded as a scoped-token pass.

--- a/documentation/FORK_PORTS.md
+++ b/documentation/FORK_PORTS.md
@@ -140,4 +140,4 @@ The real Obsidian desktop profile also passed with the new feature fixture and s
 
 Both integration profiles include a 12-entity ER diagram check for actual PNG resolution and SVG text/custom colors. This caught an Electron initialization issue: sanitized theme variables must be supplied during Mermaid initialization so derived colors are calculated correctly.
 
-Scoped-token verification is pending: the saved test credential returned HTTP 404 when reading the dedicated test parent, before feature execution. This is not recorded as a scoped-token pass.
+Scoped-token verification also passed on 8 September 2026 after replacing the expired test token with the same ten scopes and a one-day lifetime. The earlier HTTP 404 occurred before feature execution because that credential had expired. The replacement run covered the complete feature profile, including the larger renderer checks and inline-comment preservation.

--- a/documentation/FORK_PORTS.md
+++ b/documentation/FORK_PORTS.md
@@ -1,0 +1,141 @@
+# Selective fork contributions
+
+These features adapt ideas from community forks to the current Cloud publishing pipeline. They do not import the forks' old clients or build tooling.
+
+## Publishing controls
+
+`foldersToExclude` is an array of paths relative to the content root (the vault in Obsidian). Exclusions override `connie-publish: true` and publish tags. `private` excludes `private/note.md`, not `private-other/note.md`. This controls which pages are published; it does not redact content explicitly embedded from another note.
+
+Set it in `.markdown-confluence.json`, use `--excludeFolders private,drafts`, or use **Excluded folders** in Obsidian's Confluence settings.
+
+Obsidian shows publish progress in the status bar. Click it or run **Cancel publishing after the current request** to stop. Cancellation lets an active operation finish, keeps completed writes, and prevents subsequent operations. It does not roll back pages or attachments already created. The result lists pages that did not publish; publishing again resumes ordinary reconciliation.
+
+Library callers can pass `{ signal: controller.signal }` as the second argument to `publish` or `publishEffect`.
+
+## Validation, planning and reports
+
+```sh
+markdown-confluence validate --input notes/example.md --output validation.json
+markdown-confluence validate --enableFolder notes --output -
+markdown-confluence plan --enableFolder notes --output plan.json
+markdown-confluence --enableFolder notes --report publish.json
+markdown-confluence --enableFolder notes --report -
+```
+
+`validate` works without Confluence credentials. It checks conversion, titles and local hierarchy. Without `--input`, it uses the normal folder/tag/exclusion selection. Explicit `--input` validates that file independently of selection.
+
+`plan` requires the normal Cloud credentials and performs read-only page discovery. It never creates placeholder pages, renders/uploads attachments or changes local frontmatter. Existing pages are marked `reconcile`, since determining every content, attachment, label and permission change requires the publishing pipeline. New pages are marked `create`; ambiguous/inaccessible pages are `blocked`. Treat this as preflight, not an exact prediction of version changes.
+
+Reports use `schemaVersion: 1`. Validation and planning support `--output FILE` or `--output -`; publishing supports `--report FILE` or `--report -`. A failed validation or partial publishing failure returns a nonzero exit status. Publishing reports include per-page failures; errors before page discovery may prevent a publishing report. No credentials are included in reports.
+
+## Footnotes
+
+```markdown
+A reference[^source], and the same reference again[^source].
+
+[^source]: A **formatted** definition.
+
+    An additional paragraph in the same footnote.
+```
+
+Numeric and named labels, repeated references, multiline definitions and inline notes use the Markdown parser. Code and escaped syntax remain literal. Generated Confluence anchors link references to definitions and back. Header/footer fragments use separate anchor namespaces.
+
+## Excerpts and page properties
+
+Use an explicit fenced block whose contents are Markdown:
+
+````markdown
+```confluence-excerpt summary
+Reusable **summary** text.
+```
+
+```confluence-properties record
+| Property | Value |
+| --- | --- |
+| Owner | Documentation team |
+```
+````
+
+The name after the fence language identifies the excerpt or properties record. Multiple blocks get deterministic macro IDs. No arbitrary frontmatter is published automatically. Existing raw `adf` fences remain available for lossless expressions and exports.
+
+## YAML tables
+
+````markdown
+```yaml-table
+- Count: 0
+  Enabled: false
+  Literal: "<"
+- Count: 12
+  Enabled: true
+  Literal: "^"
+```
+````
+
+For explicit spans, use columns and rows. A spanned-over column is omitted from the row input; absent remaining cells are empty.
+
+````markdown
+```yaml-table
+columns: [Name, Details]
+rows:
+  - [{value: Group, colspan: 2}]
+  - [{value: Shared, rowspan: 2}, First]
+  - [Second]
+```
+````
+
+Scalar values preserve `0`, `false`, and empty text. Literal `<` and `^` never merge cells. Invalid or overlapping spans fail conversion instead of deleting content. Tables are limited to 100 columns and 1000 rows. Cells contain literal scalar text; use ordinary Markdown or raw ADF for richer cell content.
+
+## Jira shorthand
+
+Set `jiraUrl` in JSON, use `--jiraUrl https://example.atlassian.net`, or set **Jira site URL** in Obsidian. Explicit `JIRA: DOCS-123` becomes a Smart Link. Code and existing links are left intact; formatting on surrounding text is preserved. This does not grant access to the linked issue.
+
+## Mermaid output
+
+```json
+{
+  "mermaid": {
+    "format": "png",
+    "scale": 2,
+    "theme": "neutral",
+    "themeVariables": { "primaryColor": "#ddebff" }
+  }
+}
+```
+
+CLI options: `--mermaidFormat png|svg`, `--mermaidScale 1..4`, `--mermaidTheme neutral`. Obsidian exposes output, scale and theme variables alongside its existing theme selector. PNG remains the default; scale controls raster resolution. SVG uploads use the correct SVG MIME type. Rendering options do not relax Mermaid's strict security mode. Different output formats get distinct attachment filenames.
+
+## Page ordering
+
+Enable `orderPages: true`, `--orderPages`, or **Apply page ordering** in Obsidian. Add numeric `sort-order` frontmatter to at least two sibling pages. Lower values come first; ties use page IDs for stability.
+
+Ordering applies only to successfully published, explicitly ranked pages sharing a parent. Unranked pages are not managed; pages with preserved parents and blog posts are excluded. Single-note publishing does not reorder siblings. The implementation reads the existing order through the v2 children endpoint and uses Cloud's v1 move endpoint where an order change is needed; v2 remains in use for the supported page operations. Permissions/API failures are surfaced. Completed content writes remain if ordering fails.
+
+## Verification
+
+```sh
+vp test run
+vp run check
+vp run build
+vp run test:integration fork-ports --settings-from /path/to/test-settings.json
+```
+
+The dedicated-site profile verifies conversion, real publishing, unchanged republishing, PNG/SVG, exclusions, ordering, cancellation/restart, and an inline comment surviving edits elsewhere. Run it for unscoped tokens, scoped tokens and OAuth. The integration harness writes reports under `reports/integration/`.
+
+## Attribution and scope
+
+- [Dongmin-Cho](https://github.com/Dongmin-Cho/obsidian-integration): unresolved link-mark fix, exclusions/cancellation and footnote anchors.
+- [renato-dransay](https://github.com/renato-dransay/markdown-confluence/commit/57064aa19b8cfae2d25db766a885294eff03e985): preflight/reporting ideas. Our planner deliberately avoids the fork's write-capable dry-run path.
+- [derari](https://github.com/derari/markdown-confluence/tree/merge): excerpt/properties, YAML table and comparison ideas. Explicit span semantics replace destructive marker handling.
+- [PTCInc](https://github.com/PTCInc/markdown-confluence): Jira shorthand.
+- [FASTEC](https://github.com/FASTEC/markdown-confluence/tree/features/mermaid), [NickSmet](https://github.com/NickSmet/markdown-confluence), [aaronsb](https://github.com/aaronsb/obsidian-to-confluence): ordering and renderer options.
+- Footnote tokenization uses the MIT-licensed [markdown-it-footnote](https://github.com/markdown-it/markdown-it-footnote) package.
+
+The review's deferred MCP preview and Kroki proposals remain separate future work. Server/Data Center changes, credential logging, unrelated rewrites and obsolete dependencies were not selected.
+
+### Verification recorded for this port
+
+On 8 September 2026, the live feature profile passed with an unscoped API token and OAuth. Both runs covered inline-comment preservation, repeated publishing, rendering, exclusions, cancellation/restart and ordering. OAuth testing found and fixed use of the retired v1 child-page listing endpoint.
+
+The real Obsidian desktop profile also passed with the new feature fixture and settings/command checks. Automated unit tests, formatting, linting and workspace builds passed.
+
+Scoped-token verification is pending: the saved test credential returned HTTP 404 when reading the dedicated test parent, before feature execution. This is not recorded as a scoped-token pass.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,9 @@ import {
 	PuppeteerMathRenderer,
 } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { getErrorMessage } from "./errorMessage";
+import { preflight } from "./preflight";
+import { FileSystem } from "effect/FileSystem";
+import { publishingReport } from "@markdown-confluence/lib";
 import { convertDocument } from "./convert";
 import { HttpPlantumlRenderer } from "@markdown-confluence/plantuml-renderer";
 
@@ -31,13 +34,21 @@ const program = Effect.gen(function* () {
 	yield* runtimeEnvironment.setMaxListeners(Infinity) as any;
 
 	const settings = yield* ConfluenceUploadSettings.ConfluenceSettingsService as any;
+	const argv: string[] = yield* runtimeEnvironment.argv;
+	const reportIndex = argv.indexOf("--report");
+	const destination = reportIndex >= 0 ? argv[reportIndex + 1] : undefined;
+	if (reportIndex >= 0 && (!destination || destination.startsWith("--")))
+		throw new Error("--report requires a file path or - for stdout");
 
 	const confluenceClient = yield* createAuthenticatedConfluenceClient(settings);
 
 	const plugins: ADFProcessingPlugin<unknown, unknown>[] = [
 		new MathRendererPlugin(new PuppeteerMathRenderer()),
 		new MermaidRendererPlugin(
-			new PuppeteerMermaidRenderer({ protocolTimeout: settings.mermaidProtocolTimeout }),
+			new PuppeteerMermaidRenderer(
+				{ protocolTimeout: settings.mermaidProtocolTimeout },
+				settings.mermaid,
+			),
 		),
 	];
 
@@ -55,15 +66,24 @@ const program = Effect.gen(function* () {
 	}
 
 	const publisher = new Publisher(settings, confluenceClient, plugins, (message) => {
-		console.log(`[publish] ${message}`);
+		console.error(`[publish] ${message}`);
 	});
 
 	const publishFilter = "";
 	const results = yield* publisher.publishEffect(publishFilter) as any;
 
+	if (destination) {
+		const json = JSON.stringify(publishingReport(results), null, 2) + "\n";
+		if (destination === "-") yield* Console.log(json);
+		else {
+			const fs = yield* FileSystem;
+			yield* fs.writeFileString(destination, json);
+		}
+	}
+
 	for (const file of results) {
 		if (file.successfulUploadResult) {
-			yield* Console.log(
+			yield* (destination === "-" ? Console.error : Console.log)(
 				chalk.green(
 					`SUCCESS: ${file.node.file.absoluteFilePath} Content: ${file.successfulUploadResult.contentResult}, Images: ${file.successfulUploadResult.imageResult}, Labels: ${file.successfulUploadResult.labelResult}, Page URL: ${file.node.file.pageUrl}`,
 				),
@@ -86,6 +106,8 @@ const program = Effect.gen(function* () {
 const command = Effect.gen(function* () {
 	const runtime = yield* RuntimeEnvironmentService;
 	const argv = yield* runtime.argv;
+	if (argv[2] === "validate" || argv[2] === "plan")
+		return yield* preflight(argv[2], argv.slice(3));
 	if (argv[2] === "to-adf" || argv[2] === "to-markdown" || argv[2] === "from-adf") {
 		const conversion = argv[2] === "to-adf" ? "to-adf" : "to-markdown";
 		return yield* convertDocument(conversion, argv.slice(3)).pipe(
@@ -94,7 +116,7 @@ const command = Effect.gen(function* () {
 	}
 	if (argv[2] === "--help" || argv[2] === "-h") {
 		return yield* Console.log(
-			"Usage: markdown-confluence [publishing options]\n\nCommands:\n  to-adf       Convert Markdown or export Confluence ADF\n  to-markdown  Convert ADF or a Confluence page to Markdown\n  from-adf     Alias for to-markdown\n\nUse COMMAND --help for conversion options. Without a command, publish using the configured settings.",
+			"Usage: markdown-confluence [publishing options]\n\nCommands:\n  validate     Validate selected Markdown without credentials\n  plan         Read-only Confluence page discovery\n  to-adf       Convert Markdown or export Confluence ADF\n  to-markdown  Convert ADF or a Confluence page to Markdown\n  from-adf     Alias for to-markdown\n\nUse COMMAND --help for conversion options. Without a command, publish using the configured settings.",
 		);
 	}
 	return yield* program.pipe(

--- a/packages/cli/src/preflight.ts
+++ b/packages/cli/src/preflight.ts
@@ -1,0 +1,59 @@
+import { Console, Effect } from "effect";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import {
+	confluenceSettingsConfig,
+	makeConfluenceSettingsConfigProvider,
+	loadMarkdownWorkspace,
+	validatePublishingFiles,
+	planPublishingFiles,
+	createAuthenticatedConfluenceClient,
+} from "@markdown-confluence/lib";
+
+export function preflight(command: "validate" | "plan", args: string[]) {
+	return Effect.gen(function* () {
+		if (args.includes("--help"))
+			return yield* Console.log(
+				`${command} [--input FILE] [--output FILE|-] [publishing settings]\nvalidate works offline. plan performs only reads; existing pages are marked reconcile, not guessed unchanged.`,
+			);
+		const argument = (name: string) => {
+			const index = args.indexOf(name);
+			if (index < 0) return undefined;
+			const value = args[index + 1];
+			if (!value || value.startsWith("--")) throw new Error(`Missing value for ${name}`);
+			return value;
+		};
+		const provider = yield* makeConfluenceSettingsConfigProvider();
+		const settings = yield* confluenceSettingsConfig.parse(provider);
+		if (command === "validate" && !settings.confluenceBaseUrl)
+			settings.confluenceBaseUrl = "https://confluence.invalid";
+		const workspace = yield* Effect.tryPromise(() => loadMarkdownWorkspace(settings));
+		const input = argument("--input");
+		const files = input
+			? [yield* workspace.loadMarkdownFile(input)]
+			: yield* workspace.getMarkdownFilesToUpload;
+		const report =
+			command === "plan"
+				? yield* Effect.tryPromise({
+						try: async () => {
+							const client = await Effect.runPromise(
+								createAuthenticatedConfluenceClient(settings),
+							);
+							return planPublishingFiles(files, settings, client);
+						},
+						catch: (error) => error,
+					})
+				: validatePublishingFiles(files, settings);
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		const output = argument("--output");
+		const json = JSON.stringify(report, null, 2) + "\n";
+		if (output && output !== "-") yield* fs.writeFileString(path.resolve(output), json);
+		else yield* Console.log(json);
+		const valid =
+			"validation" in report
+				? report.validation.valid && report.pages.every((page) => page.action !== "blocked")
+				: report.valid;
+		if (!valid) return yield* Effect.fail(new Error("Preflight failed; see the JSON report"));
+	});
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -66,6 +66,7 @@
 		"glob": "^13.0.6",
 		"lodash-es": "^4.18.1",
 		"markdown-it": "^14.2.0",
+		"markdown-it-footnote": "4.0.0",
 		"markdown-it-table": "^4.1.1",
 		"markdown-table": "^3.0.4",
 		"mime-types": "^3.0.2",
@@ -77,6 +78,7 @@
 	"devDependencies": {
 		"@types/lodash-es": "^4.17.12",
 		"@types/markdown-it": "^14.1.2",
+		"@types/markdown-it-footnote": "^3.0.4",
 		"@types/mime-types": "^3.0.1",
 		"@types/spark-md5": "^3.0.5",
 		"image-size": "^2.0.2"

--- a/packages/lib/src/ADFProcessingPlugins/MermaidRendererPlugin.ts
+++ b/packages/lib/src/ADFProcessingPlugins/MermaidRendererPlugin.ts
@@ -7,10 +7,13 @@ import SparkMD5 from "spark-md5";
 import { Effect } from "effect";
 import { MarkdownConfluencePlatform, runEffect } from "../effects";
 
-export function getMermaidFileName(mermaidContent: string | undefined) {
+export function getMermaidFileName(
+	mermaidContent: string | undefined,
+	format: "png" | "svg" = "png",
+) {
 	const mermaidText = mermaidContent ?? "flowchart LR\nid1[Missing Chart]";
 	const pathMd5 = SparkMD5.hash(mermaidText);
-	const uploadFilename = `RenderedMermaidChart-${pathMd5}.png`;
+	const uploadFilename = `RenderedMermaidChart-${pathMd5}.${format}`;
 	return { uploadFilename, mermaidText };
 }
 
@@ -20,6 +23,7 @@ export interface ChartData {
 }
 
 export interface MermaidRenderer {
+	format?: "png" | "svg";
 	captureMermaidCharts(charts: ChartData[]): Promise<Map<string, Buffer>>;
 }
 
@@ -37,7 +41,10 @@ export class MermaidRendererPlugin implements ADFProcessingPlugin<
 
 		const mermaidNodesToUpload = new Set(
 			mermaidNodes.map((node) => {
-				const mermaidDetails = getMermaidFileName(node?.content?.at(0)?.text);
+				const mermaidDetails = getMermaidFileName(
+					node?.content?.at(0)?.text,
+					this.mermaidRenderer.format,
+				);
 				return {
 					name: mermaidDetails.uploadFilename,
 					data: mermaidDetails.mermaidText,
@@ -80,7 +87,7 @@ export class MermaidRendererPlugin implements ADFProcessingPlugin<
 				const uploadedContent = yield* supportFunctions.uploadBufferEffect(
 					mermaidImage[0],
 					mermaidImage[1],
-					"image/png",
+					mermaidRenderer.format === "svg" ? "image/svg+xml" : "image/png",
 				);
 
 				imageMap = {
@@ -103,7 +110,10 @@ export class MermaidRendererPlugin implements ADFProcessingPlugin<
 						if (!mermaidContent) {
 							return;
 						}
-						const mermaidFilename = getMermaidFileName(mermaidContent);
+						const mermaidFilename = getMermaidFileName(
+							mermaidContent,
+							this.mermaidRenderer.format,
+						);
 
 						if (!imageMap[mermaidFilename.uploadFilename]) {
 							return;

--- a/packages/lib/src/AdfEqual.test.ts
+++ b/packages/lib/src/AdfEqual.test.ts
@@ -210,3 +210,41 @@ test("ignores transient server media metadata without mutating exports", () => {
 		);
 	}
 });
+
+test("canonicalizes card slugs and default tables without hiding authored attributes", () => {
+	const card = (url: string): ADFEntity => ({ type: "inlineCard", attrs: { url } });
+	const url = "https://example.atlassian.net/wiki/spaces/DOCS/pages/123";
+	expect(adfEqual(card(url + "/Title#A"), card(url + "#A"))).toBe(true);
+	expect(adfEqual(card(url + "#A"), card(url + "#B"))).toBe(false);
+	const table: ADFEntity = { type: "table", content: [] };
+	expect(adfEqual(table, { ...table, attrs: { layout: "default" } })).toBe(true);
+	expect(adfEqual(table, { ...table, attrs: { layout: "wide" } })).toBe(false);
+	expect(adfEqual(table, { ...table, attrs: { localId: "authored" } })).toBe(false);
+	expect(table.attrs).toBeUndefined();
+});
+
+test("ignores Cloud legacy aliases only for generated footnote anchors", () => {
+	const anchor = (name: string, legacy?: string): ADFEntity => ({
+		type: "inlineExtension",
+		attrs: {
+			extensionType: "com.atlassian.confluence.macro.core",
+			extensionKey: "anchor",
+			parameters: {
+				macroParams: {
+					"": { value: name },
+					...(legacy ? { legacyAnchorId: { value: legacy } } : {}),
+				},
+			},
+		},
+	});
+	expect(
+		adfEqual(
+			anchor("connie-fn-body-test", "Title-connie-fn-body-test"),
+			anchor("connie-fn-body-test"),
+		),
+	).toBe(true);
+	expect(adfEqual(anchor("authored", "Title-authored"), anchor("authored"))).toBe(false);
+	expect(
+		adfEqual(anchor("connie-fn-body-test", "other-target"), anchor("connie-fn-body-test")),
+	).toBe(false);
+});

--- a/packages/lib/src/AdfEqual.ts
+++ b/packages/lib/src/AdfEqual.ts
@@ -47,6 +47,12 @@ export function normalizeAdfForComparison(adf: ADFEntity): ADFEntity {
 					delete mark.attrs["__confluenceMetadata"];
 				}
 			}
+			if (node.type === "inlineCard" && typeof node.attrs?.["url"] === "string") {
+				node.attrs["url"] = canonicalConfluencePageLink(node.attrs["url"]);
+			}
+			if (node.type === "table") {
+				node.attrs = { layout: "default", ...node.attrs };
+			}
 			// These file details are transient server caches, not authored media attributes.
 			if (node.type === "media" && node.attrs) {
 				delete node.attrs["__fileName"];
@@ -64,6 +70,27 @@ export function normalizeAdfForComparison(adf: ADFEntity): ADFEntity {
 			}
 
 			const parameters = node.attrs?.["parameters"];
+			if (
+				node.attrs?.["extensionType"] === "com.atlassian.confluence.macro.core" &&
+				node.attrs["extensionKey"] === "anchor" &&
+				isRecord(parameters) &&
+				isRecord(parameters["macroParams"])
+			) {
+				const options = parameters["macroParams"];
+				const name = isRecord(options[""]) ? options[""]["value"] : undefined;
+				const legacy = isRecord(options["legacyAnchorId"])
+					? options["legacyAnchorId"]["value"]
+					: undefined;
+				// Cloud stamps a title-prefixed legacy alias onto generated footnote anchors.
+				if (
+					typeof name === "string" &&
+					name.startsWith("connie-fn-") &&
+					typeof legacy === "string" &&
+					legacy.endsWith(`-${name}`)
+				)
+					delete options["legacyAnchorId"];
+			}
+
 			if (
 				node.attrs?.["extensionType"] === "com.atlassian.confluence.macro.core" &&
 				node.attrs["extensionKey"] === "toc" &&

--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -191,3 +191,17 @@ test.each(["Anchor", "Before Anchor"])(
 		expect(node.file.contents).toEqual(expected);
 	},
 );
+
+test("unresolved formatted wikilinks retain dense formatting marks", () => {
+	const contents = docWithLink("Missing", "wikilinks:missing");
+	const text = contents.content[0]!.content![0] as TextDefinition;
+	text.marks!.push({ type: "strong" });
+	const pages = [createNode({ contents })];
+	prepareAdfToUpload(pages, testSettings);
+	const serialized = JSON.parse(JSON.stringify(pages[0]!.file.contents));
+	expect(serialized.content[0].content[0]).toEqual({
+		type: "text",
+		text: "Missing",
+		marks: [{ type: "strong" }],
+	});
+});

--- a/packages/lib/src/AdfProcessing.ts
+++ b/packages/lib/src/AdfProcessing.ts
@@ -600,7 +600,7 @@ function processWikilinkToActualLink(
 							return node;
 						}
 					} else {
-						delete node.marks[0];
+						node.marks.splice(0, 1);
 					}
 					return node;
 				}

--- a/packages/lib/src/ForkPorts.test.ts
+++ b/packages/lib/src/ForkPorts.test.ts
@@ -1,3 +1,7 @@
+import { Effect } from "effect";
+import { Path } from "effect/Path";
+import { NodePath } from "@effect/platform-node";
+const nativePath = Effect.runSync(Path.pipe(Effect.provide(NodePath.layer)));
 import { expect, test } from "@effect/vitest";
 import { parseMarkdownToADF } from "./MdToADF";
 import { shouldPublishMarkdownFile } from "./MarkdownWorkspace";
@@ -97,7 +101,7 @@ test("Jira shorthand preserves formatting and skips code and existing links", ()
 
 const planningFiles = ["one", "two"].map((name) => ({
 	folderName: "docs",
-	absoluteFilePath: `docs/${name}.md`,
+	absoluteFilePath: nativePath.resolve("docs", `${name}.md`),
 	fileName: `${name}.md`,
 	contents: name,
 	pageTitle: name,
@@ -183,4 +187,32 @@ test("ordering follows v2 cursors without treating cursors as request URLs", asy
 		"/wiki/api/v2/pages/1/children",
 	]);
 	expect(requests[1]!.searchParams?.cursor).toBe("next-page");
+});
+
+test("missing footnotes stay literal and nested excerpt footnotes have separate anchors", () => {
+	const source =
+		"Missing[^missing].\n\n[^outer]: Outer.\n\nOuter[^outer].\n\n```confluence-excerpt one\nInner[^outer].\n\n[^outer]: Inner.\n```\n\n```confluence-excerpt two\nInner[^outer].\n\n[^outer]: Other inner.\n```";
+	const adf = parseMarkdownToADF(source, "https://example.atlassian.net");
+	expect(JSON.stringify(adf)).toContain("Missing[^missing].");
+	const anchors: string[] = [];
+	const visit = (node: any) => {
+		if (node.attrs?.extensionKey === "anchor")
+			anchors.push(node.attrs.parameters.macroParams[""].value);
+		for (const child of node.content ?? []) visit(child);
+	};
+	visit(adf);
+	expect(anchors.length).toBe(6);
+	expect(new Set(anchors).size).toBe(anchors.length);
+});
+
+test("highlighted URL links produce valid inline cards without invalid text marks", () => {
+	const adf = parseMarkdownToADF(
+		"Before ==[https://example.com](https://example.com)== after",
+		"https://example.atlassian.net",
+	);
+	expect(adf.content[0]!.content).toEqual([
+		{ type: "text", text: "Before " },
+		{ type: "inlineCard", attrs: { url: "https://example.com" } },
+		{ type: "text", text: " after" },
+	]);
 });

--- a/packages/lib/src/ForkPorts.test.ts
+++ b/packages/lib/src/ForkPorts.test.ts
@@ -1,0 +1,186 @@
+import { expect, test } from "@effect/vitest";
+import { parseMarkdownToADF } from "./MdToADF";
+import { shouldPublishMarkdownFile } from "./MarkdownWorkspace";
+import { DEFAULT_SETTINGS } from "./Settings";
+import { cancellableClient } from "./PublishCancellation";
+
+test("exclusions override tags and frontmatter without excluding similarly named folders", () => {
+	const settings = { ...DEFAULT_SETTINGS, folderToPublish: ".", foldersToExclude: ["private/"] };
+	expect(
+		shouldPublishMarkdownFile("/private/note.md", { "connie-publish": true }, settings),
+	).toBe(false);
+	expect(shouldPublishMarkdownFile("private-other/note.md", {}, settings)).toBe(true);
+});
+
+test("cancellation finishes an active request and rejects subsequent requests", async () => {
+	const controller = new AbortController();
+	let writes = 0;
+	const client = cancellableClient(
+		{
+			content: {
+				async update() {
+					writes++;
+					controller.abort();
+					return "saved";
+				},
+			},
+		},
+		controller.signal,
+	);
+	expect(await client.content.update()).toBe("saved");
+	expect(() => client.content.update()).toThrow("Publishing cancelled");
+	expect(writes).toBe(1);
+});
+
+test("named repeated multiline footnotes preserve code literals and unique backlinks", () => {
+	const adf = parseMarkdownToADF(
+		"A[^note], again[^note]. `[^note]`\n\n[^note]: First **paragraph**.\n\n    Second paragraph.\n\n```text\n[^note]\n```",
+		"https://example.atlassian.net",
+	);
+	const json = JSON.stringify(adf);
+	expect(json).toContain("Second paragraph.");
+	expect(json).toContain('"extensionKey":"anchor"');
+	expect(json).toContain("-ref-0");
+	expect(json).toContain("-ref-1");
+	expect(json).toContain('"text":"[^note]"');
+	expect(json).toContain('"type":"strong"');
+});
+
+test("YAML table scalar values and explicit merged cells are lossless", () => {
+	const adf = parseMarkdownToADF(
+		'```yaml-table\n- Count: 0\n  Enabled: false\n  Literal: "<"\n- Count: 1\n  Literal: "^"\n```',
+		"https://example.atlassian.net",
+	);
+	expect(JSON.stringify(adf)).toContain('"text":"0"');
+	expect(JSON.stringify(adf)).toContain('"text":"false"');
+	expect(JSON.stringify(adf)).toContain('"text":"<"');
+	const merged = parseMarkdownToADF(
+		"```yaml-table\ncolumns: [A, B]\nrows:\n  - [{value: span, colspan: 2}]\n```",
+		"https://example.atlassian.net",
+	);
+	expect(JSON.stringify(merged)).toContain('"colspan":2');
+	expect(() =>
+		parseMarkdownToADF(
+			"```yaml-table\ncolumns: [A]\nrows: [[{value: bad, rowspan: 2}]]\n```",
+			"https://example.atlassian.net",
+		),
+	).toThrow("bounds");
+});
+
+test("named excerpt and properties fences preserve body and deterministic IDs", () => {
+	const source =
+		"```confluence-excerpt summary\n**Body**\n```\n\n```confluence-properties record\n| Key | Value |\n| --- | --- |\n| A | B |\n```";
+	const adf = parseMarkdownToADF(source, "https://example.atlassian.net");
+	expect(adf.content[0]!.type).toBe("bodiedExtension");
+	expect(adf.content[0]!.attrs!["extensionKey"]).toBe("excerpt");
+	expect(adf.content[1]!.attrs!["extensionKey"]).toBe("details");
+	expect(parseMarkdownToADF(source, "https://example.atlassian.net")).toEqual(adf);
+});
+
+import { jiraShorthand } from "./StructuredMarkdown";
+import { planPublishingFiles, validatePublishingFiles } from "./PublishingReport";
+import { orderPublishedPages } from "./PageOrdering";
+
+test("Jira shorthand preserves formatting and skips code and existing links", () => {
+	const adf = parseMarkdownToADF(
+		"**Before JIRA: DOCS-1 and JIRA: DOCS-2 after** `JIRA: DOCS-3` [JIRA: DOCS-4](https://example.com)",
+		"https://example.atlassian.net",
+	);
+	jiraShorthand(adf, "https://example.atlassian.net");
+	const json = JSON.stringify(adf);
+	expect(json).toContain("/browse/DOCS-1");
+	expect(json).toContain("/browse/DOCS-2");
+	expect(json).not.toContain("/browse/DOCS-3");
+	expect(json).not.toContain("/browse/DOCS-4");
+	expect(json).toContain('"text":"Before ","marks":[{"type":"strong"}]');
+});
+
+const planningFiles = ["one", "two"].map((name) => ({
+	folderName: "docs",
+	absoluteFilePath: `docs/${name}.md`,
+	fileName: `${name}.md`,
+	contents: name,
+	pageTitle: name,
+	frontmatter: {},
+}));
+
+test("planning cannot mutate remote pages or local frontmatter", async () => {
+	const original = structuredClone(planningFiles);
+	const calls: string[] = [];
+	const report = await planPublishingFiles(
+		planningFiles,
+		{ ...DEFAULT_SETTINGS, confluenceParentId: "1" },
+		{
+			content: {
+				getContentById: async () => {
+					calls.push("read parent");
+					return { id: "1", space: { key: "DOC" } };
+				},
+				getContent: async () => {
+					calls.push("read title");
+					return { results: [] };
+				},
+				createContent: () => {
+					throw new Error("Unexpected write");
+				},
+				updateContent: () => {
+					throw new Error("Unexpected write");
+				},
+			},
+		} as never,
+	);
+	expect(report.pages.map((page) => page.action)).toEqual(["create", "create"]);
+	expect(calls).toEqual(["read parent", "read title", "read title"]);
+	expect(planningFiles).toEqual(original);
+	expect(validatePublishingFiles([], DEFAULT_SETTINGS).valid).toBe(false);
+});
+
+test("ordering moves ranked siblings only and skips a correctly ordered tree", async () => {
+	const requests: { method: string; url: string }[] = [];
+	const client = {
+		sendRequest: async (request: { method: string; url: string }) => {
+			requests.push(request);
+			return { results: [{ id: "2" }, { id: "3" }] };
+		},
+	};
+	const results = [2, 3].map((id) => ({
+		successfulUploadResult: {},
+		node: {
+			ancestors: ["1"],
+			file: { pageId: String(id), contentType: "page", frontmatter: { "sort-order": id } },
+		},
+	}));
+	await orderPublishedPages(client as never, results as never);
+	expect(requests.map((request) => request.method)).toEqual(["GET"]);
+	results[0]!.node.file.frontmatter["sort-order"] = 4;
+	await orderPublishedPages(client as never, results as never);
+	expect(requests.at(-1)!.url).toContain("/2/move/after/3");
+});
+
+test("ordering follows v2 cursors without treating cursors as request URLs", async () => {
+	const requests: { url: string; searchParams?: { cursor?: string } }[] = [];
+	const client = {
+		sendRequest: async (request: { url: string; searchParams?: { cursor?: string } }) => {
+			requests.push(request);
+			return request.searchParams?.cursor
+				? { results: [{ id: "3" }] }
+				: {
+						results: [{ id: "2" }],
+						_links: { next: "/wiki/api/v2/pages/1/children?cursor=next-page" },
+					};
+		},
+	};
+	const results = [2, 3].map((id) => ({
+		successfulUploadResult: {},
+		node: {
+			ancestors: ["1"],
+			file: { pageId: String(id), contentType: "page", frontmatter: { "sort-order": id } },
+		},
+	}));
+	await orderPublishedPages(client as never, results as never);
+	expect(requests.map((request) => request.url)).toEqual([
+		"/wiki/api/v2/pages/1/children",
+		"/wiki/api/v2/pages/1/children",
+	]);
+	expect(requests[1]!.searchParams?.cursor).toBe("next-page");
+});

--- a/packages/lib/src/MarkdownTransformer/footnotes.ts
+++ b/packages/lib/src/MarkdownTransformer/footnotes.ts
@@ -1,0 +1,65 @@
+import type MarkdownIt from "markdown-it";
+import Token from "markdown-it/lib/token.mjs";
+import footnote from "markdown-it-footnote";
+import SparkMD5 from "spark-md5";
+
+export function footnoteAnchorAttributes(token: Token) {
+	return {
+		extensionType: "com.atlassian.confluence.macro.core",
+		extensionKey: "anchor",
+		parameters: { macroParams: { "": { value: token.content } } },
+	};
+}
+
+/** Adapt parser tokens, never regex-rewrite code or escaped Markdown text. */
+export default function footnotes(md: MarkdownIt) {
+	// The DefinitelyTyped plugin uses CJS MarkdownIt types; runtime API is identical.
+	md.use(footnote as unknown as (markdown: MarkdownIt) => void);
+	md.core.ruler.after("footnote_tail", "confluence_footnotes", (state) => {
+		const anchor = (name: string) => {
+			const token = new Token("footnote_target", "", 0);
+			token.content = name;
+			return token;
+		};
+		const text = (value: string) => {
+			const token = new Token("text", "", 0);
+			token.content = value;
+			return token;
+		};
+		const link = (name: string, value: string) => {
+			const open = new Token("link_open", "a", 1);
+			open.attrSet("href", `#${name}`);
+			return [open, text(value), new Token("link_close", "a", -1)];
+		};
+		const target = (token: Token) => {
+			const label = state.env.footnotes.list[token.meta.id]?.label ?? String(token.meta.id);
+			return `connie-fn-${state.env.confluenceFragment ?? "body"}-${SparkMD5.hash(label)}`;
+		};
+		const reference = (token: Token) => `${target(token)}-ref-${token.meta.subId ?? 0}`;
+		const rewriteInline = (tokens: Token[]): Token[] =>
+			tokens.flatMap((token) => {
+				if (token.type === "footnote_ref")
+					return [
+						anchor(reference(token)),
+						...link(target(token), `[${token.meta.id + 1}]`),
+					];
+				if (token.type === "footnote_anchor") return link(reference(token), " ↩");
+				if (token.children) token.children = rewriteInline(token.children);
+				return [token];
+			});
+		state.tokens = state.tokens.flatMap((token) => {
+			if (token.type === "footnote_block_open") return [new Token("hr", "hr", 0)];
+			if (token.type === "footnote_block_close" || token.type === "footnote_close") return [];
+			if (token.type === "footnote_open") {
+				const inline = new Token("inline", "", 0);
+				inline.children = [anchor(target(token)), text(`[${token.meta.id + 1}]`)];
+				return [
+					new Token("paragraph_open", "p", 1),
+					inline,
+					new Token("paragraph_close", "p", -1),
+				];
+			}
+			return rewriteInline([token]);
+		});
+	});
+}

--- a/packages/lib/src/MarkdownTransformer/index.ts
+++ b/packages/lib/src/MarkdownTransformer/index.ts
@@ -1,3 +1,4 @@
+import footnotes, { footnoteAnchorAttributes } from "./footnotes";
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { defaultSchema } from "@atlaskit/adf-schema/schema-default";
@@ -58,6 +59,7 @@ const pmSchemaToMdMapping: SchemaMapping = {
 };
 
 const mdToPmMapping = {
+	footnote_target: { node: "inlineExtension", attrs: footnoteAnchorAttributes },
 	math_inline: { node: "inlineExtension", attrs: mathAttributes },
 	math_block: { node: "extension", attrs: mathAttributes },
 	alignment: { mark: "alignment", attrs: (token: any) => ({ align: token.attrGet("align") }) },
@@ -180,6 +182,7 @@ export class MarkdownTransformer implements Transformer<Markdown> {
 		tokenizer.use(highlightPlugin);
 		tokenizer.use(formattingPlugin);
 		tokenizer.use(mathPlugin);
+		tokenizer.use(footnotes);
 
 		(["nodes", "marks"] as (keyof SchemaMapping)[]).forEach((key) => {
 			for (const idx in pmSchemaToMdMapping[key]) {
@@ -240,8 +243,8 @@ export class MarkdownTransformer implements Transformer<Markdown> {
 		throw new Error("This is not implemented yet");
 	}
 
-	parse(content: Markdown): PMNode {
-		const pmnodes = this.markdownParser.parse(content);
+	parse(content: Markdown, fragment = "body"): PMNode {
+		const pmnodes = this.markdownParser.parse(content, { confluenceFragment: fragment });
 		if (!pmnodes) {
 			throw new Error("Unable to parse Markdown");
 		}

--- a/packages/lib/src/MarkdownWorkspace.ts
+++ b/packages/lib/src/MarkdownWorkspace.ts
@@ -561,6 +561,22 @@ export function shouldPublishMarkdownFile(
 	frontmatter: Record<string, unknown> | undefined,
 	settings: ConfluenceSettings,
 ): boolean {
+	const normalize = (value: string) =>
+		value
+			.replaceAll("\\", "/")
+			.replace(/^\/+|\/+$/g, "")
+			.replace(/^\.\//, "");
+	const relativePath = normalize(absoluteFilePath);
+	if (
+		(settings.foldersToExclude ?? []).some((value) => {
+			const folder = normalize(value.trim());
+			return (
+				folder !== "" &&
+				(folder === "." || relativePath === folder || relativePath.startsWith(`${folder}/`))
+			);
+		})
+	)
+		return false;
 	if (frontmatter?.["connie-publish"] === false) {
 		return false;
 	}

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -1,3 +1,4 @@
+import { structuredMarkdown, jiraShorthand } from "./StructuredMarkdown";
 import { JSONDocNode, JSONTransformer } from "@atlaskit/editor-json-transformer";
 import { MarkdownTransformer } from "./MarkdownTransformer";
 import { traverse } from "@atlaskit/adf-utils/traverse";
@@ -124,8 +125,9 @@ function parsePageFragmentToADF(
 	markdown: string,
 	confluenceBaseUrl: string,
 	pageFragment: PageFragment,
-) {
-	const prosenodes = transformer.parse(stripMarkdownHtmlComments(markdown));
+	namespace: string = pageFragment,
+): JSONDocNode {
+	const prosenodes = transformer.parse(stripMarkdownHtmlComments(markdown), namespace);
 	const adfNodes = serializer.encode(prosenodes);
 	let nodes = processADF(adfNodes, confluenceBaseUrl);
 	if (pageFragment !== "body") {
@@ -140,7 +142,14 @@ function parsePageFragmentToADF(
 			}),
 		}) as JSONDocNode;
 	}
-	return restoreAdfCodeBlocks(replaceSupportedMacroPlaceholders(nodes, pageFragment));
+	return restoreAdfCodeBlocks(
+		structuredMarkdown(
+			replaceSupportedMacroPlaceholders(nodes, pageFragment),
+			(source, childNamespace) =>
+				parsePageFragmentToADF(source, confluenceBaseUrl, pageFragment, childNamespace),
+			namespace,
+		) as JSONDocNode,
+	);
 }
 
 function processADF(adf: JSONDocNode, confluenceBaseUrl: string): JSONDocNode {
@@ -511,10 +520,18 @@ function safeDecodeURIComponent(value: string): string {
 }
 
 export function convertMDtoADF(file: MarkdownFile, settings: ConfluenceSettings): LocalAdfFile {
+	const rank = file.frontmatter["sort-order"];
+	if (
+		settings.orderPages &&
+		rank !== undefined &&
+		(typeof rank !== "number" || !Number.isFinite(rank))
+	)
+		throw new Error("sort-order must be a finite number");
 	file.contents = file.contents.replace(frontmatterRegex, "");
 
 	const adfContent = parseMarkdownToADF(file.contents, resolveSiteUrl(settings));
 
+	if (settings.jiraUrl) jiraShorthand(adfContent, settings.jiraUrl);
 	const results = processConniePerPageConfig(file, settings, adfContent);
 	stripIgnoredCodeBlocks(adfContent as ADFNode, settings.ignoredCodeBlockLanguages ?? []);
 	addConfiguredPageChrome(adfContent, settings);

--- a/packages/lib/src/MermaidOptions.ts
+++ b/packages/lib/src/MermaidOptions.ts
@@ -1,0 +1,23 @@
+export interface MermaidOptions {
+	format?: "png" | "svg";
+	scale?: number;
+	theme?: "default" | "neutral" | "dark" | "forest" | "base";
+	themeVariables?: Record<string, string>;
+}
+export function validateMermaidOptions(options: MermaidOptions = {}): MermaidOptions {
+	if (options.format && !["png", "svg"].includes(options.format))
+		throw new Error("Mermaid format must be png or svg");
+	if (
+		options.scale !== undefined &&
+		(!Number.isFinite(options.scale) || options.scale < 1 || options.scale > 4)
+	)
+		throw new Error("Mermaid scale must be between 1 and 4");
+	if (options.theme && !["default", "neutral", "dark", "forest", "base"].includes(options.theme))
+		throw new Error("Unknown Mermaid theme");
+	if (
+		options.themeVariables &&
+		Object.values(options.themeVariables).some((value) => typeof value !== "string")
+	)
+		throw new Error("Mermaid theme variables must be strings");
+	return options;
+}

--- a/packages/lib/src/PageOrdering.ts
+++ b/packages/lib/src/PageOrdering.ts
@@ -1,0 +1,65 @@
+import type { Client } from "confluence.js/core";
+import type { FilePublishResult } from "./Publisher";
+
+/** Reorder explicitly ranked, successfully published siblings only. */
+export async function orderPublishedPages(
+	client: Client,
+	results: FilePublishResult[],
+): Promise<void> {
+	const groups = new Map<string, { id: string; rank: number }[]>();
+	for (const result of results) {
+		const file = result.node.file;
+		const rank = file.frontmatter["sort-order"];
+		if (
+			rank === undefined ||
+			!result.successfulUploadResult ||
+			file.contentType !== "page" ||
+			file.dontChangeParentPageId
+		)
+			continue;
+		if (typeof rank !== "number" || !Number.isFinite(rank))
+			throw new Error("sort-order must be a finite number");
+		const parent = result.node.ancestors.at(-1);
+		if (!parent) continue;
+		const group = groups.get(parent) ?? [];
+		group.push({ id: file.pageId, rank });
+		groups.set(parent, group);
+	}
+	for (const [parent, group] of groups) {
+		if (group.length < 2) continue;
+		const desired = group
+			.sort((left, right) => left.rank - right.rank || left.id.localeCompare(right.id))
+			.map((page) => page.id);
+		const current: string[] = [];
+		for (let cursor: string | undefined; ; ) {
+			const response = await client.sendRequest<{
+				results: { id: string }[];
+				limit?: number;
+				_links?: { next?: string };
+			}>({
+				method: "GET",
+				url: `/wiki/api/v2/pages/${encodeURIComponent(parent)}/children`,
+				searchParams: { ...(cursor ? { cursor } : {}), limit: 100 },
+			});
+			current.push(...response.results.map((page) => page.id));
+			if (!response._links?.next) break;
+			if (!response.results.length)
+				throw new Error("Page ordering pagination did not advance");
+			const nextCursor = new URL(
+				response._links.next,
+				"https://confluence.invalid",
+			).searchParams.get("cursor");
+			if (!nextCursor || nextCursor === cursor)
+				throw new Error("Page ordering pagination did not advance");
+			cursor = nextCursor;
+		}
+		if (desired.some((id) => !current.includes(id)))
+			throw new Error("Page parent changed; refusing to reorder pages across parents");
+		if (current.filter((id) => desired.includes(id)).join(",") === desired.join(",")) continue;
+		for (let index = 1; index < desired.length; index++)
+			await client.sendRequest({
+				method: "PUT",
+				url: `/wiki/rest/api/content/${encodeURIComponent(desired[index]!)}/move/after/${encodeURIComponent(desired[index - 1]!)}`,
+			});
+	}
+}

--- a/packages/lib/src/PublishCancellation.ts
+++ b/packages/lib/src/PublishCancellation.ts
@@ -1,0 +1,27 @@
+/** Cooperative cancellation: finish the current request, then stop issuing requests.
+ * Successful writes are not rolled back. Do not abort a write with an unknown outcome.
+ */
+export function cancellableClient<T extends object>(client: T, signal: AbortSignal): T {
+	const wrappers = new WeakMap<object, object>();
+	const wrap = (target: object): object => {
+		const cached = wrappers.get(target);
+		if (cached) return cached;
+		const proxy = new Proxy(target, {
+			get(object, key) {
+				const value = Reflect.get(object, key);
+				if (typeof value === "function")
+					return (...args: unknown[]) => {
+						if (signal.aborted)
+							throw new Error(
+								"Publishing cancelled. Completed writes have been kept.",
+							);
+						return Reflect.apply(value, object, args);
+					};
+				return value && typeof value === "object" ? wrap(value) : value;
+			},
+		});
+		wrappers.set(target, proxy);
+		return proxy;
+	};
+	return wrap(client) as T;
+}

--- a/packages/lib/src/Publisher.ts
+++ b/packages/lib/src/Publisher.ts
@@ -158,6 +158,7 @@ export class Publisher {
 			return publisher.publishEffect(publishFilter);
 		}
 		const settings = this.settings;
+		const signal = this.signal;
 		const confluenceClient = this.confluenceClient;
 		const getMyAccountId = () => this.myAccountId;
 		const setMyAccountId = (accountId: string) => {
@@ -228,7 +229,7 @@ export class Publisher {
 				// Each page may launch Chromium and upload several attachments.
 				{ concurrency: 2 },
 			);
-			if (settings.orderPages && !publishFilter && !this.signal?.aborted)
+			if (settings.orderPages && !publishFilter && !signal?.aborted)
 				yield* Effect.tryPromise(() => orderPublishedPages(confluenceClient, results));
 			return results;
 		});

--- a/packages/lib/src/Publisher.ts
+++ b/packages/lib/src/Publisher.ts
@@ -1,3 +1,5 @@
+import { orderPublishedPages } from "./PageOrdering";
+import { cancellableClient } from "./PublishCancellation";
 import { lockPageEditing } from "./PageEditLock";
 import { MarkdownPublishFilter } from "./MarkdownSourceTransformer";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
@@ -28,7 +30,7 @@ export interface LocalAdfFileTreeNode {
 	file?: LocalAdfFile;
 }
 
-interface FilePublishResult {
+export interface FilePublishResult {
 	successfulUploadResult?: UploadAdfFileResult;
 	node: ConfluenceNode;
 	reason?: string;
@@ -108,6 +110,7 @@ export interface UploadAdfFileResult {
 export class Publisher {
 	private confluenceClient: RequiredConfluenceClient;
 	private myAccountId: string | undefined;
+	private signal: AbortSignal | undefined;
 	private settings: ConfluenceSettings;
 	private adfProcessingPlugins: ADFProcessingPlugin<unknown, unknown>[];
 
@@ -123,9 +126,12 @@ export class Publisher {
 		this.adfProcessingPlugins = adfProcessingPlugins.concat(AlwaysADFProcessingPlugins);
 	}
 
-	publish(publishFilter?: string): Promise<FilePublishResult[]> {
+	publish(
+		publishFilter?: string,
+		options?: { signal?: AbortSignal | undefined },
+	): Promise<FilePublishResult[]> {
 		return runEffect(
-			this.publishEffect(publishFilter).pipe(
+			this.publishEffect(publishFilter, options).pipe(
 				Effect.provide(MarkdownWorkspaceLive),
 				Effect.provide(Layer.succeed(ConfluenceSettingsService, this.settings)),
 			),
@@ -134,11 +140,23 @@ export class Publisher {
 
 	publishEffect(
 		publishFilter?: string,
+		options?: { signal?: AbortSignal | undefined },
 	): Effect.Effect<
 		FilePublishResult[],
 		unknown,
 		MarkdownConfluencePlatform | MarkdownWorkspaceService
 	> {
+		if (options?.signal) {
+			const publisher = new Publisher(
+				this.settings,
+				cancellableClient(this.confluenceClient, options.signal),
+				[],
+				this.onProgress,
+			);
+			publisher.adfProcessingPlugins = this.adfProcessingPlugins;
+			publisher.signal = options.signal;
+			return publisher.publishEffect(publishFilter);
+		}
 		const settings = this.settings;
 		const confluenceClient = this.confluenceClient;
 		const getMyAccountId = () => this.myAccountId;
@@ -201,7 +219,7 @@ export class Publisher {
 				);
 			}
 
-			return yield* Effect.all(
+			const results = yield* Effect.all(
 				confluencePagesToPublish.map((file, index) =>
 					progress(
 						`Publishing ${index + 1}/${confluencePagesToPublish.length}: ${file.file.pageTitle}`,
@@ -210,6 +228,9 @@ export class Publisher {
 				// Each page may launch Chromium and upload several attachments.
 				{ concurrency: 2 },
 			);
+			if (settings.orderPages && !publishFilter && !this.signal?.aborted)
+				yield* Effect.tryPromise(() => orderPublishedPages(confluenceClient, results));
+			return results;
 		});
 	}
 
@@ -220,23 +241,30 @@ export class Publisher {
 		never,
 		MarkdownConfluencePlatform | MarkdownWorkspaceService
 	> {
-		return this.updatePageContentEffect(
-			node.ancestors,
-			node.version,
-			node.existingPageData,
-			node.file,
-			node.lastUpdatedBy,
-		).pipe(
-			Effect.map((successfulUploadResult) => ({
-				node,
-				successfulUploadResult,
-			})),
-			Effect.catch((e: unknown) =>
-				Effect.succeed({
-					node,
-					reason: e instanceof Error ? e.message : JSON.stringify(e),
-				}),
-			),
+		return Effect.suspend(() =>
+			this.signal?.aborted
+				? Effect.succeed({
+						node,
+						reason: "Publishing cancelled before this page was started",
+					})
+				: this.updatePageContentEffect(
+						node.ancestors,
+						node.version,
+						node.existingPageData,
+						node.file,
+						node.lastUpdatedBy,
+					).pipe(
+						Effect.map((successfulUploadResult) => ({
+							node,
+							successfulUploadResult,
+						})),
+						Effect.catch((e: unknown) =>
+							Effect.succeed({
+								node,
+								reason: e instanceof Error ? e.message : JSON.stringify(e),
+							}),
+						),
+					),
 		);
 	}
 

--- a/packages/lib/src/PublishingReport.ts
+++ b/packages/lib/src/PublishingReport.ts
@@ -1,0 +1,143 @@
+import type { MarkdownFile } from "./MarkdownWorkspace";
+import type { ConfluenceSettings } from "./Settings";
+import type { FilePublishResult, LocalAdfFileTreeNode } from "./Publisher";
+import type { RequiredConfluenceClient } from "./ConfluenceClient";
+import { createFolderStructure } from "./TreeLocal";
+import { convertMDtoADF } from "./MdToADF";
+
+export interface ValidationReport {
+	schemaVersion: 1;
+	valid: boolean;
+	files: { source: string; title?: string; errors: string[] }[];
+	errors: string[];
+}
+
+export function validatePublishingFiles(
+	files: MarkdownFile[],
+	settings: ConfluenceSettings,
+): ValidationReport {
+	const report: ValidationReport = { schemaVersion: 1, valid: true, files: [], errors: [] };
+	for (const file of files) {
+		try {
+			const converted = convertMDtoADF(structuredClone(file), settings);
+			report.files.push({
+				source: file.absoluteFilePath,
+				title: converted.pageTitle,
+				errors: converted.pageTitle.trim() ? [] : ["Page title is empty"],
+			});
+		} catch (error) {
+			report.files.push({ source: file.absoluteFilePath, errors: [message(error)] });
+		}
+	}
+	if (!files.length) report.errors.push("No files selected for publishing");
+	else if (report.files.every((file) => !file.errors.length)) {
+		try {
+			createFolderStructure(structuredClone(files), settings);
+		} catch (error) {
+			report.errors.push(message(error));
+		}
+	}
+	report.valid = !report.errors.length && report.files.every((file) => !file.errors.length);
+	return report;
+}
+
+/** Read-only discovery. Never calls the publisher, attachment renderer or frontmatter writer.
+ * Existing pages require reconciliation at publish time; this is not a claim of exact no-op detection.
+ */
+export async function planPublishingFiles(
+	files: MarkdownFile[],
+	settings: ConfluenceSettings,
+	client: Pick<RequiredConfluenceClient, "content">,
+) {
+	const validation = validatePublishingFiles(files, settings);
+	const pages: {
+		source: string;
+		title: string;
+		action: "create" | "reconcile" | "blocked";
+		pageId?: string;
+		reason?: string;
+	}[] = [];
+	if (!validation.valid) return { schemaVersion: 1, validation, pages };
+	const parent = await client.content.getContentById({
+		id: settings.confluenceParentId,
+		expand: ["space"],
+	});
+	if (!parent.space?.key) throw new Error("Publish parent has no space key");
+	const visit = async (node: LocalAdfFileTreeNode, root = false) => {
+		if (node.file && !root) {
+			const file = node.file;
+			try {
+				const candidates = file.pageId
+					? [
+							await client.content.getContentById({
+								id: file.pageId,
+								expand: ["ancestors", "space"],
+							}),
+						]
+					: (
+							await client.content.getContent({
+								title: file.pageTitle,
+								spaceKey: parent.space!.key,
+								type: file.contentType,
+								expand: ["ancestors", "space"],
+							})
+						).results;
+				const existing = candidates[0];
+				if (candidates.length > 1)
+					throw new Error(
+						"Ambiguous page title; assign a connie-page-id before publishing",
+					);
+				if (
+					existing &&
+					!file.pageId &&
+					file.contentType === "page" &&
+					!existing.ancestors?.some((ancestor) => ancestor.id === parent.id)
+				)
+					throw new Error("Matching page is outside the selected page tree");
+				pages.push({
+					source: file.absoluteFilePath,
+					title: file.pageTitle,
+					action: existing ? "reconcile" : "create",
+					...(existing
+						? {
+								pageId: existing.id,
+								reason: "Publishing will compare rendered content, attachments, labels and permissions",
+							}
+						: {}),
+				});
+			} catch (error) {
+				pages.push({
+					source: file.absoluteFilePath,
+					title: file.pageTitle,
+					action: "blocked",
+					reason: message(error),
+				});
+			}
+		}
+		for (const child of node.children) await visit(child);
+	};
+	await visit(createFolderStructure(structuredClone(files), settings), true);
+	return { schemaVersion: 1, validation, pages };
+}
+
+export function publishingReport(results: FilePublishResult[]) {
+	return {
+		schemaVersion: 1,
+		pages: results.map((result) => ({
+			source: result.node.file.absoluteFilePath,
+			pageId: result.node.file.pageId,
+			url: result.node.file.pageUrl,
+			status: result.successfulUploadResult ? "published" : "failed",
+			...(result.successfulUploadResult
+				? {
+						content: result.successfulUploadResult.contentResult,
+						attachments: result.successfulUploadResult.imageResult,
+						labels: result.successfulUploadResult.labelResult,
+					}
+				: { error: result.reason ?? "Unknown publishing error" }),
+		})),
+	};
+}
+function message(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -1,3 +1,4 @@
+import type { MermaidOptions } from "./MermaidOptions";
 import { Context } from "effect";
 
 export type ConfluenceAuthType = "basic" | "bearer" | "oauth2";
@@ -19,6 +20,10 @@ export type ConfluenceSettings = {
 	atlassianClientId: string;
 	atlassianClientSecret: string;
 	folderToPublish: string;
+	foldersToExclude?: readonly string[];
+	jiraUrl?: string;
+	orderPages?: boolean;
+	mermaid?: MermaidOptions;
 	tagsToPublish: string;
 	contentRoot: string;
 	firstHeadingPageTitle: boolean;
@@ -53,6 +58,10 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	atlassianClientId: "",
 	atlassianClientSecret: "",
 	folderToPublish: "Confluence Pages",
+	foldersToExclude: [],
+	jiraUrl: "",
+	orderPages: false,
+	mermaid: {},
 	tagsToPublish: "",
 	contentRoot: ".",
 	firstHeadingPageTitle: false,

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -1,3 +1,4 @@
+import { validateMermaidOptions, type MermaidOptions } from "./MermaidOptions";
 import { FileSystem } from "effect/FileSystem";
 import { Path } from "effect/Path";
 import { Config, ConfigProvider, Effect, Layer, Schema } from "effect";
@@ -26,7 +27,7 @@ type ArgumentDefinition = {
 type ArgumentValue = boolean | string | undefined;
 
 const confluenceConnectionFields = {
-	confluenceBaseUrl: Config.string("confluenceBaseUrl"),
+	confluenceBaseUrl: Config.string("confluenceBaseUrl").pipe(Config.withDefault("")),
 	confluenceSiteUrl: Config.string("confluenceSiteUrl").pipe(
 		Config.withDefault(DEFAULT_SETTINGS.confluenceSiteUrl),
 	),
@@ -56,8 +57,27 @@ export const confluenceReadSettingsConfig = Config.all(confluenceConnectionField
 
 export const confluenceSettingsConfig = Config.all({
 	...confluenceConnectionFields,
-	confluenceParentId: Config.string("confluenceParentId"),
+	confluenceParentId: Config.string("confluenceParentId").pipe(Config.withDefault("")),
 	folderToPublish: Config.string("folderToPublish"),
+	orderPages: Config.boolean("orderPages").pipe(Config.withDefault(false)),
+	jiraUrl: Config.string("jiraUrl").pipe(Config.withDefault("")),
+	mermaid: Config.schema(
+		Schema.Struct({
+			format: Schema.optionalKey(Schema.Literals(["png", "svg"])),
+			scale: Schema.optionalKey(Schema.Number),
+			theme: Schema.optionalKey(
+				Schema.Literals(["default", "neutral", "dark", "forest", "base"]),
+			),
+			themeVariables: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+		}),
+		"mermaid",
+	).pipe(
+		Config.withDefault({}),
+		Config.map((value) => validateMermaidOptions(value as MermaidOptions)),
+	),
+	foldersToExclude: Config.schema(Schema.Array(Schema.String), "foldersToExclude").pipe(
+		Config.withDefault([]),
+	),
 	tagsToPublish: Config.string("tagsToPublish").pipe(
 		Config.withDefault(DEFAULT_SETTINGS.tagsToPublish),
 	),
@@ -280,6 +300,12 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "clientId", type: "string" },
 		{ name: "clientSecret", type: "string" },
 		{ name: "enableFolder", aliases: ["f"], type: "string" },
+		{ name: "mermaidFormat", type: "string" },
+		{ name: "mermaidScale", type: "string" },
+		{ name: "mermaidTheme", type: "string" },
+		{ name: "jiraUrl", type: "string" },
+		{ name: "orderPages", type: "boolean" },
+		{ name: "excludeFolders", type: "string" },
 		{ name: "tagsToPublish", aliases: ["t"], type: "string" },
 		{ name: "contentRoot", aliases: ["cr"], type: "string" },
 		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
@@ -291,6 +317,11 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "plantumlServerUrl", type: "string" },
 	]);
 
+	const mermaid = compactRecord({
+		format: options["mermaidFormat"],
+		scale: options["mermaidScale"],
+		theme: options["mermaidTheme"],
+	});
 	const plantuml = compactRecord({
 		enabled: options["plantumlEnabled"],
 		serverUrl: options["plantumlServerUrl"],
@@ -310,7 +341,16 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			atlassianClientId: options["clientId"],
 			atlassianClientSecret: options["clientSecret"],
 			folderToPublish: options["enableFolder"],
+			jiraUrl: options["jiraUrl"],
+			orderPages: options["orderPages"],
 			tagsToPublish: options["tagsToPublish"],
+			foldersToExclude:
+				typeof options["excludeFolders"] === "string"
+					? options["excludeFolders"]
+							.split(",")
+							.map((folder) => folder.trim())
+							.filter(Boolean)
+					: undefined,
 			contentRoot: options["contentRoot"],
 			firstHeadingPageTitle: options["firstHeaderPageTitle"],
 			forceOverwrite: options["forceOverwrite"],
@@ -319,6 +359,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			pageFooterMarkdown: options["pageFooterMarkdown"],
 		}),
 		...(Object.keys(plantuml).length > 0 ? { plantuml } : {}),
+		...(Object.keys(mermaid).length > 0 ? { mermaid } : {}),
 	});
 }
 

--- a/packages/lib/src/StructuredMarkdown.ts
+++ b/packages/lib/src/StructuredMarkdown.ts
@@ -1,0 +1,178 @@
+import { parse } from "yaml";
+import type { ADFEntity } from "@atlaskit/adf-utils/types";
+import SparkMD5 from "spark-md5";
+
+const record = (value: unknown): value is Record<string, unknown> =>
+	!!value && typeof value === "object" && !Array.isArray(value);
+const paragraph = (value: unknown): ADFEntity => ({
+	type: "paragraph",
+	content: String(value ?? "") === "" ? [] : [{ type: "text", text: String(value) }],
+});
+
+/** Explicit YAML authoring; literal < and ^ are ordinary text, never destructive markers. */
+export function yamlTable(source: string): ADFEntity {
+	const data: unknown = parse(source, { maxAliasCount: 50 });
+	let columns: string[];
+	let rows: unknown[][];
+	if (Array.isArray(data) && data.every(record)) {
+		columns = [...new Set(data.flatMap((row) => Object.keys(row)))];
+		rows = data.map((row) => columns.map((column) => row[column] ?? ""));
+	} else if (
+		record(data) &&
+		Array.isArray(data["columns"]) &&
+		data["columns"].every((value) => typeof value === "string") &&
+		Array.isArray(data["rows"]) &&
+		data["rows"].every(Array.isArray)
+	) {
+		columns = data["columns"];
+		rows = data["rows"];
+	} else throw new Error("yaml-table requires an array of records, or columns and rows arrays");
+	if (!columns.length || !rows.length || columns.length > 100 || rows.length > 1000)
+		throw new Error("yaml-table requires 1–100 columns and 1–1000 rows");
+	const occupied = new Set<string>();
+	const body = rows.map((row, rowIndex) => {
+		let column = 0;
+		const cells: ADFEntity[] = [];
+		for (const input of row) {
+			while (occupied.has(`${rowIndex}:${column}`)) column++;
+			if (
+				record(input) &&
+				(!Object.hasOwn(input, "value") ||
+					Object.keys(input).some(
+						(key) => !["value", "rowspan", "colspan"].includes(key),
+					))
+			)
+				throw new Error(
+					"yaml-table structured cells require value and optional rowspan/colspan",
+				);
+			const cell = record(input) ? input : { value: input };
+			const colspan = cell["colspan"] ?? 1;
+			const rowspan = cell["rowspan"] ?? 1;
+			if (
+				typeof colspan !== "number" ||
+				typeof rowspan !== "number" ||
+				!Number.isInteger(colspan) ||
+				!Number.isInteger(rowspan) ||
+				colspan < 1 ||
+				rowspan < 1 ||
+				column + colspan > columns.length ||
+				rowIndex + rowspan > rows.length
+			)
+				throw new Error("yaml-table cell span exceeds the table bounds");
+			const value = cell["value"] ?? "";
+			if (typeof value === "object") throw new Error("yaml-table cell values must be scalar");
+			for (let down = 0; down < rowspan; down++)
+				for (let across = 0; across < colspan; across++) {
+					const key = `${rowIndex + down}:${column + across}`;
+					if (occupied.has(key)) throw new Error("yaml-table contains overlapping spans");
+					occupied.add(key);
+				}
+			cells.push({
+				type: "tableCell",
+				attrs: { colspan, rowspan },
+				content: [paragraph(value)],
+			});
+			column += colspan;
+		}
+		for (let index = column; index < columns.length; index++)
+			if (!occupied.has(`${rowIndex}:${index}`))
+				cells.push({
+					type: "tableCell",
+					attrs: { colspan: 1, rowspan: 1 },
+					content: [paragraph("")],
+				});
+		return { type: "tableRow", content: cells };
+	});
+	return {
+		type: "table",
+		attrs: { layout: "default" },
+		content: [
+			{
+				type: "tableRow",
+				content: columns.map((value) => ({
+					type: "tableHeader",
+					attrs: { colspan: 1, rowspan: 1 },
+					content: [paragraph(value)],
+				})),
+			},
+			...body,
+		],
+	};
+}
+
+export function structuredMarkdown(
+	document: ADFEntity,
+	parseMarkdown: (source: string, namespace: string) => ADFEntity,
+	namespace: string,
+): ADFEntity {
+	let index = 0;
+	const walk = (node: ADFEntity): ADFEntity => {
+		if (node.type === "codeBlock") {
+			const language = String(node.attrs?.["language"] ?? "");
+			const source = (node.content ?? []).map((child) => child?.text ?? "").join("");
+			if (language === "yaml-table" || language === "yaml table") return yamlTable(source);
+			const macro = language.match(/^confluence-(excerpt|properties)(?:\s+(.+))?$/);
+			if (macro) {
+				const key = macro[1] === "excerpt" ? "excerpt" : "details";
+				const name = macro[2]?.trim() ?? macro[1]!;
+				const seed = `${namespace}:${key}:${name}:${index++}`;
+				return {
+					type: "bodiedExtension",
+					attrs: {
+						extensionType: "com.atlassian.confluence.macro.core",
+						extensionKey: key,
+						parameters: {
+							macroParams: { [key === "excerpt" ? "name" : "id"]: { value: name } },
+							macroMetadata: {
+								macroId: { value: SparkMD5.hash(seed) },
+								title: key === "excerpt" ? "Excerpt" : "Page Properties",
+							},
+						},
+					},
+					content: parseMarkdown(source, `${namespace}-${index}`).content ?? [],
+				};
+			}
+		}
+		if (node.content) node.content = node.content.map((child) => (child ? walk(child) : child));
+		return node;
+	};
+	return walk(document);
+}
+
+export function jiraShorthand(document: ADFEntity, jiraUrl: string): void {
+	const base = new URL(jiraUrl);
+	if (base.protocol !== "https:" || base.username || base.password || base.search || base.hash)
+		throw new Error(
+			"Jira URL must be an HTTPS site URL without credentials, query or fragment",
+		);
+	const walk = (node: ADFEntity) => {
+		if (node.type === "codeBlock") return;
+		if (!node.content) return;
+		node.content = node.content.flatMap((child) => {
+			if (!child) return [];
+			if (
+				child.type !== "text" ||
+				!child.text ||
+				child.marks?.some((mark) => mark.type === "code" || mark.type === "link")
+			) {
+				walk(child);
+				return [child];
+			}
+			const result: ADFEntity[] = [];
+			let end = 0;
+			for (const match of child.text.matchAll(/\bJIRA:\s*([A-Z][A-Z0-9_]*-\d+)\b/g)) {
+				if (match.index! > end)
+					result.push({ ...child, text: child.text.slice(end, match.index) });
+				result.push({
+					type: "inlineCard",
+					attrs: { url: `${base.href.replace(/\/$/, "")}/browse/${match[1]}` },
+				});
+				end = match.index! + match[0].length;
+			}
+			if (!end) return [child];
+			if (end < child.text.length) result.push({ ...child, text: child.text.slice(end) });
+			return result;
+		});
+	};
+	walk(document);
+}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -197,3 +197,9 @@ export {
 
 import { lockPageEditing } from "./PageEditLock";
 export { lockPageEditing };
+
+import { validatePublishingFiles, planPublishingFiles, publishingReport } from "./PublishingReport";
+export { validatePublishingFiles, planPublishingFiles, publishingReport };
+
+import { validateMermaidOptions, type MermaidOptions } from "./MermaidOptions";
+export { validateMermaidOptions, type MermaidOptions };

--- a/packages/mermaid-electron-renderer/src/ElectronRenderer.test.ts
+++ b/packages/mermaid-electron-renderer/src/ElectronRenderer.test.ts
@@ -12,6 +12,7 @@ vi.doMock("@electron/remote", () => ({
 		close = mockedRenderer.close;
 		setSize = vi.fn();
 		webContents = {
+			setZoomFactor: vi.fn(),
 			executeJavaScript: async () => ({ width: 100, height: 50 }),
 			capturePage: async () => ({ toPNG: () => Buffer.from("rendered image") }),
 		};

--- a/packages/mermaid-electron-renderer/src/ElectronRenderer.test.ts
+++ b/packages/mermaid-electron-renderer/src/ElectronRenderer.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from "@effect/vitest";
 
 const mockedRenderer = {
 	load: vi.fn(),
+	initialize: vi.fn(),
 	render: vi.fn(),
 	close: vi.fn(),
 };
@@ -21,7 +22,7 @@ vi.doMock("@electron/remote", () => ({
 
 vi.doMock("mermaid", () => ({
 	default: {
-		initialize: vi.fn(),
+		initialize: mockedRenderer.initialize,
 		mermaidAPI: { updateSiteConfig: vi.fn() },
 		render: mockedRenderer.render,
 	},
@@ -74,4 +75,24 @@ test("uses each renderer's current theme document and preserves Unicode CSS", as
 	expect(await documents[0]!.text()).toContain('class="theme-dark"');
 	expect(await documents[0]!.text()).toContain("中文 café");
 	expect(await documents[1]!.text()).toContain('class="theme-light"');
+});
+
+test("initializes derived theme colors before rendering SVG and closes its hidden window", async () => {
+	const renderer = new ElectronMermaidRenderer([], [], {}, "", {
+		format: "svg",
+		theme: "base",
+		themeVariables: { primaryColor: "#ddebff" },
+	});
+	const charts = await renderer.captureMermaidCharts([
+		{ name: "chart", data: "graph TD; A-->B" },
+	]);
+	expect(mockedRenderer.initialize).toHaveBeenCalledWith(
+		expect.objectContaining({
+			theme: "base",
+			themeVariables: { primaryColor: "#ddebff" },
+			securityLevel: "strict",
+		}),
+	);
+	expect(charts.get("chart")?.toString()).toBe("<svg />");
+	expect(mockedRenderer.close).toHaveBeenCalledOnce();
 });

--- a/packages/mermaid-electron-renderer/src/index.ts
+++ b/packages/mermaid-electron-renderer/src/index.ts
@@ -1,3 +1,4 @@
+import { validateMermaidOptions, type MermaidOptions } from "@markdown-confluence/lib";
 import { BrowserWindow } from "@electron/remote";
 import { ChartData, MermaidRenderer } from "@markdown-confluence/lib";
 import mermaid, { MermaidConfig } from "mermaid";
@@ -26,12 +27,17 @@ const pluginMermaidConfig: MermaidConfig = {
 };
 
 export class ElectronMermaidRenderer implements MermaidRenderer {
+	readonly format: "png" | "svg";
 	constructor(
 		private extraStyleSheets: string[],
 		private extraStyles: string[],
 		private mermaidConfig: MermaidConfig = pluginMermaidConfig,
 		private bodyClasses = "",
-	) {}
+		private renderOptions: MermaidOptions = {},
+	) {
+		validateMermaidOptions(renderOptions);
+		this.format = renderOptions.format ?? "png";
+	}
 
 	async captureMermaidCharts(charts: ChartData[]): Promise<Map<string, Buffer>> {
 		const mermaidRenderHtml = URL.createObjectURL(
@@ -39,9 +45,15 @@ export class ElectronMermaidRenderer implements MermaidRenderer {
 		);
 		const capturedCharts = new Map<string, Buffer>();
 		try {
-			const { themeVariables, ...mermaidInitConfig } = sanitizeMermaidConfig(
-				this.mermaidConfig,
-			);
+			const { themeVariables, ...mermaidInitConfig } = sanitizeMermaidConfig({
+				...this.mermaidConfig,
+				...(this.renderOptions.theme ? { theme: this.renderOptions.theme } : {}),
+				themeVariables: {
+					...this.mermaidConfig.themeVariables,
+					...this.renderOptions.themeVariables,
+				},
+				securityLevel: "strict",
+			});
 			mermaid.initialize({
 				...mermaidInitConfig,
 				startOnLoad: false,
@@ -60,9 +72,17 @@ export class ElectronMermaidRenderer implements MermaidRenderer {
 					await chartWindow.loadURL(mermaidRenderHtml);
 					const id = "mm" + uuidv4().replace(/-/g, "");
 					const { svg } = await mermaid.render(id, chart.data);
+					if (this.format === "svg") {
+						capturedCharts.set(chart.name, Buffer.from(svg));
+						continue;
+					}
+					const scale = this.renderOptions.scale ?? 1;
+					await chartWindow.webContents.setZoomFactor(scale);
 					const dimensions = await chartWindow.webContents.executeJavaScript(
 						`renderSvg(${JSON.stringify(svg)});`,
 					);
+					dimensions.width = Math.ceil(dimensions.width * scale);
+					dimensions.height = Math.ceil(dimensions.height * scale);
 					chartWindow.setSize(dimensions.width, dimensions.height);
 					const capturedImage = await chartWindow.webContents.capturePage(dimensions, {
 						stayHidden: true,

--- a/packages/mermaid-electron-renderer/src/index.ts
+++ b/packages/mermaid-electron-renderer/src/index.ts
@@ -56,10 +56,10 @@ export class ElectronMermaidRenderer implements MermaidRenderer {
 			});
 			mermaid.initialize({
 				...mermaidInitConfig,
+				...(themeVariables ? { themeVariables } : {}),
 				startOnLoad: false,
 				suppressErrorRendering: true,
 			});
-			if (themeVariables) mermaid.mermaidAPI.updateSiteConfig({ themeVariables });
 
 			for (const chart of charts) {
 				const chartWindow = new BrowserWindow({

--- a/packages/mermaid-puppeteer-renderer/src/index.ts
+++ b/packages/mermaid-puppeteer-renderer/src/index.ts
@@ -1,3 +1,4 @@
+import { validateMermaidOptions, type MermaidOptions } from "@markdown-confluence/lib";
 import { ChartData, MermaidRenderer, ConfluenceUploadSettings } from "@markdown-confluence/lib";
 import puppeteer, { LaunchOptions } from "puppeteer";
 import { downloadBrowsers } from "puppeteer/lib/puppeteer/node/install.js";
@@ -12,7 +13,13 @@ interface RemoteWindowedCustomFunctions {
 export class PuppeteerMermaidRenderer implements MermaidRenderer {
 	private readonly protocolTimeout: number;
 
-	constructor(options: Pick<LaunchOptions, "protocolTimeout"> = {}) {
+	readonly format: "png" | "svg";
+	constructor(
+		options: Pick<LaunchOptions, "protocolTimeout"> = {},
+		private renderOptions: MermaidOptions = {},
+	) {
+		validateMermaidOptions(renderOptions);
+		this.format = renderOptions.format ?? "png";
 		this.protocolTimeout =
 			options.protocolTimeout ??
 			ConfluenceUploadSettings.DEFAULT_SETTINGS.mermaidProtocolTimeout;
@@ -89,13 +96,31 @@ export class PuppeteerMermaidRenderer implements MermaidRenderer {
 							return renderMermaidChart(mermaidData, mermaidConfig);
 						},
 						chart.data,
-						mermaidConfig,
+						{
+							...mermaidConfig,
+							...(this.renderOptions.theme
+								? { theme: this.renderOptions.theme }
+								: {}),
+							themeVariables: {
+								...mermaidConfig.themeVariables,
+								...this.renderOptions.themeVariables,
+							},
+							securityLevel: "strict",
+						},
 					);
 					await page.setViewport({
 						width: result.width,
 						height: result.height,
+						deviceScaleFactor: this.renderOptions.scale ?? 1,
 					});
-					const imageBuffer = Buffer.from(await page.screenshot());
+					const imageBuffer =
+						this.format === "svg"
+							? Buffer.from(
+									await page.evaluate(
+										() => document.querySelector("svg")!.outerHTML,
+									),
+								)
+							: Buffer.from(await page.screenshot());
 					capturedCharts.set(chart.name, imageBuffer);
 				} finally {
 					await page.close();

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -356,6 +356,104 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Excluded folders")
+			.setDesc(
+				"One vault-relative folder per line. Exclusions override publish tags and frontmatter.",
+			)
+			.addTextArea((text) =>
+				text
+					.setValue((this.plugin.settings.foldersToExclude ?? []).join("\n"))
+					.onChange(async (value) => {
+						this.plugin.settings.foldersToExclude = value
+							.split("\n")
+							.map((folder) => folder.trim())
+							.filter(Boolean);
+						await this.plugin.saveSettings();
+					}),
+			);
+		new Setting(containerEl)
+			.setName("Jira site URL")
+			.setDesc("Optional HTTPS Jira site for JIRA: PROJECT-123 smart links.")
+			.addText((text) =>
+				text.setValue(this.plugin.settings.jiraUrl ?? "").onChange(async (value) => {
+					this.plugin.settings.jiraUrl = value;
+					await this.plugin.saveSettings();
+				}),
+			);
+		new Setting(containerEl)
+			.setName("Apply page ordering")
+			.setDesc(
+				"Order successfully published siblings with numeric sort-order frontmatter. Unranked pages are not managed.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.orderPages ?? false)
+					.onChange(async (value) => {
+						this.plugin.settings.orderPages = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl).setName("Mermaid output").addDropdown((dropdown) =>
+			dropdown
+				.addOption("png", "PNG")
+				.addOption("svg", "SVG")
+				.setValue(this.plugin.settings.mermaid?.format ?? "png")
+				.onChange(async (value) => {
+					this.plugin.settings.mermaid = {
+						...this.plugin.settings.mermaid,
+						format: value as "png" | "svg",
+					};
+					await this.plugin.saveSettings();
+				}),
+		);
+		new Setting(containerEl)
+			.setName("Mermaid scale")
+			.setDesc("PNG resolution multiplier, 1–4.")
+			.addSlider((slider) =>
+				slider
+					.setLimits(1, 4, 1)
+					.setValue(this.plugin.settings.mermaid?.scale ?? 1)
+					.setDynamicTooltip()
+					.onChange(async (value) => {
+						this.plugin.settings.mermaid = {
+							...this.plugin.settings.mermaid,
+							scale: value,
+						};
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Mermaid theme variables")
+			.setDesc("Optional JSON object of Mermaid color variables. Invalid JSON is not saved.")
+			.addTextArea((text) =>
+				text
+					.setValue(
+						JSON.stringify(this.plugin.settings.mermaid?.themeVariables ?? {}, null, 2),
+					)
+					.onChange(async (value) => {
+						try {
+							const variables: unknown = JSON.parse(value || "{}");
+							if (
+								!variables ||
+								typeof variables !== "object" ||
+								Array.isArray(variables) ||
+								Object.values(variables).some((color) => typeof color !== "string")
+							)
+								return;
+							this.plugin.settings.mermaid = {
+								...this.plugin.settings.mermaid,
+								themeVariables: variables as Record<string, string>,
+							};
+							await this.plugin.saveSettings();
+						} catch {
+							/* Keep the last valid settings while the user types. */
+						}
+					}),
+			);
+
+		new Setting(containerEl)
 			.setName("Tags to publish")
 			.setDesc("Publish files with any matching YAML tag, separated by commas")
 			.addText((text) =>

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -70,6 +70,8 @@ interface FilePublishResult {
 
 export default class ConfluencePlugin extends Plugin {
 	settings!: ObsidianPluginSettings;
+	private publishAbort: AbortController | undefined;
+	private publishStatus: HTMLElement | undefined;
 	browserOAuth = new BrowserOAuth(
 		() => this.settings,
 		() => this.app.secretStorage,
@@ -137,6 +139,7 @@ export default class ConfluencePlugin extends Plugin {
 			mermaidItems.extraStyles,
 			mermaidItems.mermaidConfig,
 			mermaidItems.bodyStyles,
+			this.settings.mermaid,
 		);
 
 		const plugins: ADFProcessingPlugin<unknown, unknown>[] = [
@@ -160,7 +163,9 @@ export default class ConfluencePlugin extends Plugin {
 			}
 		}
 
-		return new Publisher(this.settings, confluenceClient, plugins);
+		return new Publisher(this.settings, confluenceClient, plugins, (message) => {
+			this.publishStatus?.setText(message + " · click to cancel");
+		});
 	}
 
 	async getMermaidItems() {
@@ -242,7 +247,9 @@ export default class ConfluencePlugin extends Plugin {
 	async doPublish(publishFilter?: string): Promise<UploadResults> {
 		this.publisher = await this.createPublisher();
 		const adrFiles: FilePublishResult[] = await this.runObsidianEffect(
-			this.publisher.publishEffect(publishFilter) as unknown as Effect.Effect<
+			this.publisher.publishEffect(publishFilter, {
+				signal: this.publishAbort?.signal,
+			}) as unknown as Effect.Effect<
 				FilePublishResult[],
 				unknown,
 				MarkdownConfluencePlatform | MarkdownWorkspaceService
@@ -272,6 +279,16 @@ export default class ConfluencePlugin extends Plugin {
 
 	override async onload() {
 		await this.init();
+		this.publishStatus = this.addStatusBarItem();
+		this.publishStatus.onclick = () => this.publishAbort?.abort();
+		this.addCommand({
+			id: "cancel-publish",
+			name: "Cancel publishing after the current request",
+			callback: () => {
+				this.publishAbort?.abort();
+				new Notice("Cancellation requested. Completed writes will be kept.");
+			},
+		});
 
 		this.addRibbonIcon("cloud", "Publish to Confluence", async () => {
 			await this.runPublish();
@@ -474,6 +491,7 @@ export default class ConfluencePlugin extends Plugin {
 		}
 
 		this.isSyncing = true;
+		this.publishAbort = new AbortController();
 		try {
 			const stats = await this.doPublish(publishFilter);
 			this.showPublishResults(stats);
@@ -481,6 +499,8 @@ export default class ConfluencePlugin extends Plugin {
 			this.showPublishError(error);
 		} finally {
 			this.isSyncing = false;
+			this.publishAbort = undefined;
+			this.publishStatus?.empty();
 		}
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       markdown-it:
         specifier: ^14.2.0
         version: 14.3.1
+      markdown-it-footnote:
+        specifier: 4.0.0
+        version: 4.0.0
       markdown-it-table:
         specifier: ^4.1.1
         version: 4.1.1
@@ -155,6 +158,9 @@ importers:
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.2.0
+      '@types/markdown-it-footnote':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/mime-types':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1348,6 +1354,9 @@ packages:
   '@types/lodash@4.17.25':
     resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
+  '@types/markdown-it-footnote@3.0.4':
+    resolution: {integrity: sha512-XJ6n+v+2u+2gmYLSHcxyoNT/YrgrKvHuDJQlykFjuxCQCr86P2/fx1V6/0lcKxv5cSIlCaJ6sUcNS3zDI7I+LA==}
+
   '@types/markdown-it@14.2.0':
     resolution: {integrity: sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==}
 
@@ -2230,6 +2239,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  markdown-it-footnote@4.0.0:
+    resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
 
   markdown-it-table@4.1.1:
     resolution: {integrity: sha512-dzFHRwCe97sXD071Gw/LSIwgAcO2vNsT0BcPCmnrKhNW/W57Bnknl8EaC+j4hM3bAqus1CiVPcTQAvLkUfHLhw==}
@@ -3978,6 +3990,10 @@ snapshots:
 
   '@types/lodash@4.17.25': {}
 
+  '@types/markdown-it-footnote@3.0.4':
+    dependencies:
+      '@types/markdown-it': 14.2.0
+
   '@types/markdown-it@14.2.0':
     dependencies:
       '@types/linkify-it': 5.0.0
@@ -4741,6 +4757,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  markdown-it-footnote@4.0.0: {}
 
   markdown-it-table@4.1.1: {}
 

--- a/scripts/integration-fork-ports.js
+++ b/scripts/integration-fork-ports.js
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import { Effect } from "effect";
+import {
+	Publisher,
+	ConfluenceUploadSettings,
+	RuntimeEnvironmentService,
+	runEffect,
+	createAuthenticatedConfluenceClient,
+	MermaidRendererPlugin,
+	loadMarkdownWorkspace,
+	planPublishingFiles,
+} from "../packages/lib/dist/index.js";
+import { PuppeteerMermaidRenderer } from "../packages/mermaid-puppeteer-renderer/dist/index.js";
+import { liveConnectionSettings } from "./integration-options.js";
+import {
+	createInlineCommentClient,
+	createInlineCommentFixture,
+	verifyInlineComment,
+	inlineCommentSelection,
+} from "./integration-comments.js";
+
+await runEffect(
+	Effect.gen(function* () {
+		const runtime = yield* RuntimeEnvironmentService;
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		const join = path.join;
+		const directory = yield* fs.makeTempDirectory({ prefix: "confluence-fork-ports-" });
+		const writeFile = (name, text) => Effect.runPromise(fs.writeFileString(name, text));
+		const readFile = (name) => Effect.runPromise(fs.readFileString(name));
+		const mkdir = (name) => Effect.runPromise(fs.makeDirectory(name));
+		const environment = {};
+		for (const name of [
+			"ATLASSIAN_USERNAME",
+			"ATLASSIAN_API_TOKEN",
+			"ATLASSIAN_CLIENT_ID",
+			"ATLASSIAN_CLIENT_SECRET",
+			"CONFLUENCE_E2E_AUTH_TYPE",
+			"CONFLUENCE_E2E_API_URL",
+			"CONFLUENCE_E2E_BASE_URL",
+			"CONFLUENCE_E2E_PARENT_ID",
+			"CONFLUENCE_E2E_SPACE_KEY",
+			"CONFLUENCE_E2E_REPORT_DIRECTORY",
+		])
+			environment[name] = yield* runtime.getEnv(name);
+		const connection = liveConnectionSettings(environment);
+		const client = yield* createAuthenticatedConfluenceClient(connection);
+		const commenter = yield* createInlineCommentClient(client, connection);
+		yield* Effect.tryPromise(async () => {
+			const parent = await client.content.getContentById({
+				id: connection.confluenceParentId,
+				expand: ["space"],
+			});
+			assert.equal(parent.space.key, environment.CONFLUENCE_E2E_SPACE_KEY);
+
+			await mkdir(join(directory, "private"));
+			const title = `Fork ports ${Date.now()}`;
+			const note = `---\nconnie-title: ${title}\n---\n\n${inlineCommentSelection}\n\n**Unresolved [[missing-note|formatted link]]**\n\nFootnote[^reference] and again[^reference].\n\n[^reference]: A **named** footnote.\n\n    Another paragraph.\n\n\`\`\`confluence-excerpt summary\nExcerpt **content**.\n\`\`\`\n\n\`\`\`confluence-properties record\n| Key | Value |\n| --- | --- |\n| Flag | false |\n\`\`\`\n\n\`\`\`yaml-table\n- Count: 0\n  Enabled: false\n  Literal: "<"\n\`\`\`\n\nJIRA: DOCS-1\n\n\`\`\`mermaid\nflowchart LR\n A[Before] --> B[After]\n\`\`\`\n`;
+			await writeFile(join(directory, "feature.md"), note);
+			await writeFile(
+				join(directory, "private", "excluded.md"),
+				"---\nconnie-publish: true\n---\nExcluded",
+			);
+			const settings = {
+				...ConfluenceUploadSettings.DEFAULT_SETTINGS,
+				...connection,
+				contentRoot: directory + "/",
+				folderToPublish: ".",
+				foldersToExclude: ["private"],
+				jiraUrl: environment.CONFLUENCE_E2E_BASE_URL,
+			};
+			const workspace = await loadMarkdownWorkspace(settings);
+			const files = await runEffect(workspace.getMarkdownFilesToUpload);
+			assert.equal(files.length, 1);
+			const before = await readFile(join(directory, "feature.md"), "utf8");
+			const plan = await planPublishingFiles(files, settings, client);
+			assert.equal(plan.pages[0].action, "create");
+			assert.equal(await readFile(join(directory, "feature.md"), "utf8"), before);
+			const publish = async (format) => {
+				const publisher = new Publisher(settings, client, [
+					new MermaidRendererPlugin(
+						new PuppeteerMermaidRenderer({}, { format, scale: 2, theme: "neutral" }),
+					),
+				]);
+				let results;
+				for (let attempt = 0; attempt < 3; attempt++) {
+					results = await publisher.publish();
+					if (!results.some((result) => result.reason?.includes("HTTP 404"))) break;
+					console.log("Retrying newly created page after a transient 404");
+					await new Promise((resolve) => setTimeout(resolve, 1000));
+				}
+				assert.ok(results.length);
+				for (const result of results)
+					assert.ok(result.successfulUploadResult, result.reason);
+				return results[0].successfulUploadResult;
+			};
+			const first = await publish("png");
+			const fixture = await createInlineCommentFixture(commenter, first.adfFile.pageId);
+			const saved = await readFile(join(directory, "feature.md"), "utf8");
+			await writeFile(
+				join(directory, "feature.md"),
+				saved + "\nA change elsewhere on the page.\n",
+			);
+			await publish("png");
+			await verifyInlineComment(commenter, fixture);
+			const page = await client.content.getContentById({ id: first.adfFile.pageId });
+			const contents = JSON.parse(page.body.atlas_doc_format.value);
+			const serialized = JSON.stringify(contents);
+			for (const expected of [
+				'"extensionKey":"excerpt"',
+				'"extensionKey":"details"',
+				'"extensionKey":"anchor"',
+				'"text":"0"',
+				'"text":"false"',
+				"/browse/DOCS-1",
+			])
+				assert.ok(serialized.includes(expected), expected);
+			const repeat = await publish("png");
+			assert.equal(repeat.contentResult, "same", "An unchanged page must not be rewritten");
+			await publish("svg");
+			await verifyInlineComment(commenter, fixture);
+
+			// Verify real sibling ordering, then cancellation and safe restart.
+			settings.orderPages = true;
+			const firstPath = join(directory, "rank-a.md");
+			const secondPath = join(directory, "rank-b.md");
+			await writeFile(firstPath, `---\nconnie-title: ${title} A\nsort-order: 1\n---\nA`);
+			await writeFile(secondPath, `---\nconnie-title: ${title} B\nsort-order: 2\n---\nB`);
+			const orderedPublisher = new Publisher(settings, client, [
+				new MermaidRendererPlugin(new PuppeteerMermaidRenderer()),
+			]);
+			const initialOrder = await orderedPublisher.publish();
+			for (const result of initialOrder)
+				assert.ok(result.successfulUploadResult, result.reason);
+			const ranked = initialOrder.filter(
+				(result) => result.node.file.frontmatter["sort-order"] !== undefined,
+			);
+			assert.equal(ranked.length, 2);
+			await writeFile(
+				firstPath,
+				(await readFile(firstPath)).replace("sort-order: 1", "sort-order: 3"),
+			);
+			const reordered = await orderedPublisher.publish();
+			for (const result of reordered) assert.ok(result.successfulUploadResult, result.reason);
+			const siblings = { results: [] };
+			for (let cursor; ; ) {
+				const batch = await client.sendRequest({
+					method: "GET",
+					url: `/wiki/api/v2/pages/${settings.confluenceParentId}/children`,
+					searchParams: { ...(cursor ? { cursor } : {}), limit: 100 },
+				});
+				siblings.results.push(...batch.results);
+				if (!batch._links?.next) break;
+				assert.ok(batch.results.length);
+				const nextCursor = new URL(
+					batch._links.next,
+					settings.confluenceBaseUrl,
+				).searchParams.get("cursor");
+				assert.ok(nextCursor && nextCursor !== cursor);
+				cursor = nextCursor;
+			}
+			const orderedIds = siblings.results
+				.map((page) => page.id)
+				.filter((id) => ranked.some((result) => result.node.file.pageId === id));
+			assert.deepEqual(orderedIds, [
+				ranked.find((result) => result.node.file.fileName === "rank-b.md").node.file.pageId,
+				ranked.find((result) => result.node.file.fileName === "rank-a.md").node.file.pageId,
+			]);
+			const controller = new AbortController();
+			const cancellation = new Publisher(settings, client, [], (message) => {
+				if (message.startsWith("Publishing 1/")) controller.abort();
+			});
+			const cancelled = await cancellation.publish(undefined, { signal: controller.signal });
+			assert.ok(
+				cancelled.every(
+					(result) =>
+						!result.successfulUploadResult && result.reason.includes("cancelled"),
+				),
+			);
+			const restarted = await orderedPublisher.publish();
+			for (const result of restarted) assert.ok(result.successfulUploadResult, result.reason);
+			await verifyInlineComment(commenter, fixture);
+			const report = {
+				status: "passed",
+				authType: settings.confluenceAuthType,
+				pageId: first.adfFile.pageId,
+				url: first.adfFile.pageUrl,
+				commentId: fixture.commentId,
+				checks: [
+					"exclusions",
+					"sibling ordering",
+					"cancellation and restart",
+					"read-only plan",
+					"footnotes",
+					"excerpt",
+					"properties",
+					"YAML values",
+					"Jira",
+					"PNG scale",
+					"SVG",
+					"inline comment preservation",
+					"unchanged republish",
+				],
+			};
+			await writeFile(
+				join(environment.CONFLUENCE_E2E_REPORT_DIRECTORY, "fork-ports.json"),
+				JSON.stringify(report, null, 2),
+			);
+			console.log(JSON.stringify(report));
+		});
+	}),
+);

--- a/scripts/integration-fork-ports.js
+++ b/scripts/integration-fork-ports.js
@@ -55,6 +55,54 @@ await runEffect(
 			});
 			assert.equal(parent.space.key, environment.CONFLUENCE_E2E_SPACE_KEY);
 
+			const diagram =
+				"erDiagram\n" +
+				Array.from(
+					{ length: 12 },
+					(_, i) => "ENTITY_" + i + " {\n string label\n int count\n}",
+				).join("\n") +
+				"\n" +
+				Array.from(
+					{ length: 11 },
+					(_, i) => "ENTITY_" + i + " ||--o{ ENTITY_" + (i + 1) + " : contains",
+				).join("\n");
+			const rendererEvidence = [];
+			for (const options of [
+				{ format: "png", scale: 1 },
+				{ format: "png", scale: 2 },
+				{ format: "svg", scale: 2 },
+			]) {
+				const renderer = new PuppeteerMermaidRenderer(
+					{},
+					{ ...options, theme: "base", themeVariables: { primaryColor: "#ddebff" } },
+				);
+				const bytes = (
+					await renderer.captureMermaidCharts([{ name: "large-er", data: diagram }])
+				).get("large-er");
+				if (options.format === "svg") {
+					const svg = bytes.toString();
+					assert.ok(
+						svg.includes("<svg") &&
+							svg.includes("ENTITY_11") &&
+							svg.includes("#ddebff"),
+					);
+					rendererEvidence.push({ format: "svg", text: true, color: true });
+				} else
+					rendererEvidence.push({
+						...options,
+						width: bytes.readUInt32BE(16),
+						height: bytes.readUInt32BE(20),
+					});
+			}
+			assert.ok(
+				rendererEvidence[1].width >= rendererEvidence[0].width * 1.5 &&
+					rendererEvidence[1].height >= rendererEvidence[0].height * 1.5,
+			);
+			await writeFile(
+				join(environment.CONFLUENCE_E2E_REPORT_DIRECTORY, "mermaid-options.json"),
+				JSON.stringify(rendererEvidence, null, 2),
+			);
+
 			await mkdir(join(directory, "private"));
 			const title = `Fork ports ${Date.now()}`;
 			const note = `---\nconnie-title: ${title}\n---\n\n${inlineCommentSelection}\n\n**Unresolved [[missing-note|formatted link]]**\n\nFootnote[^reference] and again[^reference].\n\n[^reference]: A **named** footnote.\n\n    Another paragraph.\n\n\`\`\`confluence-excerpt summary\nExcerpt **content**.\n\`\`\`\n\n\`\`\`confluence-properties record\n| Key | Value |\n| --- | --- |\n| Flag | false |\n\`\`\`\n\n\`\`\`yaml-table\n- Count: 0\n  Enabled: false\n  Literal: "<"\n\`\`\`\n\nJIRA: DOCS-1\n\n\`\`\`mermaid\nflowchart LR\n A[Before] --> B[After]\n\`\`\`\n`;

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -365,6 +365,35 @@ export function runObsidianIntegration({
 			JSON.stringify(forkControls),
 		);
 
+		const rendererOptions = yield* evaluate(`
+            const p=app.plugins.plugins['confluence-integration'];
+            const original=p.settings.mermaid;
+            const diagram='erDiagram\\n'+Array.from({length:12},(_,i)=>'ENTITY_'+i+' {\\n string label\\n int count\\n}').join('\\n')+'\\n'+Array.from({length:11},(_,i)=>'ENTITY_'+i+' ||--o{ ENTITY_'+(i+1)+' : contains').join('\\n');
+            const results=[];
+            try {
+                for(const options of [{format:'png',scale:1},{format:'png',scale:2},{format:'svg',scale:2}]) {
+                    p.settings.mermaid={...options,theme:'base',themeVariables:{primaryColor:'#ddebff'}};
+                    const publisher=await p.createPublisher();
+                    const renderer=publisher.adfProcessingPlugins.find(plugin=>plugin.mermaidRenderer)?.mermaidRenderer;
+                    if(!renderer) throw Error('Mermaid renderer not found');
+                    const bytes=(await renderer.captureMermaidCharts([{name:'large-er',data:diagram}])).get('large-er');
+                    if(options.format==='svg') {
+                        const svg=bytes.toString();
+                        if(!svg.includes('<svg')||!svg.includes('ENTITY_11')||!svg.includes('#ddebff')) throw Error('SVG verification: '+JSON.stringify({svg:svg.includes('<svg'),text:svg.includes('ENTITY_11'),color:svg.includes('#ddebff')}));
+                        results.push({format:'svg',text:true,color:true});
+                    } else {
+                        results.push({format:'png',scale:options.scale,width:bytes.readUInt32BE(16),height:bytes.readUInt32BE(20)});
+                    }
+                }
+                if(results[1].width<results[0].width*1.5||results[1].height<results[0].height*1.5) throw Error('Mermaid scale did not increase raster resolution');
+                return JSON.stringify(results);
+            } finally {p.settings.mermaid=original;}
+        `);
+		yield* fs.writeFileString(
+			path.join(reportDirectory, "mermaid-options.json"),
+			JSON.stringify(rendererOptions, null, 2),
+		);
+
 		// Exercise the real settings control, then publish an unchanged note with locking enabled.
 		const originalLock = yield* evaluate(
 			`return JSON.stringify(app.plugins.plugins['confluence-integration'].settings.lockPublishedPages ?? false);`,

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -19,6 +19,7 @@ import { runOAuthUiIntegration, runDeviceAvailabilityIntegration } from "./integ
 const publishedNotes = [
 	"Release Tests/Release Tests.md",
 	"Release Tests/Formatting.md",
+	"Release Tests/Fork Features.md",
 	"Release Tests/Media.md",
 	"Release Tests/Embeds.md",
 	"Release Tests/Hierarchy/README.md",
@@ -265,6 +266,15 @@ export function runObsidianIntegration({
 					pages["Release Tests/Hierarchy/Child.md"].ancestors.at(-1),
 					pages["Release Tests/Hierarchy/README.md"].id,
 				);
+				const features = JSON.stringify(pages["Release Tests/Fork Features.md"].body);
+				for (const expected of [
+					'"extensionKey":"excerpt"',
+					'"extensionKey":"details"',
+					'"extensionKey":"anchor"',
+					'"text":"0"',
+					'"text":"false"',
+				])
+					assert.ok(features.includes(expected), expected);
 				return pages;
 			});
 		const publish = () =>
@@ -341,6 +351,18 @@ export function runObsidianIntegration({
 			yield* snapshot(),
 			restored,
 			"A page with an inline comment must remain unchanged on republish",
+		);
+
+		const forkControls = yield* evaluate(`
+            app.setting.open(); app.setting.openTabById('confluence-integration');
+            const names=[...app.setting.activeTab.containerEl.querySelectorAll('.setting-item-name')].map(el=>el.textContent);
+            for(const name of ['Excluded folders','Jira site URL','Mermaid output','Mermaid scale','Mermaid theme variables','Apply page ordering']) if(!names.includes(name)) throw Error('Missing control: '+name);
+            if(!app.commands.commands['confluence-integration:cancel-publish']) throw Error('Missing cancel command');
+            app.setting.close(); return JSON.stringify({controls:true});
+        `);
+		yield* fs.writeFileString(
+			path.join(reportDirectory, "fork-controls.json"),
+			JSON.stringify(forkControls),
 		);
 
 		// Exercise the real settings control, then publish an unchanged note with locking enabled.

--- a/scripts/integration-options.js
+++ b/scripts/integration-options.js
@@ -4,6 +4,7 @@ export const integrationProfiles = [
 	"live",
 	"blogs",
 	"edit-lock",
+	"fork-ports",
 	"regressions",
 	"docker",
 	"vault",

--- a/scripts/integration-tests.js
+++ b/scripts/integration-tests.js
@@ -284,13 +284,19 @@ function runIntegration() {
 					);
 				});
 			const work = Effect.gen(function* () {
-				const live = ["live", "blogs", "edit-lock", "regressions", "obsidian"].includes(
-					options.profile,
-				);
+				const live = [
+					"live",
+					"blogs",
+					"edit-lock",
+					"fork-ports",
+					"regressions",
+					"obsidian",
+				].includes(options.profile);
 				const environment = [
 					"live",
 					"blogs",
 					"edit-lock",
+					"fork-ports",
 					"regressions",
 					"obsidian",
 					"vault",
@@ -368,6 +374,19 @@ function runIntegration() {
 					);
 					return;
 				}
+				if (options.profile === "fork-ports") {
+					yield* step(
+						"Selective fork features and comment preservation",
+						command(node, ["scripts/integration-fork-ports.js"], {
+							env: {
+								...environment,
+								CONFLUENCE_E2E_REPORT_DIRECTORY: reportDirectory,
+							},
+						}),
+					);
+					return;
+				}
+
 				if (options.profile === "edit-lock") {
 					yield* step(
 						"Live edit lock and publisher update",

--- a/test-fixtures/release-vault/Release Tests/Fork Features.md
+++ b/test-fixtures/release-vault/Release Tests/Fork Features.md
@@ -1,0 +1,31 @@
+---
+connie-title: Obsidian Fork Features
+tags: [release-test]
+---
+# Obsidian Fork Features
+
+A named footnote[^source], referenced again[^source].
+
+[^source]: The footnote **definition**.
+
+    A second paragraph.
+
+**An unresolved [[missing-note|formatted link]] remains readable.**
+
+```confluence-excerpt summary
+A reusable **summary**.
+```
+
+```confluence-properties record
+| Key | Value |
+| --- | --- |
+| Enabled | false |
+```
+
+```yaml-table
+columns: [Name, Detail]
+rows:
+  - [{value: Shared heading, colspan: 2}]
+  - [Count, 0]
+  - [Enabled, false]
+```


### PR DESCRIPTION
Adds the recommended community-fork features to the current Cloud pipeline: folder exclusions and cooperative cancellation, CLI validation/read-only planning/JSON reports, footnotes, excerpt and page-properties fences, explicit YAML table spans, Jira shorthand, Mermaid output controls, and opt-in sibling ordering. Fixes sparse link marks and narrowly normalizes Cloud-generated ADF differences.

The ports retain the existing client, publishing and raw-ADF architecture. Planning does not create placeholder pages. Ordering uses v2 child discovery and the supported v1 move operation. Contributor attribution, syntax and limitations are documented in `documentation/FORK_PORTS.md`; deferred MCP/Kroki ideas are outside this PR.

Validation:
- 44 test files: 375 passed, 1 skipped; formatting/lint checks and workspace build.
- Live Cloud feature suite passed using an unscoped API token and OAuth, including PNG/SVG, footnotes/macros/tables, exclusions, read-only planning, ordering, cancellation/restart, unchanged republishing, and an inline comment surviving edits elsewhere.
- Real Obsidian desktop suite passed with the new feature fixture and settings/cancellation-command checks. Both hosts also verified a 12-entity ER diagram at PNG scales 1 and 2 plus SVG text/custom colors; this caught and fixed Electron theme initialization.
- Browser navigation verified the footnote target and repeated-reference backlink after republishing. Windows CI passed after correcting a non-native planner test fixture.
- Scoped-token verification passed after replacing the expired test token with an equivalent one-day token. The complete feature profile passed, including rendering, ordering, cancellation/restart, no-op publishing and inline-comment preservation.

Live OAuth test page: https://markdown-confluence.atlassian.net/wiki/spaces/MCRT20260907/pages/991330370/
