### PR TITLE
feat: render Kroki diagrams in CLI and Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ This project is licensed under the [Apache 2.0](https://github.com/markdown-conf
 
 ## Disclaimer:
 The Apache license is only applicable to the Obsidian Confluence Integration (“Integration“), not to any third parties' services, websites, content or platforms that this Integration may enable you to connect with.  In another word, there is no license granted to you by the above identified licensor(s) to access any third-party services, websites, content, or platforms.  You are solely responsible for obtaining licenses from such third parties to use and access their services and to comply with their license terms. Please do not disclose any passwords, credentials, or tokens to any third-party service in your contribution to this Obsidian Confluence Integration project.”
+
+See [Kroki diagrams](documentation/KROKI.md) to render `kroki-*` fences through a trusted server in the CLI or Obsidian.

--- a/documentation/KROKI.md
+++ b/documentation/KROKI.md
@@ -1,0 +1,53 @@
+# Kroki diagrams
+
+Kroki renders fenced diagram blocks into attachments in Confluence Cloud. It is
+optional and disabled by default. Configure a trusted Kroki server before enabling
+it: diagram source is sent to that server. Confluence credentials are never sent
+to Kroki. A self-hosted server can keep diagram source inside your network.
+
+In Obsidian, open the Confluence settings, find **Kroki diagrams**, enter the server
+URL and enable rendering. Choose PNG (default) or SVG. Supported diagram types
+and output formats depend on your Kroki server.
+
+For example:
+
+````markdown
+```kroki-graphviz
+digraph G { Markdown -> Confluence }
+```
+````
+
+The language is `kroki-` followed by the Kroki diagram type, such as `graphviz` or
+`ditaa`. Existing Mermaid and PlantUML fences retain their existing renderers.
+
+CLI configuration:
+
+```json
+{
+  "kroki": {
+    "enabled": true,
+    "serverUrl": "https://kroki.example.com",
+    "format": "png",
+    "timeoutMs": 30000
+  }
+}
+```
+
+Equivalent CLI flags are `--krokiEnabled`, `--krokiServerUrl`, `--krokiFormat` and
+`--krokiTimeoutMs`. Environment variables use `CONFLUENCE_KROKI_ENABLED`,
+`CONFLUENCE_KROKI_SERVER_URL`, `CONFLUENCE_KROKI_FORMAT` and
+`CONFLUENCE_KROKI_TIMEOUT_MS`.
+
+Identical diagrams within a page are rendered once. Stable attachment names let
+unchanged publications reuse attachments; changed source produces a new image.
+Renderer errors stop publication instead of silently replacing diagrams with
+invalid images. Requests time out after 30 seconds by default.
+
+Run `vp run test:integration kroki` against the dedicated test space to verify
+Graphviz and Ditaa, PNG/SVG, updates, unchanged publication and inline comments.
+This test sends only synthetic diagrams to the public `https://kroki.io` service.
+
+The fence convention is adapted from the
+[PTCInc fork](https://github.com/PTCInc/markdown-confluence). The upstream
+implementation renders directly through the [Kroki API](https://docs.kroki.io/kroki/setup/usage/)
+instead of requiring pre-rendered SVG files.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { KrokiRendererPlugin, HttpKrokiRenderer } from "@markdown-confluence/lib";
 
 import { NodeRuntime } from "@effect/platform-node";
 import chalk from "chalk";
@@ -52,6 +53,8 @@ const program = Effect.gen(function* () {
 		),
 	];
 
+	if (settings.kroki?.enabled)
+		plugins.push(new KrokiRendererPlugin(new HttpKrokiRenderer(settings.kroki)));
 	if (settings.plantuml.enabled) {
 		if (!settings.plantuml.serverUrl) {
 			throw new Error(

--- a/packages/lib/src/ADFProcessingPlugins/KrokiRendererPlugin.ts
+++ b/packages/lib/src/ADFProcessingPlugins/KrokiRendererPlugin.ts
@@ -1,0 +1,190 @@
+import { filter, traverse } from "@atlaskit/adf-utils/traverse";
+import type { JSONDocNode } from "@atlaskit/editor-json-transformer";
+import type { ADFEntity } from "@atlaskit/adf-utils/types";
+import SparkMD5 from "spark-md5";
+import { Effect } from "effect";
+import type { UploadedImageData } from "../Attachments";
+import { runEffect } from "../effects";
+import type { ADFProcessingPlugin, PublisherFunctions } from "./types";
+
+type KrokiFetch = (
+	url: string,
+	init: RequestInit,
+) => Promise<Pick<Response, "ok" | "status" | "headers" | "arrayBuffer">>;
+
+export interface KrokiSettings {
+	enabled: boolean;
+	serverUrl: string;
+	format: "png" | "svg";
+	timeoutMs: number;
+}
+export const DEFAULT_KROKI_SETTINGS: KrokiSettings = {
+	enabled: false,
+	serverUrl: "",
+	format: "png",
+	timeoutMs: 30000,
+};
+export interface KrokiChart {
+	name: string;
+	data: string;
+	diagramType: string;
+}
+
+function diagramType(language: unknown): string | undefined {
+	if (typeof language !== "string" || !language.toLowerCase().startsWith("kroki-")) return;
+	const type = language.slice(6).toLowerCase();
+	if (!/^[a-z][a-z0-9-]*$/.test(type))
+		throw new Error("Invalid Kroki diagram type; use kroki-graphviz, for example");
+	return type;
+}
+export function getKrokiFileName(type: string, source: string, format: "png" | "svg") {
+	return `RenderedKrokiChart-${SparkMD5.hash(JSON.stringify([type, source]))}.${format}`;
+}
+
+/** Explicitly configured rendering service. Never receives Confluence credentials. */
+export class HttpKrokiRenderer {
+	readonly format: "png" | "svg";
+	private readonly serverUrl: string;
+	private readonly timeoutMs: number;
+	private readonly request: KrokiFetch;
+	constructor(options: Omit<KrokiSettings, "enabled"> & { fetchImpl?: KrokiFetch }) {
+		const url = new URL(options.serverUrl);
+		if (
+			!["http:", "https:"].includes(url.protocol) ||
+			url.username ||
+			url.password ||
+			url.search ||
+			url.hash
+		)
+			throw new Error(
+				"Kroki server must be an HTTP(S) URL without credentials, query or fragment",
+			);
+		if (!["png", "svg"].includes(options.format))
+			throw new Error("Kroki format must be png or svg");
+		if (
+			!Number.isSafeInteger(options.timeoutMs) ||
+			options.timeoutMs < 1 ||
+			options.timeoutMs > 2147483647
+		)
+			throw new Error("Kroki timeout must be a positive integer no greater than 2147483647");
+		this.serverUrl = url.href.replace(/\/$/, "");
+		this.format = options.format;
+		this.timeoutMs = options.timeoutMs;
+		this.request = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+	}
+	async capture(charts: KrokiChart[]): Promise<Map<string, Buffer>> {
+		const result = new Map<string, Buffer>();
+		// Sequential requests bound service load and stop immediately after a failure.
+		for (const chart of charts) {
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+			try {
+				const response = await this.request(this.serverUrl, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Accept: this.format === "png" ? "image/png" : "image/svg+xml",
+					},
+					body: JSON.stringify({
+						diagram_source: chart.data,
+						diagram_type: chart.diagramType,
+						output_format: this.format,
+					}),
+					signal: controller.signal,
+					redirect: "error",
+				});
+				if (!response.ok)
+					throw new Error(
+						`Kroki rendering failed: HTTP ${response.status} (${chart.diagramType})`,
+					);
+				const expected = this.format === "png" ? "image/png" : "image/svg+xml";
+				if (response.headers.get("content-type")?.split(";")[0]?.trim() !== expected)
+					throw new Error(
+						`Kroki returned an unexpected content type; expected ${expected}`,
+					);
+				const bytes = Buffer.from(await response.arrayBuffer());
+				if (
+					this.format === "png"
+						? !bytes
+								.subarray(0, 8)
+								.equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+						: !/<svg[\s>]/i.test(bytes.toString())
+				)
+					throw new Error("Kroki returned invalid image data");
+				result.set(chart.name, bytes);
+			} catch (error) {
+				if (controller.signal.aborted)
+					throw new Error(`Kroki rendering timed out after ${this.timeoutMs}ms`);
+				throw error;
+			} finally {
+				clearTimeout(timer);
+			}
+		}
+		return result;
+	}
+}
+
+export class KrokiRendererPlugin implements ADFProcessingPlugin<
+	KrokiChart[],
+	Record<string, UploadedImageData | null>
+> {
+	constructor(private readonly renderer: HttpKrokiRenderer) {}
+	extract(adf: JSONDocNode): KrokiChart[] {
+		const charts = new Map<string, KrokiChart>();
+		for (const node of filter(adf, (node) => node.type === "codeBlock")) {
+			const type = diagramType(node.attrs?.["language"]);
+			const source = node.content?.map((child) => child?.text ?? "").join("");
+			if (!type || !source?.trim()) continue;
+			const name = getKrokiFileName(type, source, this.renderer.format);
+			charts.set(name, { name, data: source, diagramType: type });
+		}
+		return [...charts.values()];
+	}
+	transform(charts: KrokiChart[], support: PublisherFunctions) {
+		return runEffect(this.transformEffect(charts, support));
+	}
+	transformEffect(charts: KrokiChart[], support: PublisherFunctions) {
+		const renderer = this.renderer;
+		return Effect.gen(function* () {
+			const images = yield* Effect.tryPromise({
+				try: () => renderer.capture(charts),
+				catch: (error) => error,
+			});
+			const result: Record<string, UploadedImageData | null> = {};
+			for (const [name, bytes] of images)
+				result[name] = yield* support.uploadBufferEffect(
+					name,
+					bytes,
+					renderer.format === "png" ? "image/png" : "image/svg+xml",
+				);
+			return result;
+		});
+	}
+	load(adf: JSONDocNode, images: Record<string, UploadedImageData | null>): JSONDocNode {
+		return (traverse(adf as ADFEntity, {
+			codeBlock: (node) => {
+				const type = diagramType(node.attrs?.["language"]);
+				const source = node.content?.map((child) => child?.text ?? "").join("");
+				if (!type || !source?.trim()) return;
+				const image = images[getKrokiFileName(type, source, this.renderer.format)];
+				if (!image) return;
+				return {
+					type: "mediaSingle",
+					attrs: { layout: "center" },
+					content: [
+						{
+							type: "media",
+							attrs: {
+								type: "file",
+								collection: image.collection,
+								id: image.id,
+								width: image.width,
+								height: image.height,
+							},
+						},
+					],
+				};
+			},
+		}) ?? adf) as JSONDocNode;
+	}
+}

--- a/packages/lib/src/Kroki.test.ts
+++ b/packages/lib/src/Kroki.test.ts
@@ -1,0 +1,100 @@
+import { expect, test, vi } from "@effect/vitest";
+import {
+	HttpKrokiRenderer,
+	KrokiRendererPlugin,
+	getKrokiFileName,
+} from "./ADFProcessingPlugins/KrokiRendererPlugin";
+import { parseMarkdownToADF } from "./MdToADF";
+const png = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const options = { serverUrl: "https://renderer.example", format: "png" as const, timeoutMs: 1000 };
+
+test("Kroki posts only diagram data, uses the configured format and deduplicates fences", async () => {
+	const fetchImpl = vi.fn(
+		async () => new Response(png, { headers: { "content-type": "image/png" } }),
+	);
+	const renderer = new HttpKrokiRenderer({ ...options, fetchImpl });
+	const plugin = new KrokiRendererPlugin(renderer);
+	const source = "```kroki-graphviz\ndigraph { A -> B }\n```";
+	const adf = parseMarkdownToADF(
+		source + "\n\n" + source + "\n\n```mermaid\ngraph TD; A-->B\n```",
+		"https://example.atlassian.net",
+	);
+	const charts = plugin.extract(adf);
+	expect(charts).toHaveLength(1);
+	const output = await renderer.capture(charts);
+	expect(output.get(charts[0]!.name)).toEqual(png);
+	const request = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+	expect(request[0]).toBe("https://renderer.example");
+	expect(request[1].headers).toEqual({ "Content-Type": "application/json", Accept: "image/png" });
+	expect(JSON.parse(request[1].body as string)).toEqual({
+		diagram_source: "digraph { A -> B }",
+		diagram_type: "graphviz",
+		output_format: "png",
+	});
+	const loaded = plugin.load(adf, {
+		[charts[0]!.name]: {
+			id: "attachment",
+			collection: "content",
+			width: 100,
+			height: 80,
+		} as never,
+	});
+	expect(loaded.content.map((n) => n.type)).toEqual(["mediaSingle", "mediaSingle", "codeBlock"]);
+	expect(adf.content[0]!.type).toBe("codeBlock");
+	expect(getKrokiFileName("graphviz", "x", "png")).not.toBe(
+		getKrokiFileName("ditaa", "x", "png"),
+	);
+});
+
+test("Kroki validates images and fails without including server response source", async () => {
+	for (const response of [
+		new Response("secret diagram", { status: 400 }),
+		new Response("<html>error</html>", { headers: { "content-type": "text/html" } }),
+		new Response("not PNG", { headers: { "content-type": "image/png" } }),
+	]) {
+		const renderer = new HttpKrokiRenderer({ ...options, fetchImpl: async () => response });
+		await expect(
+			renderer.capture([{ name: "test", diagramType: "graphviz", data: "source" }]),
+		).rejects.toThrow(/Kroki/);
+	}
+	const renderer = new HttpKrokiRenderer({
+		...options,
+		format: "svg",
+		fetchImpl: async () =>
+			new Response('<svg xmlns="http://www.w3.org/2000/svg"/>', {
+				headers: { "content-type": "image/svg+xml; charset=utf-8" },
+			}),
+	});
+	expect(
+		(await renderer.capture([{ name: "svg", diagramType: "graphviz", data: "source" }]))
+			.get("svg")
+			?.toString(),
+	).toContain("<svg");
+});
+
+test("Kroki aborts timed out requests and rejects unsafe server configuration", async () => {
+	const renderer = new HttpKrokiRenderer({
+		...options,
+		timeoutMs: 5,
+		fetchImpl: async (_url, request) =>
+			new Promise((_resolve, reject) =>
+				request?.signal?.addEventListener("abort", () => reject(new Error("aborted"))),
+			),
+	});
+	await expect(
+		renderer.capture([{ name: "slow", diagramType: "graphviz", data: "x" }]),
+	).rejects.toThrow("timed out");
+	for (const serverUrl of [
+		"file:///tmp/render",
+		"https://user:pass@example.com",
+		"https://example.com?token=x",
+	])
+		expect(() => new HttpKrokiRenderer({ ...options, serverUrl })).toThrow();
+	expect(() => new HttpKrokiRenderer({ ...options, timeoutMs: 0 })).toThrow();
+	const plugin = new KrokiRendererPlugin(new HttpKrokiRenderer(options));
+	expect(
+		plugin.extract(
+			parseMarkdownToADF("```kroki-graphviz\n\n```", "https://example.atlassian.net"),
+		),
+	).toEqual([]);
+});

--- a/packages/lib/src/Settings.ts
+++ b/packages/lib/src/Settings.ts
@@ -1,3 +1,4 @@
+import type { KrokiSettings } from "./ADFProcessingPlugins/KrokiRendererPlugin";
 import type { MermaidOptions } from "./MermaidOptions";
 import { Context } from "effect";
 
@@ -33,6 +34,7 @@ export type ConfluenceSettings = {
 	forceOverwrite: boolean;
 	lockPublishedPages?: boolean;
 	plantuml: PlantumlSettings;
+	kroki?: KrokiSettings;
 	mermaidProtocolTimeout: number;
 };
 
@@ -70,6 +72,7 @@ export const DEFAULT_SETTINGS: ConfluenceSettings = {
 	pageHeaderMarkdown: "",
 	pageFooterMarkdown: "",
 	ignoredCodeBlockLanguages: [],
+	kroki: { enabled: false, serverUrl: "", format: "png", timeoutMs: 30000 },
 	plantuml: {
 		enabled: false,
 		serverUrl: "",

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -542,3 +542,69 @@ test("falls back to default plantuml settings when nothing is configured", async
 		serverUrl: "",
 	});
 });
+
+test("loads nested kroki settings with CLI > env > file > default precedence", async () => {
+	const { configPath } = await runEffect(
+		Effect.gen(function* () {
+			const fs = yield* FileSystem;
+			const path = yield* Path;
+
+			tmpRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-settings-" });
+			const filePath = path.join(tmpRoot, ".markdown-confluence.json");
+
+			yield* fs.writeFileString(
+				filePath,
+				JSON.stringify({
+					confluenceBaseUrl: "https://file.example.atlassian.net",
+					confluenceParentId: "file-parent",
+					atlassianUserName: "file-user@example.com",
+					atlassianApiToken: "file-token",
+					folderToPublish: "file-folder",
+					contentRoot: "file-root",
+					firstHeadingPageTitle: true,
+					kroki: {
+						enabled: false,
+						serverUrl: "https://file-kroki.example.com",
+					},
+				}),
+			);
+
+			return { configPath: filePath };
+		}),
+	);
+
+	const runtimeEnvironment = makeRuntimeEnvironment({
+		argv: [
+			"node",
+			"markdown-confluence",
+			"--config",
+			configPath,
+			"--krokiServerUrl",
+			"https://cli-kroki.example.com",
+		],
+		cwd: tmpRoot ?? ".",
+		env: {
+			CONFLUENCE_KROKI_ENABLED: "true",
+		},
+	});
+
+	const settings = await Effect.runPromise(
+		loadConfluenceSettingsEffect().pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					NodeFileSystem.layer,
+					NodePath.layer,
+					Layer.succeed(RuntimeEnvironmentService, runtimeEnvironment),
+				),
+			),
+		),
+	);
+
+	// serverUrl from CLI (highest precedence with a value), enabled from env.
+	expect(settings.kroki).toEqual({
+		enabled: true,
+		serverUrl: "https://cli-kroki.example.com",
+		format: "png",
+		timeoutMs: 30000,
+	});
+});

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -93,6 +93,14 @@ export const confluenceSettingsConfig = Config.all({
 		Schema.Array(Schema.String),
 		"ignoredCodeBlockLanguages",
 	).pipe(Config.withDefault([])),
+	kroki: Config.all({
+		enabled: Config.boolean("enabled").pipe(Config.withDefault(false)),
+		serverUrl: Config.string("serverUrl").pipe(Config.withDefault("")),
+		format: Config.schema(Schema.Literals(["png", "svg"]), "format").pipe(
+			Config.withDefault("png"),
+		),
+		timeoutMs: Config.number("timeoutMs").pipe(Config.withDefault(30000)),
+	}).pipe(Config.nested("kroki")),
 	plantuml: Config.all({
 		enabled: Config.boolean("enabled").pipe(
 			Config.withDefault(DEFAULT_SETTINGS.plantuml.enabled),
@@ -279,6 +287,10 @@ function makeEnvironmentProvider(
 				// fromEnv splits nested config paths on "_", so plantuml.enabled
 				// and plantuml.serverUrl are supplied as plantuml_enabled /
 				// plantuml_serverUrl here.
+				kroki_enabled: yield* runtimeEnvironment.getEnv("CONFLUENCE_KROKI_ENABLED"),
+				kroki_serverUrl: yield* runtimeEnvironment.getEnv("CONFLUENCE_KROKI_SERVER_URL"),
+				kroki_format: yield* runtimeEnvironment.getEnv("CONFLUENCE_KROKI_FORMAT"),
+				kroki_timeoutMs: yield* runtimeEnvironment.getEnv("CONFLUENCE_KROKI_TIMEOUT_MS"),
 				plantuml_enabled: plantumlEnabled,
 				plantuml_serverUrl: plantumlServerUrl,
 			}),
@@ -313,6 +325,10 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		{ name: "forceOverwrite", aliases: ["fo"], type: "boolean" },
 		{ name: "pageHeaderMarkdown", type: "string" },
 		{ name: "pageFooterMarkdown", type: "string" },
+		{ name: "krokiEnabled", type: "boolean" },
+		{ name: "krokiServerUrl", type: "string" },
+		{ name: "krokiFormat", type: "string" },
+		{ name: "krokiTimeoutMs", type: "string" },
 		{ name: "plantumlEnabled", type: "boolean" },
 		{ name: "plantumlServerUrl", type: "string" },
 	]);
@@ -321,6 +337,12 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 		format: options["mermaidFormat"],
 		scale: options["mermaidScale"],
 		theme: options["mermaidTheme"],
+	});
+	const kroki = compactRecord({
+		enabled: options["krokiEnabled"],
+		serverUrl: options["krokiServerUrl"],
+		format: options["krokiFormat"],
+		timeoutMs: options["krokiTimeoutMs"],
 	});
 	const plantuml = compactRecord({
 		enabled: options["plantumlEnabled"],
@@ -358,6 +380,7 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 			pageHeaderMarkdown: options["pageHeaderMarkdown"],
 			pageFooterMarkdown: options["pageFooterMarkdown"],
 		}),
+		...(Object.keys(kroki).length > 0 ? { kroki } : {}),
 		...(Object.keys(plantuml).length > 0 ? { plantuml } : {}),
 		...(Object.keys(mermaid).length > 0 ? { mermaid } : {}),
 	});
@@ -438,6 +461,12 @@ function pickConfluenceSettings(config: Record<string, unknown>): Partial<Conflu
 
 		// `plantuml` is a nested object; copy its known sub-keys through with
 		// the right types so a partial config file still merges cleanly.
+		if (key === "kroki") {
+			const value = config[key];
+			if (value && typeof value === "object" && !Array.isArray(value))
+				result.kroki = value as NonNullable<ConfluenceSettings["kroki"]>;
+			continue;
+		}
 		if (key === "plantuml") {
 			const value = config[key];
 			if (value && typeof value === "object" && !Array.isArray(value)) {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -203,3 +203,21 @@ export { validatePublishingFiles, planPublishingFiles, publishingReport };
 
 import { validateMermaidOptions, type MermaidOptions } from "./MermaidOptions";
 export { validateMermaidOptions, type MermaidOptions };
+
+import {
+	KrokiRendererPlugin,
+	HttpKrokiRenderer,
+	DEFAULT_KROKI_SETTINGS,
+	getKrokiFileName,
+	type KrokiSettings,
+	type KrokiChart,
+} from "./ADFProcessingPlugins/KrokiRendererPlugin";
+
+export {
+	KrokiRendererPlugin,
+	HttpKrokiRenderer,
+	DEFAULT_KROKI_SETTINGS,
+	getKrokiFileName,
+	type KrokiSettings,
+	type KrokiChart,
+};

--- a/packages/obsidian/src/ConfluenceSettingTab.ts
+++ b/packages/obsidian/src/ConfluenceSettingTab.ts
@@ -556,6 +556,42 @@ export class ConfluenceSettingTab extends PluginSettingTab {
 				/* eslint-enable @typescript-eslint/naming-convention */
 			});
 
+		containerEl.createEl("h2", { text: "Kroki diagrams" });
+		const kroki = this.plugin.settings.kroki!;
+		new Setting(containerEl)
+			.setName("Enable Kroki rendering")
+			.setDesc(
+				"Render kroki-* code blocks. Enabling sends their diagram source to the server below.",
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(kroki.enabled).onChange(async (value) => {
+					kroki.enabled = value;
+					await this.plugin.saveSettings();
+				}),
+			);
+		new Setting(containerEl)
+			.setName("Kroki server URL")
+			.setDesc(
+				"Use a server you trust, such as a self-hosted Kroki instance. No Confluence credentials are sent to it.",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("https://kroki.io")
+					.setValue(kroki.serverUrl)
+					.onChange(async (value) => {
+						kroki.serverUrl = value.trim();
+						await this.plugin.saveSettings();
+					}),
+			);
+		new Setting(containerEl).setName("Kroki output").addDropdown((dropdown) =>
+			dropdown
+				.addOptions({ png: "PNG", svg: "SVG" })
+				.setValue(kroki.format)
+				.onChange(async (value) => {
+					kroki.format = value as "png" | "svg";
+					await this.plugin.saveSettings();
+				}),
+		);
 		containerEl.createEl("h2", { text: "PlantUML diagrams" });
 
 		new Setting(containerEl)

--- a/packages/obsidian/src/KrokiFetch.test.ts
+++ b/packages/obsidian/src/KrokiFetch.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@effect/vitest";
+import { createServer } from "node:http";
+import { krokiFetch } from "./KrokiFetch";
+
+test("desktop Kroki transport preserves image bytes, rejects redirects and honors abort", async () => {
+	const bytes = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10, 0, 255, 128]);
+	const server = createServer((request, response) => {
+		if (request.url === "/redirect") {
+			response.writeHead(302, { location: "/image" });
+			response.end();
+			return;
+		}
+		if (request.url === "/slow") return;
+		expect(request.method).toBe("POST");
+		expect(request.headers.authorization).toBeUndefined();
+		response.writeHead(200, { "content-type": "image/png" });
+		response.end(bytes);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	try {
+		const address = server.address();
+		if (!address || typeof address === "string") throw new Error("Missing test address");
+		const base = `http://127.0.0.1:${address.port}`;
+		const response = await krokiFetch(base + "/image", { method: "POST", body: "{}" });
+		expect(Buffer.from(await response.arrayBuffer())).toEqual(bytes);
+		expect(response.headers.get("content-type")).toBe("image/png");
+		await expect(krokiFetch(base + "/redirect", {})).rejects.toThrow("redirects");
+		const controller = new AbortController();
+		const pending = krokiFetch(base + "/slow", { signal: controller.signal });
+		controller.abort();
+		await expect(pending).rejects.toThrow();
+	} finally {
+		server.closeAllConnections();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+});

--- a/packages/obsidian/src/KrokiFetch.ts
+++ b/packages/obsidian/src/KrokiFetch.ts
@@ -1,0 +1,46 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+
+/** Desktop diagram transport avoids browser CORS and preserves binary image bytes. */
+export async function krokiFetch(url: string, init: RequestInit) {
+	const protocol = new URL(url).protocol;
+	if (protocol !== "http:" && protocol !== "https:") throw new Error("Kroki requires HTTP(S)");
+	return new Promise<Pick<Response, "ok" | "status" | "headers" | "arrayBuffer">>(
+		(resolve, reject) => {
+			const outgoing = (protocol === "https:" ? httpsRequest : httpRequest)(
+				url,
+				{
+					method: init.method,
+					headers: Object.fromEntries(new Headers(init.headers)),
+					signal: init.signal ?? undefined,
+				},
+				(incoming) => {
+					const status = incoming.statusCode ?? 0;
+					if (status >= 300 && status < 400) {
+						incoming.destroy();
+						reject(new Error("Kroki redirects are not permitted"));
+						return;
+					}
+					const chunks: Buffer[] = [];
+					incoming.on("data", (chunk: Buffer) => chunks.push(chunk));
+					incoming.on("error", reject);
+					incoming.on("end", () => {
+						const bytes = Buffer.concat(chunks);
+						const headers = new Headers();
+						for (const [key, value] of Object.entries(incoming.headers))
+							if (value !== undefined)
+								headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+						resolve({
+							ok: status >= 200 && status < 300,
+							status,
+							headers,
+							arrayBuffer: async () => Uint8Array.from(bytes).buffer,
+						});
+					});
+				},
+			);
+			outgoing.on("error", reject);
+			outgoing.end(init.body);
+		},
+	);
+}

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -1,3 +1,9 @@
+import { krokiFetch } from "./KrokiFetch";
+import {
+	KrokiRendererPlugin,
+	HttpKrokiRenderer,
+	DEFAULT_KROKI_SETTINGS,
+} from "@markdown-confluence/lib";
 import { Plugin, Notice, MarkdownView, Workspace, loadMermaid } from "obsidian";
 import {
 	ADFProcessingPlugin,
@@ -147,6 +153,12 @@ export default class ConfluencePlugin extends Plugin {
 			new MermaidRendererPlugin(mermaidRenderer),
 		];
 
+		if (this.settings.kroki?.enabled)
+			plugins.push(
+				new KrokiRendererPlugin(
+					new HttpKrokiRenderer({ ...this.settings.kroki, fetchImpl: krokiFetch }),
+				),
+			);
 		if (this.settings.plantuml.enabled) {
 			if (this.settings.plantuml.serverUrl) {
 				plugins.push(
@@ -454,6 +466,7 @@ export default class ConfluencePlugin extends Plugin {
 			{
 				// Deep-merge the nested plantuml object so a persisted partial (or
 				// an older settings file missing it) keeps the defaults.
+				kroki: { ...DEFAULT_KROKI_SETTINGS, ...loaded.kroki },
 				plantuml: {
 					...ConfluenceUploadSettings.DEFAULT_SETTINGS.plantuml,
 					...loaded.plantuml,

--- a/scripts/integration-kroki.js
+++ b/scripts/integration-kroki.js
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { Effect } from "effect";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import {
+	runEffect,
+	RuntimeEnvironmentService,
+	Publisher,
+	DEFAULT_KROKI_SETTINGS,
+	ConfluenceUploadSettings,
+	createAuthenticatedConfluenceClient,
+	KrokiRendererPlugin,
+	HttpKrokiRenderer,
+} from "../packages/lib/dist/index.js";
+import { liveConnectionSettings } from "./integration-options.js";
+import {
+	createInlineCommentClient,
+	createInlineCommentFixture,
+	verifyInlineComment,
+	inlineCommentSelection,
+} from "./integration-comments.js";
+
+await runEffect(
+	Effect.gen(function* () {
+		const runtime = yield* RuntimeEnvironmentService;
+		const fs = yield* FileSystem;
+		const path = yield* Path;
+		const environment = {};
+		for (const key of [
+			"ATLASSIAN_USERNAME",
+			"ATLASSIAN_API_TOKEN",
+			"ATLASSIAN_CLIENT_ID",
+			"ATLASSIAN_CLIENT_SECRET",
+			"CONFLUENCE_E2E_AUTH_TYPE",
+			"CONFLUENCE_E2E_API_URL",
+			"CONFLUENCE_E2E_BASE_URL",
+			"CONFLUENCE_E2E_PARENT_ID",
+			"CONFLUENCE_E2E_SPACE_KEY",
+			"CONFLUENCE_E2E_REPORT_DIRECTORY",
+		])
+			environment[key] = yield* runtime.getEnv(key);
+		const directory = yield* fs.makeTempDirectory({ prefix: "confluence-kroki-" });
+		const connection = liveConnectionSettings(environment);
+		const client = yield* createAuthenticatedConfluenceClient(connection);
+		const commenter = yield* createInlineCommentClient(client, connection);
+		const note = path.join(directory, "kroki.md");
+		const source = `---\nconnie-title: Kroki integration ${Date.now()}\n---\n\n${inlineCommentSelection}\n\n\`\`\`kroki-graphviz\ndigraph G { Hello -> World }\n\`\`\`\n\n\`\`\`kroki-ditaa\n+-------+   +-------+\n| Hello |-->| World |\n+-------+   +-------+\n\`\`\`\n`;
+		yield* fs.writeFileString(note, source);
+		yield* Effect.tryPromise(async () => {
+			const parent = await client.content.getContentById({
+				id: connection.confluenceParentId,
+				expand: ["space"],
+			});
+			assert.equal(parent.space.key, environment.CONFLUENCE_E2E_SPACE_KEY);
+			const settings = {
+				...ConfluenceUploadSettings.DEFAULT_SETTINGS,
+				...connection,
+				contentRoot: directory,
+				folderToPublish: ".",
+			};
+			const publisher = (format) =>
+				new Publisher(settings, client, [
+					new KrokiRendererPlugin(
+						new HttpKrokiRenderer({
+							...DEFAULT_KROKI_SETTINGS,
+							serverUrl: "https://kroki.io",
+							format,
+						}),
+					),
+				]);
+			const publish = async (format) => {
+				const results = await publisher(format).publish();
+				assert.equal(results.length, 1);
+				assert.ok(results[0].successfulUploadResult, results[0].reason);
+				return results[0];
+			};
+			const first = await publish("png");
+			const pageId = first.node.file.pageId;
+			const read = () =>
+				client.content.getContentById({
+					id: pageId,
+					expand: ["body.atlas_doc_format", "version"],
+				});
+			const before = await read();
+			const body = JSON.parse(before.body.atlas_doc_format.value);
+			assert.equal(body.content.filter((node) => node.type === "mediaSingle").length, 2);
+			const comment = await createInlineCommentFixture(commenter, pageId);
+			await Effect.runPromise(
+				fs.writeFileString(
+					note,
+					(await Effect.runPromise(fs.readFileString(note))) +
+						"\nAn edit outside the comment.\n",
+				),
+			);
+			await publish("png");
+			await verifyInlineComment(commenter, comment);
+			const edited = await read();
+			await publish("png");
+			assert.equal((await read()).version.number, edited.version.number);
+			await publish("svg");
+			const svg = await read();
+			assert.equal(
+				JSON.parse(svg.body.atlas_doc_format.value).content.filter(
+					(node) => node.type === "mediaSingle",
+				).length,
+				2,
+			);
+			await verifyInlineComment(commenter, comment);
+			await publish("svg");
+			assert.equal((await read()).version.number, svg.version.number);
+			await Effect.runPromise(
+				fs.writeFileString(
+					note,
+					(await Effect.runPromise(fs.readFileString(note))).replace(
+						"Hello -> World",
+						"Hello -> Changed",
+					),
+				),
+			);
+			await publish("svg");
+			assert.ok((await read()).version.number > svg.version.number);
+			await verifyInlineComment(commenter, comment);
+			const evidence = {
+				status: "passed",
+				authType: connection.confluenceAuthType,
+				pageId,
+				checks: [
+					"Graphviz and Ditaa",
+					"PNG and SVG",
+					"create/update/no-op",
+					"inline comment preservation",
+					"source changes",
+				],
+			};
+			await Effect.runPromise(
+				fs.writeFileString(
+					path.join(environment.CONFLUENCE_E2E_REPORT_DIRECTORY, "kroki.json"),
+					JSON.stringify(evidence, null, 2),
+				),
+			);
+			console.log(JSON.stringify(evidence));
+		});
+	}),
+);

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -394,6 +394,46 @@ export function runObsidianIntegration({
 			JSON.stringify(rendererOptions, null, 2),
 		);
 
+		const krokiUi = yield* evaluate(`
+            const p=app.plugins.plugins['confluence-integration'];
+            const original={...p.settings.kroki};
+            const note='Release Tests/Kroki.md';
+            try {
+                app.setting.open(); app.setting.openTabById('confluence-integration');
+                const rows=[...app.setting.activeTab.containerEl.querySelectorAll('.setting-item')];
+                const row=name=>rows.find(el=>el.querySelector('.setting-item-name')?.textContent===name);
+                const input=row('Kroki server URL')?.querySelector('input');
+                const toggle=row('Enable Kroki rendering')?.querySelector('.checkbox-container');
+                const output=row('Kroki output')?.querySelector('select');
+                if(!input||!toggle||!output) throw Error('Missing Kroki settings controls');
+                input.value='https://kroki.io'; input.dispatchEvent(new Event('input'));
+                if(!toggle.classList.contains('is-enabled')) toggle.click();
+                output.value='png'; output.dispatchEvent(new Event('change'));
+                if(!p.settings.kroki.enabled||p.settings.kroki.serverUrl!=='https://kroki.io') throw Error('Kroki controls did not update settings');
+                await p.saveSettings(); app.setting.close();
+                const source='---\\nconnie-publish: true\\nconnie-title: Desktop Kroki '+Date.now()+'\\n---\\n\\n'+String.fromCharCode(96).repeat(3)+'kroki-graphviz\\ndigraph G { Desktop -> Confluence }\\n'+String.fromCharCode(96).repeat(3)+'\\n';
+                const existing=app.vault.getAbstractFileByPath(note);
+                if(existing) await app.vault.modify(existing,source); else await app.vault.create(note,source);
+                const result=await p.doPublish(note);
+                if(result.errorMessage||result.failedFiles.length) throw Error('Desktop Kroki publish failed');
+                const file=app.vault.getAbstractFileByPath(note);
+                const content=await app.vault.read(file);
+                const pageId=content.match(/connie-page-id: ['"]?(\\d+)/)?.[1];
+                if(!pageId) throw Error('Kroki page ID missing');
+                return JSON.stringify({controls:true,published:true,pageId});
+            } finally {p.settings.kroki=original; await p.saveSettings(); app.setting.close();}
+        `);
+		const krokiPage = yield* get(`content/${krokiUi.pageId}?expand=body.atlas_doc_format`);
+		assert.ok(
+			JSON.parse(krokiPage.body.atlas_doc_format.value).content.some(
+				(node) => node.type === "mediaSingle",
+			),
+		);
+		yield* fs.writeFileString(
+			path.join(reportDirectory, "kroki-ui.json"),
+			JSON.stringify(krokiUi, null, 2),
+		);
+
 		// Exercise the real settings control, then publish an unchanged note with locking enabled.
 		const originalLock = yield* evaluate(
 			`return JSON.stringify(app.plugins.plugins['confluence-integration'].settings.lockPublishedPages ?? false);`,

--- a/scripts/integration-options.js
+++ b/scripts/integration-options.js
@@ -5,6 +5,7 @@ export const integrationProfiles = [
 	"blogs",
 	"edit-lock",
 	"fork-ports",
+	"kroki",
 	"regressions",
 	"docker",
 	"vault",

--- a/scripts/integration-tests.js
+++ b/scripts/integration-tests.js
@@ -22,6 +22,7 @@ const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 const help = `Integration profiles (vp run test:integration [profile] [options]):
   quick      Build, check all fixture conversions and render real Mermaid PNGs (default).
   packages   Pack all five npm packages, install into a fresh consumer and verify them.
+  kroki      Verify rendered diagrams, updates, no-op publication and inline comments.
   edit-lock  Verify page edit locking, read preservation and publisher updates.
   blogs      Publish a blog post; verify attachments, labels, updates and CLI export.
   live       Publish synthetic fixtures to Confluence; verify unchanged/update/recovery.
@@ -289,6 +290,7 @@ function runIntegration() {
 					"blogs",
 					"edit-lock",
 					"fork-ports",
+					"kroki",
 					"regressions",
 					"obsidian",
 				].includes(options.profile);
@@ -297,6 +299,7 @@ function runIntegration() {
 					"blogs",
 					"edit-lock",
 					"fork-ports",
+					"kroki",
 					"regressions",
 					"obsidian",
 					"vault",
@@ -374,6 +377,19 @@ function runIntegration() {
 					);
 					return;
 				}
+				if (options.profile === "kroki") {
+					yield* step(
+						"Kroki rendering and comment preservation",
+						command(node, ["scripts/integration-kroki.js"], {
+							env: {
+								...environment,
+								CONFLUENCE_E2E_REPORT_DIRECTORY: reportDirectory,
+							},
+						}),
+					);
+					return;
+				}
+
 				if (options.profile === "fork-ports") {
 					yield* step(
 						"Selective fork features and comment preservation",


### PR DESCRIPTION
Add opt-in `kroki-*` diagram rendering to the CLI and Obsidian. Users choose a trusted server and PNG/SVG output; diagram sources are sent only to that server, without Confluence credentials. Stable attachment names support updates and unchanged publishing.

Adapted from the PTCInc fork's fence convention, replacing its pre-rendered SVG requirement with direct Kroki HTTP rendering. Includes settings/configuration, response validation, timeouts, documentation and repeatable live/desktop integration checks.

Validation:
- Vite+ lint/format checks and workspace build pass.
- Full suite: 380 passed, one existing skip.
- Live Graphviz/Ditaa PNG/SVG create/update/no-op and inline-comment preservation passed with scoped tokens, unscoped tokens and OAuth.
- Candidate Docker CLI also published a Kroki diagram through the updated action entrypoint.
- Isolated real Obsidian settings-controls and publication test passed; Cloud API independently confirms media and PNG attachment. Fixed Electron CORS using a binary-safe Node transport. The broader desktop harness timed out before Kroki; its isolated test was then run successfully after reloading the test vault.
