### PR TITLE
test: verify edit locks against the Obsidian publisher

### DIFF
--- a/documentation/CLOUD_OAUTH.md
+++ b/documentation/CLOUD_OAUTH.md
@@ -25,6 +25,12 @@ Select these Confluence granular scopes:
 - `read:label:confluence`
 - `write:label:confluence`
 
+To enable **Restrict editing to the publishing account**, also grant
+`read:content.restriction:confluence` and `write:content.restriction:confluence`,
+and allow the account to restrict pages in the target space. These additional
+scopes also apply to scoped API tokens. Without them, content can publish while
+the edit-lock step reports a permission failure.
+
 The publisher uses v2 for pages, blog posts and metadata and v1 for the current user,
 attachment uploads and label writes. Both scopes and the account's space
 permissions must allow these operations. For blog posts, enable **Blogs** in the

--- a/documentation/OBSIDIAN_OAUTH.md
+++ b/documentation/OBSIDIAN_OAUTH.md
@@ -79,6 +79,11 @@ The registered Atlassian app needs the Confluence scopes in
 Resource-level grants restrict access to sites selected at consent. No shared
 client secret is embedded in the distributed plugin.
 
+After adding scopes to an existing app registration, use **Reconnect** and accept
+the updated grant. Refreshing an existing token does not add new permissions.
+Page edit locking requires both `read:content.restriction:confluence` and
+`write:content.restriction:confluence` in the app registration and user grant.
+
 Atlassian's [current guidance](https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/)
 states that integrations instructing customers to create individual 3LO apps do not
 comply with its requirements. The configurable credentials support integration

--- a/scripts/integration-obsidian.js
+++ b/scripts/integration-obsidian.js
@@ -459,7 +459,10 @@ export function runObsidianIntegration({
 			`const r=await app.plugins.plugins['confluence-integration'].doPublish(${JSON.stringify("Release Tests/Formatting.md")}); if(r.errorMessage || r.failedFiles.length) throw Error('Locked desktop publish failed'); return JSON.stringify({published:true});`,
 		);
 		const lockedPageId = restored[lockedNote].id;
-		const editor = yield* Effect.tryPromise(() => client.users.getCurrentUser());
+		// Browser login can publish as a different user from the API verifier.
+		const editor = yield* evaluate(
+			`const client=await app.plugins.plugins['confluence-integration'].authenticationClient(); const user=await client.users.getCurrentUser(); return JSON.stringify({accountId:user.accountId});`,
+		);
 		const restriction = yield* Effect.tryPromise(() =>
 			client.sendRequest({
 				url: `/wiki/rest/api/content/${lockedPageId}/restriction/byOperation/update`,


### PR DESCRIPTION
The desktop integration test used the separate API verification account when asserting edit-lock ownership. Browser OAuth can publish as a different user, so the test now reads the identity from the plugin authentication client and retains the exact owner assertion. Documentation now explains the additional restriction scopes and reconnecting after app scopes change. Formatting passed. Live browser OAuth verification includes fresh consent, rotating refresh tokens, publishing and edit restrictions; the complete desktop rerun is in progress.