### PR TITLE
fix: prevent unsafe publishing and preserve document content

### DIFF
--- a/packages/cli/src/command.test.ts
+++ b/packages/cli/src/command.test.ts
@@ -1,0 +1,145 @@
+import { expect, test, vi } from "@effect/vitest";
+import { Console, Effect } from "effect";
+import { RuntimeEnvironmentService, type RuntimeEnvironment } from "@markdown-confluence/lib";
+import { dispatchCommand, parseCliCommand } from "./command";
+
+function commandHarness(args: string[]) {
+	const createClient = vi.fn(() => ({}));
+	const publishEffect = vi.fn(() => Effect.void);
+	const createPublisher = vi.fn(() => ({ publishEffect }));
+	const handlers = {
+		publish: vi.fn((_report?: string) => {
+			createClient();
+			return createPublisher().publishEffect();
+		}),
+		preflight: vi.fn(() => Effect.void),
+		convert: vi.fn(() => Effect.void),
+	};
+	const getEnv = vi.fn(() => Effect.die("Unexpected settings access"));
+	const runtime: RuntimeEnvironment = {
+		argv: Effect.succeed(["node", "markdown-confluence", ...args]),
+		cwd: Effect.die("Unexpected workspace access"),
+		chdir: () => Effect.die("Unexpected workspace access"),
+		getEnv,
+		setMaxListeners: () => Effect.die("Unexpected runtime mutation"),
+		exit: () => Effect.die("Unexpected exit"),
+	};
+	const log = vi.fn();
+	const effect = dispatchCommand(handlers).pipe(
+		Effect.provideService(RuntimeEnvironmentService, runtime),
+		Effect.provideService(Console.Console, { ...console, log }),
+	);
+	return { effect, handlers, createClient, createPublisher, publishEffect, getEnv, log };
+}
+
+test.each([
+	{ args: ["valdiate"], error: "Unknown command: valdiate" },
+	{ args: ["plna"], error: "Unknown command: plna" },
+	{ args: ["--dry-run"], error: "Unknown option: --dry-run" },
+	{ args: ["--forceOverwrite=fales"], error: "--forceOverwrite requires a boolean value" },
+	{ args: ["--forceOverwrite", "fales"], error: "--forceOverwrite requires a boolean value" },
+	{ args: ["--forceOverwrite="], error: "--forceOverwrite requires a boolean value" },
+	{ args: ["--parentId"], error: "--parentId requires a value" },
+	{ args: ["--config"], error: "--config requires a value" },
+	{ args: ["--report"], error: "--report requires a value" },
+	{ args: ["--report", "--forceOverwrite"], error: "--report requires a value" },
+	{ args: ["--parentId="], error: "--parentId requires a value" },
+	{ args: ["--parentId", "-123"], error: "--parentId requires a value" },
+	{ args: ["--apiToken", "test-token", "plna"], error: "Unexpected argument: plna" },
+	{ args: ["--forceOverwrite", "false", "valdiate"], error: "Unexpected argument: valdiate" },
+	{ args: ["--", "valdiate"], error: "Unexpected argument: valdiate" },
+	{ args: ["validate", "--dry-run"], error: "Unknown option: --dry-run" },
+	{ args: ["plan", "--input"], error: "--input requires a value" },
+	{ args: ["plan", "--report", "-"], error: "Unknown option: --report" },
+	{ args: ["to-adf", "--forceOverwrite"], error: "Unknown to-adf option" },
+	{ args: ["to-markdown", "--input"], error: "--input requires a value" },
+])("rejects $args before calling any command or service", async ({ args, error }) => {
+	const harness = commandHarness(args);
+	await expect(Effect.runPromise(harness.effect)).rejects.toThrow(error);
+	expect(harness.handlers.publish).not.toHaveBeenCalled();
+	expect(harness.handlers.preflight).not.toHaveBeenCalled();
+	expect(harness.handlers.convert).not.toHaveBeenCalled();
+	expect(harness.createClient).not.toHaveBeenCalled();
+	expect(harness.createPublisher).not.toHaveBeenCalled();
+	expect(harness.publishEffect).not.toHaveBeenCalled();
+	expect(harness.getEnv).not.toHaveBeenCalled();
+	expect(harness.log).not.toHaveBeenCalled();
+});
+
+test.each([
+	["-h"],
+	["--help"],
+	["--forceOverwrite", "--help"],
+	["--parentId", "123", "-h"],
+	...["validate", "plan", "to-adf", "to-markdown", "from-adf"].flatMap((command) => [
+		[command, "-h"],
+		[command, "--help"],
+	]),
+])("help %j avoids settings, clients, publishers and command work", async (...args) => {
+	const harness = commandHarness(args);
+	await Effect.runPromise(harness.effect);
+	expect(harness.log).toHaveBeenCalledOnce();
+	expect(harness.handlers.publish).not.toHaveBeenCalled();
+	expect(harness.handlers.preflight).not.toHaveBeenCalled();
+	expect(harness.handlers.convert).not.toHaveBeenCalled();
+	expect(harness.createClient).not.toHaveBeenCalled();
+	expect(harness.createPublisher).not.toHaveBeenCalled();
+	expect(harness.publishEffect).not.toHaveBeenCalled();
+	expect(harness.getEnv).not.toHaveBeenCalled();
+});
+
+test("keeps intentional no-command publishing and passes report destinations", async () => {
+	for (const args of [[], ["--report", "-"], ["--report=publish.json"]]) {
+		const harness = commandHarness(args);
+		await Effect.runPromise(harness.effect);
+		expect(harness.createClient).toHaveBeenCalledOnce();
+		expect(harness.createPublisher).toHaveBeenCalledOnce();
+		expect(harness.publishEffect).toHaveBeenCalledOnce();
+		expect(harness.handlers.publish).toHaveBeenCalledExactlyOnceWith(
+			args.length === 0 ? undefined : args.length === 2 ? "-" : "publish.json",
+		);
+	}
+});
+
+test("option values that look like command names remain values", () => {
+	expect(
+		parseCliCommand([
+			"--config",
+			"validate",
+			"--pageHeaderMarkdown",
+			"plan",
+			"--apiToken=to-adf",
+			"--fo=false",
+			"-p",
+			"123",
+			"--report",
+			"to-markdown",
+		]),
+	).toEqual({ kind: "publish", report: "to-markdown" });
+});
+
+test("dispatches validated preflight options and conversion aliases", async () => {
+	const preflight = commandHarness([
+		"validate",
+		"--input=page.md",
+		"--output",
+		"-",
+		"-c",
+		"config.json",
+		"--fo=false",
+	]);
+	await Effect.runPromise(preflight.effect);
+	expect(preflight.handlers.preflight).toHaveBeenCalledExactlyOnceWith("validate", {
+		input: "page.md",
+		output: "-",
+	});
+	expect(preflight.createClient).not.toHaveBeenCalled();
+	const conversion = commandHarness(["from-adf", "--readable", "--", "-h"]);
+	await Effect.runPromise(conversion.effect);
+	expect(conversion.handlers.convert).toHaveBeenCalledExactlyOnceWith("to-markdown", [
+		"--readable",
+		"--",
+		"-h",
+	]);
+	expect(conversion.createClient).not.toHaveBeenCalled();
+});

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -1,0 +1,98 @@
+import { Console, Effect } from "effect";
+import {
+	parseConfluenceCommandLineOptions,
+	RuntimeEnvironmentService,
+} from "@markdown-confluence/lib";
+import { conversionHelp, parseConversionOptions } from "./conversionOptions";
+
+export type PreflightOptions = { input: string | undefined; output: string | undefined };
+
+type CliCommand =
+	| { kind: "help"; text: string }
+	| { kind: "publish"; report: string | undefined }
+	| { kind: "preflight"; command: "validate" | "plan"; options: PreflightOptions }
+	| { kind: "convert"; command: "to-adf" | "to-markdown"; args: string[] };
+
+type CommandHandlers<Failure, Requirements> = {
+	publish: (report?: string) => Effect.Effect<void, Failure, Requirements>;
+	preflight: (
+		command: "validate" | "plan",
+		options: PreflightOptions,
+	) => Effect.Effect<void, Failure, Requirements>;
+	convert: (
+		command: "to-adf" | "to-markdown",
+		args: string[],
+	) => Effect.Effect<void, Failure, Requirements>;
+};
+
+export function parseCliCommand(args: string[]): CliCommand {
+	const first = args[0];
+	if (first === "to-adf" || first === "to-markdown" || first === "from-adf") {
+		const command = first === "to-adf" ? "to-adf" : "to-markdown";
+		const conversionArgs = args.slice(1);
+		const options = parseConversionOptions(conversionArgs, command);
+		return options.help
+			? { kind: "help", text: conversionHelp(command) }
+			: { kind: "convert", command, args: conversionArgs };
+	}
+	if (first === "validate" || first === "plan") {
+		const options = parseConfluenceCommandLineOptions(args.slice(1), [
+			{ name: "help", aliases: ["h"], type: "flag" },
+			{ name: "input", type: "string" },
+			{ name: "output", type: "string" },
+		]);
+		return options["help"]
+			? {
+					kind: "help",
+					text: `${first} [--input FILE] [--output FILE|-] [publishing settings]\nvalidate works offline. plan performs only reads; existing pages are marked reconcile, not guessed unchanged.`,
+				}
+			: {
+					kind: "preflight",
+					command: first,
+					options: {
+						input: stringOption(options["input"]),
+						output: stringOption(options["output"]),
+					},
+				};
+	}
+	if (first !== undefined && !first.startsWith("-"))
+		throw new Error(`Unknown command: ${first}. Use --help for usage.`);
+	const options = parseConfluenceCommandLineOptions(args, [
+		{ name: "help", aliases: ["h"], type: "flag" },
+		{ name: "report", type: "string" },
+	]);
+	return options["help"]
+		? { kind: "help", text: cliHelp }
+		: { kind: "publish", report: stringOption(options["report"]) };
+}
+
+function stringOption(value: string | boolean | undefined): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+// Parse before invoking any handler: publishing handlers load credentials and construct clients.
+export function dispatchCommand<Failure, Requirements>(
+	handlers: CommandHandlers<Failure, Requirements>,
+) {
+	return Effect.gen(function* () {
+		const runtime = yield* RuntimeEnvironmentService;
+		const argv = yield* runtime.argv;
+		const command = yield* Effect.try({
+			try: () => parseCliCommand(argv.slice(2)),
+			catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+		});
+		switch (command.kind) {
+			case "help":
+				return yield* Console.log(command.text);
+			case "publish":
+				return yield* handlers.publish(command.report);
+			case "preflight":
+				return yield* handlers.preflight(command.command, command.options);
+			case "convert":
+				return yield* handlers.convert(command.command, command.args);
+		}
+	});
+}
+
+const cliHelp =
+	"Usage: markdown-confluence [publishing options]\n\nCommands:\n  validate     Validate selected Markdown without credentials\n  plan         Read-only Confluence page discovery\n  to-adf       Convert Markdown or export Confluence ADF\n  to-markdown  Convert ADF or a Confluence page to Markdown\n  from-adf     Alias for to-markdown\n\nUse COMMAND --help for command options. Without a command, publish using the configured settings.";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,107 +25,95 @@ import {
 } from "@markdown-confluence/mermaid-puppeteer-renderer";
 import { getErrorMessage } from "./errorMessage";
 import { preflight } from "./preflight";
+import { dispatchCommand } from "./command";
 import { FileSystem } from "effect/FileSystem";
 import { publishingReport } from "@markdown-confluence/lib";
 import { convertDocument } from "./convert";
 import { HttpPlantumlRenderer } from "@markdown-confluence/plantuml-renderer";
 
-const program = Effect.gen(function* () {
-	const runtimeEnvironment = yield* RuntimeEnvironmentService as any;
-	yield* runtimeEnvironment.setMaxListeners(Infinity) as any;
+const program = (destination?: string) =>
+	Effect.gen(function* () {
+		const runtimeEnvironment = yield* RuntimeEnvironmentService as any;
+		yield* runtimeEnvironment.setMaxListeners(Infinity) as any;
 
-	const settings = yield* ConfluenceUploadSettings.ConfluenceSettingsService as any;
-	const argv: string[] = yield* runtimeEnvironment.argv;
-	const reportIndex = argv.indexOf("--report");
-	const destination = reportIndex >= 0 ? argv[reportIndex + 1] : undefined;
-	if (reportIndex >= 0 && (!destination || destination.startsWith("--")))
-		throw new Error("--report requires a file path or - for stdout");
+		const settings = yield* ConfluenceUploadSettings.ConfluenceSettingsService as any;
 
-	const confluenceClient = yield* createAuthenticatedConfluenceClient(settings);
+		const confluenceClient = yield* createAuthenticatedConfluenceClient(settings);
 
-	const plugins: ADFProcessingPlugin<unknown, unknown>[] = [
-		new MathRendererPlugin(new PuppeteerMathRenderer()),
-		new MermaidRendererPlugin(
-			new PuppeteerMermaidRenderer(
-				{ protocolTimeout: settings.mermaidProtocolTimeout },
-				settings.mermaid,
+		const plugins: ADFProcessingPlugin<unknown, unknown>[] = [
+			new MathRendererPlugin(new PuppeteerMathRenderer()),
+			new MermaidRendererPlugin(
+				new PuppeteerMermaidRenderer(
+					{ protocolTimeout: settings.mermaidProtocolTimeout },
+					settings.mermaid,
+				),
 			),
-		),
-	];
+		];
 
-	if (settings.kroki?.enabled)
-		plugins.push(new KrokiRendererPlugin(new HttpKrokiRenderer(settings.kroki)));
-	if (settings.plantuml.enabled) {
-		if (!settings.plantuml.serverUrl) {
-			throw new Error(
-				"PlantUML rendering is enabled but plantuml.serverUrl is empty. Set CONFLUENCE_PLANTUML_SERVER_URL, --plantumlServerUrl, or plantuml.serverUrl in .markdown-confluence.json — or set plantuml.enabled to false.",
+		if (settings.kroki?.enabled)
+			plugins.push(new KrokiRendererPlugin(new HttpKrokiRenderer(settings.kroki)));
+		if (settings.plantuml.enabled) {
+			if (!settings.plantuml.serverUrl) {
+				throw new Error(
+					"PlantUML rendering is enabled but plantuml.serverUrl is empty. Set CONFLUENCE_PLANTUML_SERVER_URL, --plantumlServerUrl, or plantuml.serverUrl in .markdown-confluence.json — or set plantuml.enabled to false.",
+				);
+			}
+			plugins.push(
+				new PlantumlRendererPlugin(
+					new HttpPlantumlRenderer({ serverUrl: settings.plantuml.serverUrl }),
+				),
 			);
 		}
-		plugins.push(
-			new PlantumlRendererPlugin(
-				new HttpPlantumlRenderer({ serverUrl: settings.plantuml.serverUrl }),
-			),
-		);
-	}
 
-	const publisher = new Publisher(settings, confluenceClient, plugins, (message) => {
-		console.error(`[publish] ${message}`);
-	});
+		const publisher = new Publisher(settings, confluenceClient, plugins, (message) => {
+			console.error(`[publish] ${message}`);
+		});
 
-	const publishFilter = "";
-	const results = yield* publisher.publishEffect(publishFilter) as any;
+		const publishFilter = "";
+		const results = yield* publisher.publishEffect(publishFilter) as any;
 
-	if (destination) {
-		const json = JSON.stringify(publishingReport(results), null, 2) + "\n";
-		if (destination === "-") yield* Console.log(json);
-		else {
-			const fs = yield* FileSystem;
-			yield* fs.writeFileString(destination, json);
+		if (destination) {
+			const json = JSON.stringify(publishingReport(results), null, 2) + "\n";
+			if (destination === "-") yield* Console.log(json);
+			else {
+				const fs = yield* FileSystem;
+				yield* fs.writeFileString(destination, json);
+			}
 		}
-	}
 
-	for (const file of results) {
-		if (file.successfulUploadResult) {
-			yield* (destination === "-" ? Console.error : Console.log)(
-				chalk.green(
-					`SUCCESS: ${file.node.file.absoluteFilePath} Content: ${file.successfulUploadResult.contentResult}, Images: ${file.successfulUploadResult.imageResult}, Labels: ${file.successfulUploadResult.labelResult}, Page URL: ${file.node.file.pageUrl}`,
+		for (const file of results) {
+			if (file.successfulUploadResult) {
+				yield* (destination === "-" ? Console.error : Console.log)(
+					chalk.green(
+						`SUCCESS: ${file.node.file.absoluteFilePath} Content: ${file.successfulUploadResult.contentResult}, Images: ${file.successfulUploadResult.imageResult}, Labels: ${file.successfulUploadResult.labelResult}, Page URL: ${file.node.file.pageUrl}`,
+					),
+				) as any;
+				continue;
+			}
+			yield* Console.error(
+				chalk.red(
+					`FAILED:  ${file.node.file.absoluteFilePath} publish failed. Error is: ${file.reason}`,
 				),
 			) as any;
-			continue;
 		}
-		yield* Console.error(
-			chalk.red(
-				`FAILED:  ${file.node.file.absoluteFilePath} publish failed. Error is: ${file.reason}`,
-			),
-		) as any;
-	}
-	if (
-		results.some((file: { successfulUploadResult?: unknown }) => !file.successfulUploadResult)
-	) {
-		return yield* Effect.fail(new Error("One or more pages failed to publish"));
-	}
-});
+		if (
+			results.some(
+				(file: { successfulUploadResult?: unknown }) => !file.successfulUploadResult,
+			)
+		) {
+			return yield* Effect.fail(new Error("One or more pages failed to publish"));
+		}
+	});
 
-const command = Effect.gen(function* () {
-	const runtime = yield* RuntimeEnvironmentService;
-	const argv = yield* runtime.argv;
-	if (argv[2] === "validate" || argv[2] === "plan")
-		return yield* preflight(argv[2], argv.slice(3));
-	if (argv[2] === "to-adf" || argv[2] === "to-markdown" || argv[2] === "from-adf") {
-		const conversion = argv[2] === "to-adf" ? "to-adf" : "to-markdown";
-		return yield* convertDocument(conversion, argv.slice(3)).pipe(
-			Effect.provide(StandardInputLive),
-		);
-	}
-	if (argv[2] === "--help" || argv[2] === "-h") {
-		return yield* Console.log(
-			"Usage: markdown-confluence [publishing options]\n\nCommands:\n  validate     Validate selected Markdown without credentials\n  plan         Read-only Confluence page discovery\n  to-adf       Convert Markdown or export Confluence ADF\n  to-markdown  Convert ADF or a Confluence page to Markdown\n  from-adf     Alias for to-markdown\n\nUse COMMAND --help for conversion options. Without a command, publish using the configured settings.",
-		);
-	}
-	return yield* program.pipe(
-		Effect.provide(MarkdownWorkspaceLive),
-		Effect.provide(ConfluenceSettingsLive),
-	);
+const command = dispatchCommand({
+	publish: (report) =>
+		program(report).pipe(
+			Effect.provide(MarkdownWorkspaceLive),
+			Effect.provide(ConfluenceSettingsLive),
+		),
+	preflight,
+	convert: (conversion, args) =>
+		convertDocument(conversion, args).pipe(Effect.provide(StandardInputLive)),
 });
 
 NodeRuntime.runMain(

--- a/packages/cli/src/preflight.ts
+++ b/packages/cli/src/preflight.ts
@@ -9,26 +9,16 @@ import {
 	planPublishingFiles,
 	createAuthenticatedConfluenceClient,
 } from "@markdown-confluence/lib";
+import type { PreflightOptions } from "./command";
 
-export function preflight(command: "validate" | "plan", args: string[]) {
+export function preflight(command: "validate" | "plan", options: PreflightOptions) {
 	return Effect.gen(function* () {
-		if (args.includes("--help"))
-			return yield* Console.log(
-				`${command} [--input FILE] [--output FILE|-] [publishing settings]\nvalidate works offline. plan performs only reads; existing pages are marked reconcile, not guessed unchanged.`,
-			);
-		const argument = (name: string) => {
-			const index = args.indexOf(name);
-			if (index < 0) return undefined;
-			const value = args[index + 1];
-			if (!value || value.startsWith("--")) throw new Error(`Missing value for ${name}`);
-			return value;
-		};
 		const provider = yield* makeConfluenceSettingsConfigProvider();
 		const settings = yield* confluenceSettingsConfig.parse(provider);
 		if (command === "validate" && !settings.confluenceBaseUrl)
 			settings.confluenceBaseUrl = "https://confluence.invalid";
 		const workspace = yield* Effect.tryPromise(() => loadMarkdownWorkspace(settings));
-		const input = argument("--input");
+		const input = options.input;
 		const files = input
 			? [yield* workspace.loadMarkdownFile(input)]
 			: yield* workspace.getMarkdownFilesToUpload;
@@ -46,7 +36,7 @@ export function preflight(command: "validate" | "plan", args: string[]) {
 				: validatePublishingFiles(files, settings);
 		const fs = yield* FileSystem;
 		const path = yield* Path;
-		const output = argument("--output");
+		const output = options.output;
 		const json = JSON.stringify(report, null, 2) + "\n";
 		if (output && output !== "-") yield* fs.writeFileString(path.resolve(output), json);
 		else yield* Console.log(json);

--- a/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.test.ts
+++ b/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.test.ts
@@ -1,7 +1,11 @@
-import { expect, test } from "@effect/vitest";
+import { expect, test, vi } from "@effect/vitest";
+import { Effect } from "effect";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { UploadedImageData } from "../Attachments";
 import { ImageUploaderPlugin } from "./ImageUploaderPlugin";
+import { convertADFToMarkdown } from "../AdfConversion";
+import { parseMarkdownToADF } from "../MdToADF";
+import { executeADFProcessingPipeline, type PublisherFunctions } from "./types";
 
 test("keeps requested media width after uploading an image", () => {
 	const adf = docWithMedia({
@@ -113,4 +117,67 @@ test("MP4 embeds remain attachment media groups even with image-style size hints
 		id: "attachment-id",
 		collection: "contentId-page-id",
 	});
+});
+
+test.each([
+	{ type: "file", id: "remote-id", collection: "remote-collection" },
+	{ type: "file", id: "remote-id", collection: "remote-collection", url: "file://old.png" },
+	{ type: "external", url: "https://example.com/image.png" },
+	{ type: "file", url: null },
+	{ type: "file", url: 123 },
+])("ignores resolved or non-local media %j", (attrs) => {
+	const adf = docWithMedia(attrs);
+	expect(ImageUploaderPlugin.extract(adf)).toEqual([]);
+	expect(ImageUploaderPlugin.load(structuredClone(adf), {})).toEqual(adf);
+});
+
+test("republishes exported remote media and uploads only unresolved local attachments", async () => {
+	const remote = docWithMedia({
+		type: "file",
+		id: "remote-id",
+		collection: "remote-collection",
+		width: 320,
+		height: 200,
+	});
+	const markdown = convertADFToMarkdown(remote);
+	const restored = parseMarkdownToADF(markdown, "https://example.atlassian.net");
+	expect(restored).toEqual(remote);
+	const uploadFileEffect = vi.fn(() => Effect.succeed(uploadedImage));
+	const support: PublisherFunctions = {
+		uploadFileEffect,
+		uploadBufferEffect: () => Effect.fail(new Error("Unexpected buffer upload")),
+		uploadFile: async () => {
+			throw new Error("Unexpected promise upload");
+		},
+		uploadBuffer: async () => {
+			throw new Error("Unexpected buffer upload");
+		},
+	};
+	expect(await executeADFProcessingPipeline([ImageUploaderPlugin], restored, support)).toEqual(
+		remote,
+	);
+	expect(uploadFileEffect).not.toHaveBeenCalled();
+	const mixed = {
+		...remote,
+		content: [
+			...remote.content,
+			...docWithMedia({ type: "file", url: "file://img/chewbacca.png" }).content,
+			...docWithMedia({ type: "external", url: "https://example.com/external.png" }).content,
+		],
+	};
+	const published = await executeADFProcessingPipeline([ImageUploaderPlugin], mixed, support);
+	expect(uploadFileEffect).toHaveBeenCalledExactlyOnceWith("img/chewbacca.png");
+	expect(published.content[0]).toEqual(remote.content[0]);
+	expect(published.content[1]?.content?.[0]?.attrs).toMatchObject({
+		id: "attachment-id",
+		collection: "contentId-page-id",
+	});
+	expect(published.content[2]).toEqual(mixed.content[2]);
+	const again = await executeADFProcessingPipeline(
+		[ImageUploaderPlugin],
+		structuredClone(published),
+		support,
+	);
+	expect(again).toEqual(published);
+	expect(uploadFileEffect).toHaveBeenCalledTimes(1);
 });

--- a/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.ts
+++ b/packages/lib/src/ADFProcessingPlugins/ImageUploaderPlugin.ts
@@ -14,10 +14,15 @@ export const ImageUploaderPlugin: ADFProcessingPlugin<
 	extract(adf: JSONDocNode): string[] {
 		const mediaNodes = filter(
 			adf,
-			(node) => node.type === "media" && (node.attrs || {})?.["type"] === "file",
+			(node) => node.type === "media" && localMediaUrl(node) !== undefined,
 		);
 
-		const imagesToUpload = new Set(mediaNodes.map((node) => node?.attrs?.["url"]));
+		const imagesToUpload = new Set(
+			mediaNodes.flatMap((node) => {
+				const url = localMediaUrl(node);
+				return url === undefined ? [] : [url];
+			}),
+		);
 
 		return Array.from(imagesToUpload);
 	},
@@ -41,7 +46,7 @@ export const ImageUploaderPlugin: ADFProcessingPlugin<
 			let imageMap: Record<string, UploadedImageData | null> = {};
 
 			for (const imageUrl of imagesToUpload.values()) {
-				const filename = imageUrl.split("://")[1];
+				const filename = imageUrl.startsWith("file://") ? imageUrl.slice(7) : undefined;
 				if (!filename) {
 					continue;
 				}
@@ -63,11 +68,12 @@ export const ImageUploaderPlugin: ADFProcessingPlugin<
 		afterAdf =
 			traverse(afterAdf, {
 				media: (node, _parent) => {
-					if (node?.attrs?.["type"] === "file") {
-						if (!imageMap[node?.attrs?.["url"]]) {
+					const url = localMediaUrl(node);
+					if (url !== undefined && node.attrs) {
+						if (!imageMap[url]) {
 							return;
 						}
-						const mappedImage = imageMap[node.attrs["url"]];
+						const mappedImage = imageMap[url];
 						if (mappedImage) {
 							// Size hints cannot turn a non-image attachment into an image.
 							const isImage = mappedImage.width > 0 || mappedImage.height > 0;
@@ -99,8 +105,7 @@ export const ImageUploaderPlugin: ADFProcessingPlugin<
 						delete media.attrs["height"];
 						return { type: "mediaGroup", content: [media] };
 					}
-					const url = node.content.at(0)?.attrs?.["url"];
-					if (typeof url === "string" && url.startsWith("file://")) {
+					if (media && localMediaUrl(media) !== undefined) {
 						return p("Invalid Image Path");
 					}
 					return;
@@ -110,6 +115,16 @@ export const ImageUploaderPlugin: ADFProcessingPlugin<
 		return afterAdf as JSONDocNode;
 	},
 };
+
+function localMediaUrl(node: ADFEntity): string | undefined {
+	const url: unknown = node.attrs?.["url"];
+	return node.attrs?.["type"] === "file" &&
+		!node.attrs?.["id"] &&
+		typeof url === "string" &&
+		url.startsWith("file://")
+		? url
+		: undefined;
+}
 
 function mediaDimension(value: unknown): number | undefined {
 	if (typeof value !== "number" && typeof value !== "string") return undefined;

--- a/packages/lib/src/AdfProcessing.test.ts
+++ b/packages/lib/src/AdfProcessing.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@effect/vitest";
 import { TextDefinition } from "@atlaskit/adf-schema";
 import { JSONDocNode } from "@atlaskit/editor-json-transformer";
 import { prepareAdfToUpload } from "./AdfProcessing";
+import { parseMarkdownToADF } from "./MdToADF";
 import { ConfluenceAdfFile, ConfluenceNode } from "./Publisher";
 import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 
@@ -204,4 +205,138 @@ test("unresolved formatted wikilinks retain dense formatting marks", () => {
 		text: "Missing",
 		marks: [{ type: "strong" }],
 	});
+});
+
+test.each([
+	{ type: "hardBreak" },
+	{ type: "mention", attrs: { id: "account", text: "@User" } },
+	{ type: "emoji", attrs: { shortName: ":smile:", text: "🙂" } },
+	{ type: "date", attrs: { timestamp: "1690000000000" } },
+	{ type: "inlineCard", attrs: { url: "https://example.com" } },
+])("merges only adjacent text around $type nodes", (barrier) => {
+	const node = createNode({
+		contents: {
+			version: 1,
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "a" },
+						{ type: "text", text: "b" },
+						barrier,
+						{ type: "text", text: "c" },
+						{ type: "text", text: "d" },
+					],
+				},
+			],
+		} as JSONDocNode,
+	});
+	prepareAdfToUpload([node], testSettings);
+	expect(node.file.contents.content[0]!.content).toEqual([
+		{ type: "text", text: "ab" },
+		barrier,
+		{ type: "text", text: "cd" },
+	]);
+});
+
+test("preserves mentions after resolving an unpublished wikilink", () => {
+	const node = createNode({
+		contents: parseMarkdownToADF(
+			"alpha [[missing|beta]] [[mention:account|@User]] gamma",
+			testSettings.confluenceBaseUrl,
+		),
+	});
+	prepareAdfToUpload([node], testSettings);
+	expect(node.file.contents.content[0]!.content).toEqual([
+		{ type: "text", text: "alpha beta " },
+		{ type: "mention", attrs: { id: "account", text: "@User" } },
+		{ type: "text", text: " gamma" },
+	]);
+});
+
+test("keeps differently marked text separate while merging identical marks", () => {
+	const node = createNode({
+		contents: {
+			version: 1,
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "a", marks: [{ type: "strong" }] },
+						{ type: "text", text: "b", marks: [{ type: "strong" }] },
+						{ type: "text", text: "c", marks: [{ type: "em" }] },
+						{ type: "text", text: "d" },
+					],
+				},
+			],
+		} as JSONDocNode,
+	});
+	prepareAdfToUpload([node], testSettings);
+	expect(node.file.contents.content[0]!.content).toEqual([
+		{ type: "text", text: "ab", marks: [{ type: "strong" }] },
+		{ type: "text", text: "c", marks: [{ type: "em" }] },
+		{ type: "text", text: "d" },
+	]);
+});
+
+test("retains every overlapping inline comment through repeated publication", () => {
+	const marks = ["comment-one", "comment-two"].map((id) => ({
+		type: "annotation",
+		attrs: { annotationType: "inlineComment", id },
+	}));
+	const remote = {
+		version: 1,
+		type: "doc",
+		content: [
+			{
+				type: "paragraph",
+				content: [
+					{ type: "text", text: "Before " },
+					{ type: "text", text: "Anchor", marks },
+					{ type: "text", text: " after" },
+				],
+			},
+		],
+	} as JSONDocNode;
+	const source = {
+		version: 1,
+		type: "doc",
+		content: [{ type: "paragraph", content: [{ type: "text", text: "Before Anchor after" }] }],
+	} as JSONDocNode;
+	const node = createNode({ contents: structuredClone(source) });
+	node.existingPageData.adfContent = remote;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		prepareAdfToUpload([node], testSettings);
+		expect(node.file.contents).toEqual(remote);
+		node.existingPageData.adfContent = structuredClone(node.file.contents);
+		node.file.contents = structuredClone(source);
+	}
+});
+
+test("does not duplicate annotations already present in losslessly imported source", () => {
+	const document = {
+		version: 1,
+		type: "doc",
+		content: [
+			{
+				type: "paragraph",
+				content: [
+					{
+						type: "text",
+						text: "Anchor",
+						marks: ["one", "two"].map((id) => ({
+							type: "annotation",
+							attrs: { annotationType: "inlineComment", id },
+						})),
+					},
+				],
+			},
+		],
+	} as JSONDocNode;
+	const node = createNode({ contents: structuredClone(document) });
+	node.existingPageData.adfContent = structuredClone(document);
+	prepareAdfToUpload([node], testSettings);
+	expect(node.file.contents).toEqual(document);
 });

--- a/packages/lib/src/AdfProcessing.ts
+++ b/packages/lib/src/AdfProcessing.ts
@@ -171,6 +171,23 @@ function applyInlineComments(adf: JSONDocNode, pageInlineComments: ExtractedInli
 								whereToApplyComment.commentEnd,
 								child.text.length,
 							);
+							const marks = [...(child.marks ?? [])];
+							if (
+								!marks.some(
+									(mark) =>
+										mark.type === "annotation" &&
+										mark.attrs?.["annotationType"] === "inlineComment" &&
+										mark.attrs?.["id"] === comment.inlineCommentId,
+								)
+							) {
+								marks.push({
+									type: "annotation",
+									attrs: {
+										annotationType: "inlineComment",
+										id: comment.inlineCommentId,
+									},
+								});
+							}
 
 							if (beforeText) {
 								newContent.push({
@@ -184,16 +201,7 @@ function applyInlineComments(adf: JSONDocNode, pageInlineComments: ExtractedInli
 								...(comment.textForComment
 									? { text: comment.textForComment }
 									: undefined),
-								marks: [
-									...(child.marks ? child.marks : []),
-									{
-										type: "annotation",
-										attrs: {
-											annotationType: "inlineComment",
-											id: comment.inlineCommentId,
-										},
-									},
-								],
+								marks,
 							});
 
 							if (afterText)
@@ -517,7 +525,7 @@ function extractInlineComments(adf: JSONDocNode) {
 						mark.attrs?.["annotationType"] === "inlineComment",
 				)
 			) {
-				const inlineCommentMark = node.marks?.find(
+				const inlineCommentMarks = node.marks.filter(
 					(mark) =>
 						mark.type === "annotation" &&
 						mark.attrs?.["annotationType"] === "inlineComment",
@@ -541,15 +549,15 @@ function extractInlineComments(adf: JSONDocNode) {
 					return prev + curr?.text;
 				}, "");
 
-				const extract: ExtractedInlineComment = {
-					pluginInternalId: uuidv4(),
-					inlineCommentId: inlineCommentMark?.attrs?.["id"],
-					textForComment: node.text,
-					beforeText,
-					afterText,
-				};
-
-				result.push(extract);
+				for (const mark of inlineCommentMarks) {
+					result.push({
+						pluginInternalId: uuidv4(),
+						inlineCommentId: mark.attrs?.["id"],
+						textForComment: node.text,
+						beforeText,
+						afterText,
+					});
+				}
 			}
 		},
 	});
@@ -763,42 +771,17 @@ function mergeTextNodes(adf: JSONDocNode) {
 				return node;
 			}
 			const processedContent: Array<ADFEntity | undefined> = [];
-			const indexToSkip: number[] = [];
-			const nodesToCheck = node.content.length ?? 0;
-			for (let index = 0; index < nodesToCheck; index++) {
-				if (indexToSkip.includes(index)) {
-					continue;
-				}
-
-				const currentNode = node.content[index];
-				const nextNode = node.content[index + 1];
-
+			for (const currentNode of node.content) {
+				const previousNode = processedContent.at(-1);
 				if (
-					nextNode === undefined ||
-					currentNode === undefined ||
-					currentNode.type !== "text" ||
-					nextNode.type !== "text"
+					previousNode?.type === "text" &&
+					currentNode?.type === "text" &&
+					marksEqual(previousNode.marks, currentNode.marks)
 				) {
+					previousNode.text = (previousNode.text ?? "") + (currentNode.text ?? "");
+				} else {
 					processedContent.push(currentNode);
-					continue;
 				}
-
-				for (
-					let lookAheadIndex = index + 1;
-					lookAheadIndex < nodesToCheck;
-					lookAheadIndex++
-				) {
-					const futureNode = node.content[lookAheadIndex];
-
-					if (marksEqual(currentNode?.marks, futureNode?.marks)) {
-						currentNode.text = (currentNode.text ?? "") + (futureNode?.text ?? "");
-						indexToSkip.push(lookAheadIndex);
-					} else {
-						break;
-					}
-				}
-
-				processedContent.push(currentNode);
 			}
 
 			if (processedContent.length > 0) {

--- a/packages/lib/src/AuthenticatedConfluenceClient.ts
+++ b/packages/lib/src/AuthenticatedConfluenceClient.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { createV1Client } from "confluence.js";
+import type { Client } from "confluence.js/core";
 import type { ConfluenceFetch } from "./ConfluenceFetch";
 import { ConfluenceSettings } from "./Settings";
 import { RequiredConfluenceClient } from "./ConfluenceClient";
@@ -7,6 +8,7 @@ import { createConfluenceClientConfig } from "./ConfluenceClientConfig";
 import { createConfluenceTransport } from "./ConfluenceTransport";
 import { ConfluenceV2Client } from "./ConfluenceV2Client";
 import { fetchOAuthAccessToken } from "./OAuthToken";
+import { cancellableClient, registerPublishCancellation } from "./PublishCancellation";
 
 /** All Cloud authentication modes use the same v2 publishing operations and transport. */
 export function createAuthenticatedConfluenceClient(
@@ -41,9 +43,15 @@ export function createAuthenticatedConfluenceClient(
 			atlassianApiToken: accessToken,
 		});
 		const transport = createConfluenceTransport(config, options.fetch);
-		const v1 = createV1Client(transport);
-		const content = new ConfluenceV2Client(settings.confluenceBaseUrl, transport);
-		return {
+		return assembleAuthenticatedClient(settings.confluenceBaseUrl, transport);
+	});
+}
+
+function assembleAuthenticatedClient(baseUrl: string, transport: Client): RequiredConfluenceClient {
+	const v1 = createV1Client(transport);
+	const content = new ConfluenceV2Client(baseUrl, transport);
+	return registerPublishCancellation<RequiredConfluenceClient>(
+		{
 			...transport,
 			content,
 			contentAttachments: { getAttachments: content.getAttachments.bind(content) },
@@ -59,6 +67,7 @@ export function createAuthenticatedConfluenceClient(
 					return { ...user, accountId: user.accountId };
 				},
 			},
-		};
-	});
+		},
+		(signal) => assembleAuthenticatedClient(baseUrl, cancellableClient(transport, signal)),
+	);
 }

--- a/packages/lib/src/ConfluenceTransport.test.ts
+++ b/packages/lib/src/ConfluenceTransport.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from "@effect/vitest";
 import type { SendRequestOptions } from "confluence.js/core";
 import { createConfluenceTransport } from "./ConfluenceTransport";
+import { cancellableClient } from "./PublishCancellation";
 
 const config = {
 	host: "https://example.atlassian.net",
@@ -86,6 +87,35 @@ test("does not send an already aborted request", async () => {
 	);
 	expect(fetch).not.toHaveBeenCalled();
 });
+test.each(["network-read", "limited-read", "limited-write"])(
+	"publishing cancellation interrupts a %s retry wait without cancelling the dispatched request",
+	async (scenario) => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		const fetch = vi.fn(async () => {
+			if (scenario === "network-read")
+				throw Object.assign(new Error("disconnected"), { code: "ECONNRESET" });
+			return json({}, 429, "10");
+		});
+		const client = cancellableClient(
+			createConfluenceTransport(config, fetch),
+			controller.signal,
+		);
+		const result = client
+			.sendRequest({ ...options, method: scenario === "limited-write" ? "PUT" : "GET" })
+			.catch((error) => error);
+		await vi.advanceTimersByTimeAsync(0);
+		controller.abort();
+		expect((await result).message).toBe(
+			"Publishing cancelled. Completed writes have been kept.",
+		);
+		expect(fetch).toHaveBeenCalledOnce();
+		expect((fetch.mock.calls[0]![1] as RequestInit).signal?.aborted).toBe(false);
+		expect(vi.getTimerCount()).toBe(0);
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(fetch).toHaveBeenCalledOnce();
+	},
+);
 test.each(["multipart", "long-delay", "forbidden"])(
 	"does not retry %s responses unsafely",
 	async (scenario) => {

--- a/packages/lib/src/ConfluenceTransport.ts
+++ b/packages/lib/src/ConfluenceTransport.ts
@@ -1,6 +1,11 @@
 import { Buffer } from "node:buffer";
 import type { Client, ClientConfig, SendRequestOptions } from "confluence.js/core";
 import type { ConfluenceFetch } from "./ConfluenceFetch";
+import {
+	assertPublishingActive,
+	PublishCancelledError,
+	registerPublishCancellation,
+} from "./PublishCancellation";
 
 /** Errors expose status and response data, never credentials or request configuration. */
 export class ConfluenceRequestError extends Error {
@@ -16,6 +21,7 @@ export class ConfluenceRequestError extends Error {
 export function createConfluenceTransport(
 	config: ClientConfig,
 	fetchRequest: ConfluenceFetch = (url, init) => fetch(url, init),
+	publishSignal?: AbortSignal,
 ): Client {
 	const host = new URL((config.host ?? "").replace(/\/$/, "") + "/");
 	if (host.protocol !== "https:" || host.username || host.password || host.search || host.hash)
@@ -31,7 +37,7 @@ export function createConfluenceTransport(
 				: undefined;
 	if (!authorization)
 		throw new Error("Resolve Confluence credentials before creating the transport");
-	return {
+	const transport: Client = {
 		async sendRequest<T>(options: SendRequestOptions<T>): Promise<T> {
 			// Endpoint paths come from the SDK or a validated pagination link, never another host.
 			if (!options.url.startsWith("/wiki/") || options.url.includes("\\"))
@@ -61,8 +67,11 @@ export function createConfluenceTransport(
 			if (multipart) headers.delete("Content-Type");
 			else if (body !== undefined) headers.set("Content-Type", "application/json");
 			const signal = AbortSignal.timeout(30_000);
+			// Cancellation stops subsequent requests, but never aborts an in-flight write.
+			const retrySignal = publishSignal ? AbortSignal.any([signal, publishSignal]) : signal;
 			const read = method === "GET" || method === "HEAD";
 			for (let attempt = 0; ; attempt++) {
+				assertPublishingActive(publishSignal);
 				if (signal.aborted) throw new Error("Confluence request aborted");
 				let response: Awaited<ReturnType<ConfluenceFetch>>;
 				try {
@@ -89,7 +98,7 @@ export function createConfluenceTransport(
 							"UND_ERR_CONNECT_TIMEOUT",
 						].includes(code)
 					) {
-						await waitForRetry(250 * 2 ** attempt, signal);
+						await waitForRetry(250 * 2 ** attempt, retrySignal, publishSignal);
 						continue;
 					}
 					throw new ConfluenceRequestError(
@@ -104,7 +113,7 @@ export function createConfluenceTransport(
 						attempt,
 					);
 					if (delay !== undefined) {
-						await waitForRetry(delay, signal);
+						await waitForRetry(delay, retrySignal, publishSignal);
 						continue;
 					}
 				}
@@ -137,6 +146,13 @@ export function createConfluenceTransport(
 			}
 		},
 	};
+	return registerPublishCancellation(transport, (signal) =>
+		createConfluenceTransport(
+			config,
+			fetchRequest,
+			publishSignal ? AbortSignal.any([publishSignal, signal]) : signal,
+		),
+	);
 }
 
 function networkErrorCode(error: unknown): string {
@@ -155,12 +171,20 @@ function rateLimitDelay(value: string | undefined, attempt: number): number | un
 				: Date.parse(value) - Date.now();
 	return Number.isFinite(delay) && delay <= 30_000 ? Math.max(0, delay) : undefined;
 }
-function waitForRetry(delay: number, signal: AbortSignal): Promise<void> {
+function waitForRetry(
+	delay: number,
+	signal: AbortSignal,
+	publishSignal?: AbortSignal,
+): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const abort = () => {
 			clearTimeout(timer);
 			signal.removeEventListener("abort", abort);
-			reject(new Error("Confluence request aborted"));
+			reject(
+				publishSignal?.aborted
+					? new PublishCancelledError()
+					: new Error("Confluence request aborted"),
+			);
 		};
 		const timer = setTimeout(() => {
 			signal.removeEventListener("abort", abort);

--- a/packages/lib/src/ConfluenceV2Client.ts
+++ b/packages/lib/src/ConfluenceV2Client.ts
@@ -1,6 +1,11 @@
 import { createV2Client } from "confluence.js";
 import type { Client } from "confluence.js/core";
 import type { ConfluenceFetch } from "./ConfluenceFetch";
+import {
+	cancellableClient,
+	PublishCancelledError,
+	registerPublishCancellation,
+} from "./PublishCancellation";
 import type {
 	ConfluenceContent,
 	ContentArray,
@@ -36,6 +41,14 @@ class SpaceKeyCache {
 	record(key: string, id: string): void {
 		this.keyToId.set(key, id);
 		this.idToKey.set(id, key);
+	}
+
+	copyFrom(source: SpaceKeyCache): void {
+		for (const [key, id] of source.keyToId) this.record(key, id);
+	}
+
+	keyForId(id: string): string | undefined {
+		return this.idToKey.get(id);
 	}
 
 	async resolveKeyToId(key: string): Promise<string> {
@@ -82,6 +95,7 @@ export class ConfluenceV2Client {
 	private readonly sdk: ReturnType<typeof createV2Client>;
 	private readonly apiRoot: URL;
 	private readonly contentTypes = new Map<string, "page" | "blogpost">();
+	private readonly contentSpaces = new Map<string, string>();
 
 	constructor(
 		baseUrl: string,
@@ -106,6 +120,16 @@ export class ConfluenceV2Client {
 					);
 		this.sdk = createV2Client(this.transport);
 		this.spaces = new SpaceKeyCache(this.sdk);
+		registerPublishCancellation(this, (signal) => {
+			const scoped = new ConfluenceV2Client(
+				baseUrl,
+				cancellableClient(this.transport, signal),
+			);
+			scoped.spaces.copyFrom(this.spaces);
+			for (const [id, type] of this.contentTypes) scoped.contentTypes.set(id, type);
+			for (const [id, key] of this.contentSpaces) scoped.contentSpaces.set(id, key);
+			return scoped;
+		});
 	}
 
 	private nextPath(currentPath: string, next: string): string {
@@ -266,6 +290,10 @@ export class ConfluenceV2Client {
 	): Promise<T> {
 		void callback;
 		const contentType = parameters.type === "blogpost" ? "blogpost" : "page";
+		// Resolve response metadata before writing so a completed PUT needs no follow-up
+		// request and can still be returned successfully if publishing is cancelled.
+		if (!this.spaces.keyForId(this.contentSpaces.get(parameters.id) ?? ""))
+			await this.getContentById({ id: parameters.id });
 
 		const parentId = parameters.ancestors?.at(-1)?.id;
 		const requestBody: V2UpdatePageBody = {
@@ -289,7 +317,16 @@ export class ConfluenceV2Client {
 				: this.sdk.page.updatePage({ id: sdkId(parameters.id), body: requestBody })),
 		);
 
-		const spaceKey = await this.spaces.resolveIdToKey(page.spaceId);
+		let spaceKey = this.spaces.keyForId(page.spaceId);
+		if (!spaceKey) {
+			try {
+				spaceKey = await this.spaces.resolveIdToKey(page.spaceId);
+			} catch (error) {
+				// A move can return a previously unknown space. Keep the completed write
+				// successful if cancellation prevents resolving that optional metadata.
+				if (!(error instanceof PublishCancelledError)) throw error;
+			}
+		}
 		const content = await this.adaptPage(page, spaceKey, false, contentType);
 		return content as T;
 	}
@@ -386,11 +423,12 @@ export class ConfluenceV2Client {
 	/** Adapts a v2 page or blog post to the publisher's `ConfluenceContent` model. */
 	private async adaptPage(
 		page: V2Page,
-		spaceKey: string,
+		spaceKey: string | undefined,
 		includeAncestors: boolean,
 		contentType: "page" | "blogpost",
 	): Promise<ConfluenceContent> {
 		this.contentTypes.set(page.id, contentType);
+		this.contentSpaces.set(page.id, page.spaceId);
 		const ancestors =
 			includeAncestors && contentType === "page" ? await this.fetchAncestors(page) : [];
 		const adfValue = page.body?.atlas_doc_format?.value;
@@ -400,7 +438,7 @@ export class ConfluenceV2Client {
 			type: contentType,
 			status: page.status,
 			title: page.title,
-			space: { key: spaceKey },
+			...(spaceKey ? { space: { key: spaceKey } } : {}),
 			version: {
 				number: page.version?.number ?? 1,
 				by: { accountId: page.version?.authorId ?? "" },

--- a/packages/lib/src/MarkdownWorkspace.test.ts
+++ b/packages/lib/src/MarkdownWorkspace.test.ts
@@ -250,6 +250,46 @@ const testSettings: ConfluenceSettings = {
 	forceOverwrite: false,
 };
 
+test.each([
+	{ folderToPublish: ".", tagsToPublish: "" },
+	{ folderToPublish: "Elsewhere", tagsToPublish: "public" },
+])("persists explicit opt-outs for selection by %j", async (selection) => {
+	const filePath = await runEffect(
+		Effect.gen(function* () {
+			const fs = yield* FileSystem;
+			const path = yield* Path;
+			tmpRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-opt-out-" });
+			const filePath = path.join(tmpRoot, "page.md");
+			yield* fs.writeFileString(
+				filePath,
+				"---\ntags: [public]\nconnie-publish: true\nconnie-dont-change-parent-page: true\nconnie-page-id: old\ncustom: retained\n---\n# Page\n",
+			);
+			return filePath;
+		}),
+	);
+	const settings = { ...testSettings, ...selection, contentRoot: tmpRoot! };
+	const workspace = await loadMarkdownWorkspace(settings);
+	await Effect.runPromise(
+		workspace.updateMarkdownValues(filePath, {
+			publish: false,
+			dontChangeParentPageId: false,
+			pageId: undefined,
+		}),
+	);
+	const reloaded = await loadMarkdownWorkspace(settings);
+	const file = await Effect.runPromise(reloaded.loadMarkdownFile(filePath));
+	expect(file.frontmatter).toMatchObject({
+		"connie-publish": false,
+		"connie-dont-change-parent-page": false,
+		custom: "retained",
+	});
+	expect(file.frontmatter).not.toHaveProperty("connie-page-id");
+	expect(file.contents).toContain("# Page");
+	expect(await Effect.runPromise(reloaded.getMarkdownFilesToUpload)).toEqual([]);
+	await Effect.runPromise(reloaded.updateMarkdownValues(filePath, { publish: undefined }));
+	expect(await Effect.runPromise(reloaded.getMarkdownFilesToUpload)).toHaveLength(1);
+});
+
 async function transformedWorkspace(
 	files: Record<string, string>,
 	transformer: MarkdownSourceTransformer,

--- a/packages/lib/src/MarkdownWorkspace.ts
+++ b/packages/lib/src/MarkdownWorkspace.ts
@@ -143,7 +143,7 @@ export function makeMarkdownWorkspaceEffect(
 					const { key } = config[propertyKey as keyof ConfluencePerPageConfig];
 					const value = values[propertyKey as keyof ConfluencePerPageAllValues];
 					if (propertyKey in values) {
-						if (value) {
+						if (value !== undefined) {
 							fm[key] = value;
 						} else if (key in fileContent.data) {
 							delete fileContent.data[key];

--- a/packages/lib/src/MdToADF.test.ts
+++ b/packages/lib/src/MdToADF.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { expect, test } from "@effect/vitest";
 import { MarkdownFile } from "./MarkdownWorkspace";
-import { convertMDtoADF, parseMarkdownToADF } from "./MdToADF";
+import { convertMDtoADF, parseMarkdownToADF, stripMarkdownHtmlComments } from "./MdToADF";
 import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
 
 const markdownTestCases: MarkdownFile[] = [
@@ -819,3 +819,115 @@ for (const image of ["![](image.png)", "![[image.png]]"]) {
 		}
 	}
 }
+
+test.each([
+	["indented body", "<!--\n    hidden\n-->\nvisible", "\n\n\nvisible"],
+	["indented closing marker", "<!--\n    hidden -->\nvisible", "\n\nvisible"],
+	["tab-indented body", "<!--\n\thidden\n\t-->\nvisible", "\n\n\nvisible"],
+	["fenced body", "<!--\n```md\nhidden\n```\n-->\nvisible", "\n\n\n\n\nvisible"],
+	["unclosed fence in body", "<!--\n```md\nhidden\n-->\nvisible", "\n\n\n\nvisible"],
+	["tilde-fenced body", "<!--\n~~~md\nhidden\n~~~\n-->\nvisible", "\n\n\n\n\nvisible"],
+	["blank lines", "<!--\n\n    hidden\n\n-->\nvisible", "\n\n\n\n\nvisible"],
+	["unclosed comment", "visible\n<!--\n    hidden\n```", "visible\n\n\n"],
+	["inline comment", "visible <!-- hidden --> after", "visible  after"],
+	["CRLF comment", "<!--\r\n    hidden\r\n-->\r\nvisible", "\r\n\r\n\r\nvisible"],
+	["paragraph continuation", "visible\n    <!-- hidden -->", "visible\n    "],
+	["inline code cannot cross blocks", "visible `\n\n<!-- hidden -->\n\n`", "visible `\n\n\n\n`"],
+	["blockquote comment", "> <!--\n>     hidden\n> -->\n\nvisible", "> \n\n\n\nvisible"],
+	["list comment", "- <!--\n      hidden\n  -->\n\nvisible", "- \n\n\n\nvisible"],
+])("does not publish an HTML comment with %s", (_description, markdown, expected) => {
+	expect(stripMarkdownHtmlComments(markdown)).toBe(expected);
+	const serialized = JSON.stringify(parseMarkdownToADF(markdown, "https://example.com"));
+	expect(serialized).not.toContain("hidden");
+	expect(serialized).toContain("visible");
+});
+
+test.each([
+	["inline code", "`<!-- literal -->`"],
+	["escaped first backtick", "\\``<!-- literal -->`"],
+	["escaped first backtick in longer run", "\\```<!-- literal -->``"],
+	["multiline inline code", "`before\n<!-- literal -->\nafter`"],
+	["multiple backticks", "`` before ` <!-- literal --> after ``"],
+	["different backtick runs", "`` before ``` <!-- literal --> after ``"],
+	["indented code", "    <!-- literal -->"],
+	["tab-indented code", "\t<!-- literal -->"],
+	["fenced code", "```html\n<!-- literal -->\n```"],
+	["tilde-fenced code", "~~~html\n<!-- literal -->\n~~~"],
+	["unclosed fenced code", "```html\n<!-- literal -->"],
+	["fence close with non-whitespace", "```html\n```not-closing\n<!-- literal -->\n```"],
+	["shorter closing fence", "````html\n```\n<!-- literal -->\n````"],
+	["tilde fence close with non-whitespace", "~~~html\n~~~not-closing\n<!-- literal -->\n~~~"],
+	["indented closing fence", "```html\n    ```\n<!-- literal -->\n```"],
+	["blockquote fenced code", "> ```html\n> <!-- literal -->\n> ```"],
+	["list fenced code", "- ```html\n  <!-- literal -->\n  ```"],
+	["blockquote indented code", ">     <!-- literal -->"],
+	["list indented code", "- item\n\n      <!-- literal -->"],
+	["fence following ordinary HTML", "<div>\n```html\n<!-- literal -->\n```"],
+	["escaped delimiter", "\\<!-- literal -->"],
+])("preserves comment-looking text in %s", (_description, markdown) => {
+	expect(stripMarkdownHtmlComments(markdown)).toBe(markdown);
+	const serialized = JSON.stringify(parseMarkdownToADF(markdown, "https://example.com"));
+	expect(serialized).toContain("<!-- literal -->");
+});
+
+test("resumes comment removal after a valid longer fence close", () => {
+	const markdown = "```html\n<!-- literal -->\n```` \t\n<!-- hidden -->\nvisible";
+	expect(stripMarkdownHtmlComments(markdown)).toBe(
+		"```html\n<!-- literal -->\n```` \t\n\nvisible",
+	);
+	const serialized = JSON.stringify(parseMarkdownToADF(markdown, "https://example.com"));
+	expect(serialized).toContain("<!-- literal -->");
+	expect(serialized).toContain("visible");
+	expect(serialized).not.toContain("hidden");
+});
+
+test.each([
+	["different table rows", "| ` | text |\n| <!-- hidden --> | ` |"],
+	["different table cells", "| `` | <!-- hidden --> `` |"],
+	["code fence in another cell", "| ``` | <!-- hidden --> |"],
+])("comment protection does not join code across %s", (_description, rows) => {
+	const markdown = `| a | b |\n| - | - |\n${rows}\n\nvisible`;
+	expect(stripMarkdownHtmlComments(markdown)).not.toContain("hidden");
+	const serialized = JSON.stringify(parseMarkdownToADF(markdown, "https://example.com"));
+	expect(serialized).not.toContain("hidden");
+	expect(serialized).toContain("visible");
+});
+
+test.each([
+	"| `<!-- literal -->` | text |",
+	"| ` | <!-- literal --> ` |",
+	"| text | ``<!-- literal -->`` |",
+	"| <!-- removed --> | `<!-- literal -->` |",
+])("preserves real inline code within a table row %s", (row) => {
+	const markdown = `| a | b |\n| - | - |\n${row}`;
+	const stripped = stripMarkdownHtmlComments(markdown);
+	expect(stripped).toContain("<!-- literal -->");
+	expect(stripped).not.toContain("removed");
+	const serialized = JSON.stringify(parseMarkdownToADF(markdown, "https://example.com"));
+	expect(serialized).toContain("<!-- literal -->");
+	expect(serialized).not.toContain("removed");
+});
+
+test.each(["\r", "\r\n", "\n"])(
+	"retains source line endings %j while removing comments after fences",
+	(newline) => {
+		const prefix = ["```html", "<!-- literal -->", "```", ""].join(newline);
+		const markdown = `${prefix}<!-- hidden -->${newline}visible`;
+		expect(stripMarkdownHtmlComments(markdown)).toBe(`${prefix}${newline}visible`);
+		const serialized = JSON.stringify(parseMarkdownToADF(markdown, "https://example.com"));
+		expect(serialized).toContain("<!-- literal -->");
+		expect(serialized).not.toContain("hidden");
+		expect(serialized).toContain("visible");
+	},
+);
+
+test("maps mixed source line endings after a fenced block", () => {
+	const markdown = "```html\r\n<!-- literal -->\r```\n<!-- hidden -->\r\nvisible";
+	expect(stripMarkdownHtmlComments(markdown)).toBe(
+		"```html\r\n<!-- literal -->\r```\n\r\nvisible",
+	);
+	const serialized = JSON.stringify(parseMarkdownToADF(markdown, "https://example.com"));
+	expect(serialized).toContain("<!-- literal -->");
+	expect(serialized).not.toContain("hidden");
+	expect(serialized).toContain("visible");
+});

--- a/packages/lib/src/MdToADF.ts
+++ b/packages/lib/src/MdToADF.ts
@@ -11,6 +11,8 @@ import { isSafeUrl } from "@atlaskit/adf-schema";
 import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
 import { cleanUpUrlIfConfluence } from "./ConfluenceUrlParser";
 import SparkMD5 from "spark-md5";
+import MarkdownIt from "markdown-it";
+import { markdownItTable } from "markdown-it-table";
 
 const frontmatterRegex = /^\s*?---\n([\s\S]*?)\n---\s*/g;
 
@@ -32,89 +34,116 @@ type TaskListCounters = {
 };
 type PageFragment = "header" | "body" | "footer";
 
+// Use the same CommonMark block grammar as MarkdownTransformer, enabling only
+// HTML comments. Other HTML remains ordinary Markdown in the converter.
+const commentParser = new MarkdownIt("commonmark", { html: true });
+commentParser.use(markdownItTable);
+const htmlBlockParser = new MarkdownIt("commonmark", { html: true });
+htmlBlockParser.block.ruler.enableOnly("html_block");
+const htmlBlockRule = htmlBlockParser.block.ruler.getRules("")[0]!;
+commentParser.block.ruler.at(
+	"html_block",
+	(state, startLine, endLine, silent) =>
+		state.src.startsWith("<!--", state.bMarks[startLine]! + state.tShift[startLine]!) &&
+		htmlBlockRule(state, startLine, endLine, silent),
+	// HTML must not interrupt paragraphs: the converter allows multiline code
+	// spans containing a line that starts with a comment delimiter.
+	{ alt: ["reference", "blockquote"] },
+);
+
 export function stripMarkdownHtmlComments(markdown: string): string {
-	const lines = markdown.split("\n");
-	const strippedLines: string[] = [];
-	let inComment = false;
-	let fenceMarker: string | undefined;
+	if (!markdown.includes("<!--")) return markdown;
 
-	for (const line of lines) {
-		const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
-		if (fenceMarker) {
-			strippedLines.push(line);
-			if (
-				fenceMatch &&
-				fenceMatch[1]?.startsWith(fenceMarker.charAt(0)) &&
-				fenceMatch[1].length >= fenceMarker.length
-			) {
-				fenceMarker = undefined;
-			}
-			continue;
-		}
-
-		if (fenceMatch) {
-			fenceMarker = fenceMatch[1];
-			strippedLines.push(line);
-			continue;
-		}
-
-		if (/^( {4,}|\t)/.test(line)) {
-			strippedLines.push(line);
-			continue;
-		}
-
-		let strippedLine = "";
-		let position = 0;
-
-		while (position < line.length) {
-			if (inComment) {
-				const commentEnd = line.indexOf("-->", position);
-				if (commentEnd === -1) {
-					position = line.length;
-				} else {
-					inComment = false;
-					position = commentEnd + 3;
-				}
-				continue;
-			}
-
-			if (line.startsWith("<!--", position)) {
-				inComment = true;
-				position += 4;
-				continue;
-			}
-
-			if (line[position] === "`") {
-				const runEnd = position + countBacktickRun(line, position);
-				const backtickRun = line.slice(position, runEnd);
-				const closingRun = line.indexOf(backtickRun, runEnd);
-
-				if (closingRun === -1) {
-					strippedLine += backtickRun;
-					position = runEnd;
-				} else {
-					strippedLine += line.slice(position, closingRun + backtickRun.length);
-					position = closingRun + backtickRun.length;
-				}
-				continue;
-			}
-
-			strippedLine += line[position];
-			position++;
-		}
-
-		strippedLines.push(strippedLine);
+	const ranges = commentCodeRanges(markdown);
+	const markers = [...markdown.matchAll(/`+|<!--/g)];
+	const nextBackticks = new Map<number, number>();
+	const closingBackticks = new Map<number, number>();
+	for (let index = markers.length - 1; index >= 0; index--) {
+		const marker = markers[index]![0];
+		if (marker === "<!--") continue;
+		// A backslash escapes only the first backtick in a run when opening a
+		// span. Within code, the complete raw run still acts as a closer.
+		const openingLength =
+			marker.length - Number(isMarkdownCharacterEscaped(markdown, markers[index]!.index));
+		const closing = nextBackticks.get(openingLength);
+		if (closing !== undefined) closingBackticks.set(index, closing);
+		nextBackticks.set(marker.length, index);
 	}
 
-	return strippedLines.join("\n");
+	const output: string[] = [];
+	let retainedFrom = 0;
+	let rangeIndex = 0;
+	for (let index = 0; index < markers.length; index++) {
+		const marker = markers[index]!;
+		const start = marker.index;
+		if (start < retainedFrom) continue;
+		while (ranges[rangeIndex] && ranges[rangeIndex]!.end <= start) rangeIndex++;
+		const range = ranges[rangeIndex];
+		const inRange = range && range.start <= start;
+		if (inRange && range.type !== "inline") continue;
+		if (
+			isMarkdownCharacterEscaped(markdown, start) &&
+			(marker[0] === "<!--" || marker[0].length === 1)
+		)
+			continue;
+
+		if (marker[0] === "<!--") {
+			const closing = markdown.indexOf("-->", start + 4);
+			const end = closing === -1 ? markdown.length : closing + 3;
+			output.push(markdown.slice(retainedFrom, start));
+			// Retain line boundaries so removing a comment cannot join separate blocks.
+			output.push(markdown.slice(start, end).replace(/[^\r\n]/g, ""));
+			retainedFrom = end;
+		} else {
+			const closing = closingBackticks.get(index);
+			if (inRange && closing !== undefined && markers[closing]!.index < range.end)
+				index = closing;
+		}
+	}
+	output.push(markdown.slice(retainedFrom));
+	return output.join("");
 }
 
-function countBacktickRun(line: string, position: number): number {
-	let count = 0;
-	while (line[position + count] === "`") {
-		count++;
+function commentCodeRanges(markdown: string) {
+	// MarkdownIt treats CR, CRLF, and LF as line endings. Keep offsets into the
+	// original source so stripping comments preserves the user's line endings.
+	const offsets = [0];
+	for (const newline of markdown.matchAll(/\r\n|\r|\n/g))
+		offsets.push(newline.index + newline[0].length);
+	offsets.push(markdown.length);
+	const ranges: { start: number; end: number; type: string }[] = [];
+	const cellEnds = new Map<number, number>();
+	let tableDepth = 0;
+	for (const token of commentParser.parse(markdown, {})) {
+		if (token.type === "table_open") tableDepth++;
+		if (token.type === "table_close") tableDepth--;
+		if (!token.map) continue;
+		let start = offsets[token.map[0]]!;
+		let end = offsets[token.map[1]]!;
+		if (tableDepth > 0 && token.map[1] === token.map[0] + 1 && token.content) {
+			// Table tokens share line maps, but each cell is parsed independently.
+			// Locate their source content in order, including HTML cells that do not
+			// produce code ranges, so repeated text cannot point into an earlier cell.
+			const content = token.content.replace(/\n$/, "");
+			const cellStart = cellEnds.get(token.map[0]) ?? start;
+			const contentOffset = markdown.slice(cellStart, end).indexOf(content);
+			if (contentOffset < 0) continue;
+			start = cellStart + contentOffset;
+			end = start + content.length;
+			cellEnds.set(token.map[0], end);
+		} else if (tableDepth > 0) {
+			continue;
+		}
+		if (["inline", "fence", "code_block"].includes(token.type))
+			ranges.push({ start, end, type: token.type });
 	}
-	return count;
+	return ranges;
+}
+
+function isMarkdownCharacterEscaped(markdown: string, position: number): boolean {
+	let backslashes = 0;
+	while (position > 0 && markdown[--position] === "\\") backslashes++;
+	return backslashes % 2 === 1;
 }
 
 export function parseMarkdownToADF(markdown: string, confluenceBaseUrl: string) {

--- a/packages/lib/src/PublishCancellation.test.ts
+++ b/packages/lib/src/PublishCancellation.test.ts
@@ -1,0 +1,202 @@
+import { expect, test, vi } from "@effect/vitest";
+import { Effect } from "effect";
+import { createAuthenticatedConfluenceClient } from "./AuthenticatedConfluenceClient";
+import { ConfluenceV2Client } from "./ConfluenceV2Client";
+import type { ConfluenceFetch } from "./ConfluenceFetch";
+import { cancellableClient } from "./PublishCancellation";
+import { DEFAULT_SETTINGS } from "./Settings";
+
+const baseUrl = "https://example.atlassian.net";
+const page = {
+	id: "123",
+	spaceId: "456",
+	title: "Page",
+	status: "current",
+	version: { number: 2 },
+};
+const update = { id: "123", title: "Page", version: { number: 2 } };
+const json = (body: unknown) => new Response(JSON.stringify(body));
+const authenticatedClient = (fetch: ConfluenceFetch) =>
+	Effect.runPromise(
+		createAuthenticatedConfluenceClient(
+			{
+				...DEFAULT_SETTINGS,
+				confluenceBaseUrl: baseUrl,
+				confluenceAuthType: "bearer",
+				atlassianApiToken: "test-token",
+			},
+			{ fetch },
+		),
+	);
+
+test.each(["authenticated", "standalone"])(
+	"%s client stops between a space lookup and page creation",
+	async (kind) => {
+		const controller = new AbortController();
+		const response = Promise.withResolvers<Response>();
+		const started = Promise.withResolvers<void>();
+		const fetch = vi.fn<ConfluenceFetch>(async () => {
+			started.resolve();
+			return response.promise;
+		});
+		const original =
+			kind === "authenticated"
+				? await authenticatedClient(fetch)
+				: {
+						content: new ConfluenceV2Client(baseUrl, "test-token", {}, fetch),
+					};
+		const client = cancellableClient(original, controller.signal);
+		const pending = client.content.createContent({ title: "Page", space: { key: "DOC" } });
+		await started.promise;
+		controller.abort();
+		response.resolve(json({ results: [{ id: "456", key: "DOC" }] }));
+		await expect(pending).rejects.toThrow("Publishing cancelled");
+		expect(fetch).toHaveBeenCalledOnce();
+		expect(fetch.mock.calls[0]?.[0]).toContain("/spaces?keys=DOC");
+	},
+);
+
+test("cancellation between an update's metadata lookup and PUT prevents the write", async () => {
+	const controller = new AbortController();
+	const lookup = Promise.withResolvers<Response>();
+	const started = Promise.withResolvers<void>();
+	const fetch = vi.fn<ConfluenceFetch>(async (url) => {
+		if (url.endsWith("/spaces/456")) {
+			started.resolve();
+			return lookup.promise;
+		}
+		return json(page);
+	});
+	const client = cancellableClient(await authenticatedClient(fetch), controller.signal);
+	const pending = client.content.updateContent(update);
+	await started.promise;
+	controller.abort();
+	lookup.resolve(json({ id: "456", key: "DOC" }));
+	await expect(pending).rejects.toThrow("Publishing cancelled");
+	expect(fetch.mock.calls.map(([, init]) => init.method)).toEqual(["GET", "GET"]);
+});
+
+test.each(["attachments", "labels"])(
+	"cancellation stops %s pagination before the next request",
+	async (kind) => {
+		const controller = new AbortController();
+		const response = Promise.withResolvers<Response>();
+		const started = Promise.withResolvers<void>();
+		const fetch = vi.fn<ConfluenceFetch>(async () => {
+			started.resolve();
+			return response.promise;
+		});
+		const client = cancellableClient(await authenticatedClient(fetch), controller.signal);
+		const pending =
+			kind === "attachments"
+				? client.contentAttachments.getAttachments({ id: "123" })
+				: client.contentLabels.getLabelsForContent({ id: "123" });
+		await started.promise;
+		controller.abort();
+		response.resolve(
+			json({ results: [], _links: { next: `/wiki/api/v2/pages/123/${kind}?cursor=next` } }),
+		);
+		await expect(pending).rejects.toThrow("Publishing cancelled");
+		expect(fetch).toHaveBeenCalledOnce();
+	},
+);
+
+test("a dispatched PUT finishes successfully and cancellation stays local to its publishing operation", async () => {
+	const controller = new AbortController();
+	const write = Promise.withResolvers<Response>();
+	const started = Promise.withResolvers<void>();
+	const fetch = vi.fn<ConfluenceFetch>(async (url, init) => {
+		if (init.method === "PUT") {
+			started.resolve();
+			return write.promise;
+		}
+		return json(url.endsWith("/spaces/456") ? { id: "456", key: "DOC" } : page);
+	});
+	const original = await authenticatedClient(fetch);
+	const client = cancellableClient(original, controller.signal);
+	const pending = client.content.updateContent(update);
+	await started.promise;
+	const writeSignal = fetch.mock.calls.at(-1)?.[1].signal;
+	controller.abort();
+	expect(writeSignal?.aborted).toBe(false);
+	write.resolve(json(page));
+	await expect(pending).resolves.toMatchObject({
+		id: "123",
+		space: { key: "DOC" },
+		version: { number: 2 },
+	});
+	expect(fetch).toHaveBeenCalledTimes(3);
+	await expect(client.content.updateContent(update)).rejects.toThrow("Publishing cancelled");
+	expect(fetch).toHaveBeenCalledTimes(3);
+	await expect(original.content.getContentById({ id: "123" })).resolves.toMatchObject({
+		id: "123",
+	});
+	const independent = cancellableClient(original, new AbortController().signal);
+	await expect(independent.content.getContentById({ id: "123" })).resolves.toMatchObject({
+		id: "123",
+	});
+});
+
+test("cancelled authenticated clients guard v1 label writes, users and direct transport requests", async () => {
+	const fetch = vi.fn<ConfluenceFetch>();
+	const client = cancellableClient(await authenticatedClient(fetch), AbortSignal.abort());
+	await expect(
+		client.contentLabels.addLabelsToContent({
+			id: "123",
+			body: [{ name: "new", prefix: "global" }],
+		}),
+	).rejects.toThrow("Publishing cancelled");
+	await expect(
+		client.contentLabels.removeLabelFromContentUsingQueryParameter({ id: "123", name: "old" }),
+	).rejects.toThrow("Publishing cancelled");
+	await expect(client.users.getCurrentUser()).rejects.toThrow("Publishing cancelled");
+	await expect(
+		client.sendRequest({
+			url: "/wiki/rest/api/content/123/child/attachment",
+			method: "PUT",
+			body: new FormData(),
+		}),
+	).rejects.toThrow("Publishing cancelled");
+	expect(fetch).not.toHaveBeenCalled();
+});
+
+test("a dispatched create finishes successfully when publishing is cancelled", async () => {
+	const controller = new AbortController();
+	const write = Promise.withResolvers<Response>();
+	const started = Promise.withResolvers<void>();
+	const fetch = vi.fn<ConfluenceFetch>(async (_url, init) => {
+		if (init.method === "POST") {
+			started.resolve();
+			return write.promise;
+		}
+		return json({ results: [{ id: "456", key: "DOC" }] });
+	});
+	const client = cancellableClient(await authenticatedClient(fetch), controller.signal);
+	const pending = client.content.createContent({ title: "Page", space: { key: "DOC" } });
+	await started.promise;
+	controller.abort();
+	expect(fetch.mock.calls.at(-1)?.[1].signal?.aborted).toBe(false);
+	write.resolve(json(page));
+	await expect(pending).resolves.toMatchObject({ id: "123", space: { key: "DOC" } });
+	expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test.each([false, true])(
+	"an update never reports the source space for an unexpected moved response (cancelled: %s)",
+	async (cancel) => {
+		const controller = new AbortController();
+		const fetch = vi.fn<ConfluenceFetch>(async (url, init) => {
+			if (init.method === "PUT") {
+				if (cancel) controller.abort();
+				return json({ ...page, spaceId: "789" });
+			}
+			if (url.endsWith("/spaces/789")) return json({ id: "789", key: "MOVED" });
+			return json(url.endsWith("/spaces/456") ? { id: "456", key: "DOC" } : page);
+		});
+		const client = cancellableClient(await authenticatedClient(fetch), controller.signal);
+		const result = await client.content.updateContent({ ...update, space: { key: "WRONG" } });
+		expect(result.id).toBe("123");
+		expect(result.space).toEqual(cancel ? undefined : { key: "MOVED" });
+		expect(fetch).toHaveBeenCalledTimes(cancel ? 3 : 4);
+	},
+);

--- a/packages/lib/src/PublishCancellation.ts
+++ b/packages/lib/src/PublishCancellation.ts
@@ -1,4 +1,27 @@
+const cancellationFactories = new WeakMap<object, (signal: AbortSignal) => object>();
+
+/** Register an isolated client factory so SDK closures use the operation's transport. */
+export function registerPublishCancellation<T extends object>(
+	client: T,
+	factory: (signal: AbortSignal) => T,
+): T {
+	cancellationFactories.set(client, factory);
+	return client;
+}
+
+export class PublishCancelledError extends Error {
+	constructor() {
+		super("Publishing cancelled. Completed writes have been kept.");
+		this.name = "PublishCancelledError";
+	}
+}
+
+export function assertPublishingActive(signal?: AbortSignal): void {
+	if (signal?.aborted) throw new PublishCancelledError();
+}
+
 /** Cooperative cancellation: finish the current request, then stop issuing requests.
+ * Repository clients copy their transport; custom clients retain a method-boundary guard.
  * Successful writes are not rolled back. Do not abort a write with an unknown outcome.
  */
 export function cancellableClient<T extends object>(client: T, signal: AbortSignal): T {
@@ -6,15 +29,18 @@ export function cancellableClient<T extends object>(client: T, signal: AbortSign
 	const wrap = (target: object): object => {
 		const cached = wrappers.get(target);
 		if (cached) return cached;
+		const factory = cancellationFactories.get(target);
+		if (factory) {
+			const scoped = factory(signal);
+			wrappers.set(target, scoped);
+			return scoped;
+		}
 		const proxy = new Proxy(target, {
 			get(object, key) {
 				const value = Reflect.get(object, key);
 				if (typeof value === "function")
 					return (...args: unknown[]) => {
-						if (signal.aborted)
-							throw new Error(
-								"Publishing cancelled. Completed writes have been kept.",
-							);
+						assertPublishingActive(signal);
 						return Reflect.apply(value, object, args);
 					};
 				return value && typeof value === "object" ? wrap(value) : value;

--- a/packages/lib/src/PublisherErrors.test.ts
+++ b/packages/lib/src/PublisherErrors.test.ts
@@ -1,4 +1,8 @@
-import { expect, test } from "@effect/vitest";
+import { expect, test, vi } from "@effect/vitest";
+import { Effect } from "effect";
+import { runEffect } from "./effects";
+import { MarkdownFile, MarkdownWorkspace, MarkdownWorkspaceService } from "./MarkdownWorkspace";
+import { validatePublishingFiles } from "./PublishingReport";
 import { RequiredConfluenceClient } from "./ConfluenceClient";
 import { Publisher } from "./Publisher";
 import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
@@ -43,3 +47,216 @@ const testSettings: ConfluenceSettings = {
 	firstHeadingPageTitle: false,
 	forceOverwrite: false,
 };
+
+test.each([
+	{ first: "/docs/one.md", second: "/docs/two.md", sameTitle: false },
+	{ first: "/docs/one.md", second: "/docs/two.md", sameTitle: true },
+	{ first: "/docs/one.md", second: "/docs/nested/two.md", sameTitle: false },
+])(
+	"rejects duplicate explicit page IDs before any writes: $second, same title $sameTitle",
+	async ({ first, second, sameTitle }) => {
+		const frontmatter = {
+			"connie-page-id": "2",
+			...(sameTitle ? { "connie-title": "Same Title" } : {}),
+		};
+		const files = [publishingFile(first, frontmatter), publishingFile(second, frontmatter)];
+		const validation = validatePublishingFiles(files, testSettings);
+		expect(validation.valid).toBe(false);
+		expect(validation.errors.join(" ")).toContain(first);
+		expect(validation.errors.join(" ")).toContain(second);
+		const fixture = publishingFixture(files);
+		await expect(fixture.publish()).rejects.toThrow('Confluence page ID "2"');
+		expect(fixture.createContent).not.toHaveBeenCalled();
+		expect(fixture.updateContent).not.toHaveBeenCalled();
+		expect(fixture.sendRequest).not.toHaveBeenCalled();
+		expect(fixture.metadata).not.toHaveBeenCalled();
+	},
+);
+
+test("rejects a title-resolved duplicate before creating an earlier missing page", async () => {
+	const fixture = publishingFixture([
+		publishingFile("/docs/new.md"),
+		publishingFile("/docs/renamed.md", { "connie-page-id": "2" }),
+		publishingFile("/docs/original.md"),
+	]);
+	fixture.getContent.mockImplementation(async ({ title }) => ({
+		results: title === "original" ? [remotePage("2", "original")] : [],
+	}));
+	await expect(fixture.publish()).rejects.toThrow(/page ID "2".*renamed.md.*original.md/);
+	expect(fixture.createContent).not.toHaveBeenCalled();
+	expect(fixture.updateContent).not.toHaveBeenCalled();
+	expect(fixture.sendRequest).not.toHaveBeenCalled();
+	expect(fixture.metadata).not.toHaveBeenCalled();
+});
+
+test.each(["README", "index", "docs"])(
+	"rejects a child targeting the configured parent of the %s root note",
+	async (rootName) => {
+		const fixture = publishingFixture([
+			publishingFile(`/docs/${rootName}.md`),
+			publishingFile("/docs/child.md", { "connie-page-id": testSettings.confluenceParentId }),
+		]);
+		await expect(fixture.publish()).rejects.toThrow(
+			`Confluence page ID "${testSettings.confluenceParentId}"`,
+		);
+		expect(fixture.createContent).not.toHaveBeenCalled();
+		expect(fixture.updateContent).not.toHaveBeenCalled();
+		expect(fixture.sendRequest).not.toHaveBeenCalled();
+		expect(fixture.metadata).not.toHaveBeenCalled();
+	},
+);
+
+test("rejects a stale ID recovering to another note's target without changing either note", async () => {
+	const fixture = publishingFixture([
+		publishingFile("/docs/one.md", { "connie-page-id": "2" }),
+		publishingFile("/docs/two.md", { "connie-page-id": "stale" }),
+	]);
+	fixture.getContentById.mockImplementation(async ({ id }) => {
+		if (id === "stale")
+			throw Object.assign(new Error("Not found"), { response: { status: 404 } });
+		return remotePage(id);
+	});
+	fixture.getContent.mockResolvedValue({ results: [remotePage("2", "two")] });
+	await expect(fixture.publish()).rejects.toThrow('Confluence page ID "2"');
+	expect(fixture.createContent).not.toHaveBeenCalled();
+	expect(fixture.updateContent).not.toHaveBeenCalled();
+	expect(fixture.sendRequest).not.toHaveBeenCalled();
+	expect(fixture.metadata).not.toHaveBeenCalled();
+});
+
+test("validates newly created target IDs before metadata, attachments, or content writes", async () => {
+	const fixture = publishingFixture([
+		publishingFile("/docs/new.md"),
+		publishingFile("/docs/existing.md", { "connie-page-id": "2" }),
+	]);
+	fixture.createContent.mockResolvedValue(remotePage("2", "new"));
+	await expect(fixture.publish()).rejects.toThrow('Confluence page ID "2"');
+	expect(fixture.createContent).toHaveBeenCalledTimes(1);
+	expect(fixture.updateContent).not.toHaveBeenCalled();
+	expect(fixture.sendRequest).not.toHaveBeenCalled();
+	expect(fixture.metadata).not.toHaveBeenCalled();
+});
+
+test.each(["lookup", "create"])(
+	"preserves stale metadata and publication intent when replacement %s fails",
+	async (failureStage) => {
+		const files = [
+			publishingFile("/docs/one.md", {
+				"connie-publish": true,
+				"connie-page-id": "stale",
+				"connie-page-url": "https://example.atlassian.net/wiki/spaces/SPACE/pages/stale/",
+			}),
+		];
+		const originalFiles = structuredClone(files);
+		const fixture = publishingFixture(files);
+		fixture.getContentById.mockImplementation(async ({ id }) => {
+			if (id === "stale")
+				throw Object.assign(new Error("Not found"), { response: { status: 404 } });
+			return remotePage(id);
+		});
+		if (failureStage === "lookup")
+			fixture.getContent.mockRejectedValue(new Error("Lookup failed"));
+		else fixture.createContent.mockRejectedValue(new Error("Create failed"));
+		await expect(fixture.publish()).rejects.toThrow(/failed/);
+		expect(fixture.metadata).not.toHaveBeenCalled();
+		expect(files).toEqual(originalFiles);
+		// A second attempt still receives the original opt-in and target, with only a final update.
+		fixture.getContent.mockResolvedValue({ results: [remotePage("3", "one")] });
+		const results = await fixture.publish();
+		expect(results[0]?.successfulUploadResult).toBeDefined();
+		expect(fixture.metadata).toHaveBeenCalledExactlyOnceWith("/docs/one.md", {
+			publish: true,
+			pageId: "3",
+			pageUrl: "https://example.atlassian.net/wiki/spaces/SPACE/pages/3/",
+		});
+	},
+);
+
+test("a metadata write failure does not trigger stale-ID recovery or clear publication intent", async () => {
+	const fixture = publishingFixture([
+		publishingFile("/docs/one.md", { "connie-page-id": "2", "connie-publish": true }),
+	]);
+	fixture.metadata.mockImplementation(() => {
+		throw Object.assign(new Error("Metadata unavailable"), { response: { status: 404 } });
+	});
+	await expect(fixture.publish()).rejects.toThrow("Metadata unavailable");
+	expect(fixture.getContent).not.toHaveBeenCalled();
+	expect(fixture.createContent).not.toHaveBeenCalled();
+	expect(fixture.metadata).toHaveBeenCalledTimes(1);
+	expect(fixture.metadata.mock.calls[0]?.[1]).toMatchObject({ publish: true, pageId: "2" });
+});
+
+function publishingFile(source: string, frontmatter: Record<string, unknown> = {}): MarkdownFile {
+	const fileName = source.split("/").at(-1)!;
+	return {
+		folderName: "docs",
+		absoluteFilePath: source,
+		fileName,
+		contents: `Body of ${source}`,
+		pageTitle: fileName.replace(/\.md$/, ""),
+		frontmatter: { ...frontmatter },
+	};
+}
+
+function remotePage(id: string, title = "Remote page") {
+	return {
+		id,
+		title,
+		type: "page",
+		space: { key: "SPACE" },
+		version: { number: 1, by: { accountId: "current-user" } },
+		body: {
+			atlas_doc_format: { value: JSON.stringify({ type: "doc", version: 1, content: [] }) },
+		},
+		ancestors: [{ id: testSettings.confluenceParentId }],
+	};
+}
+
+function publishingFixture(files: MarkdownFile[]) {
+	const metadata = vi.fn((_source: string, _values: unknown) => {});
+	const workspace: MarkdownWorkspace = {
+		getMarkdownFilesToUpload: Effect.succeed(files),
+		updateMarkdownValues: (source, values) =>
+			Effect.try({ try: () => metadata(source, values), catch: (error) => error as Error }),
+		loadMarkdownFile: () => Effect.fail(new Error("Unused")),
+		readBinary: () => Effect.succeed(false),
+		readText: () => Effect.succeed(false),
+	};
+	const getContentById = vi.fn(async ({ id }: { id: string }) => remotePage(id));
+	const getContent = vi.fn(async (_request: { title?: string }) => ({
+		results: [] as ReturnType<typeof remotePage>[],
+	}));
+	const createContent = vi.fn(async ({ title }: { title: string }) => remotePage("new", title));
+	// Keep optimistic concurrency realistic: duplicate detection must run before retries can overwrite.
+	let version = 1;
+	const updateContent = vi.fn(async (request: { id: string; version: { number: number } }) => {
+		if (request.version.number !== version + 1)
+			throw Object.assign(new Error("Version conflict"), { response: { status: 409 } });
+		version++;
+		return remotePage(request.id);
+	});
+	const sendRequest = vi.fn(async () => {
+		throw new Error("Unexpected attachment write");
+	});
+	const client = {
+		users: { getCurrentUser: async () => ({ accountId: "current-user" }) },
+		content: { getContentById, getContent, createContent, updateContent },
+		contentAttachments: { getAttachments: async () => ({ results: [] }) },
+		contentLabels: { getLabelsForContent: async () => ({ results: [] }) },
+		sendRequest,
+	} as unknown as RequiredConfluenceClient;
+	return {
+		metadata,
+		getContentById,
+		getContent,
+		createContent,
+		updateContent,
+		sendRequest,
+		publish: () =>
+			runEffect(
+				new Publisher(testSettings, client, [])
+					.publishEffect()
+					.pipe(Effect.provideService(MarkdownWorkspaceService, workspace)),
+			),
+	};
+}

--- a/packages/lib/src/SettingsConfig.test.ts
+++ b/packages/lib/src/SettingsConfig.test.ts
@@ -3,7 +3,11 @@ import { Path } from "effect/Path";
 import { NodeFileSystem, NodePath } from "@effect/platform-node";
 import { afterEach, expect, test } from "@effect/vitest";
 import { ConfigProvider, Effect, Layer } from "effect";
-import { loadConfluenceSettingsEffect, parseConfluenceSettingsEffect } from "./SettingsConfig";
+import {
+	loadConfluenceSettingsEffect,
+	parseConfluenceCommandLineOptions,
+	parseConfluenceSettingsEffect,
+} from "./SettingsConfig";
 import { DEFAULT_SETTINGS, type ConfluenceSettings, validateConfluenceSettings } from "./Settings";
 import { RuntimeEnvironment, RuntimeEnvironmentService, runEffect } from "./effects";
 
@@ -240,6 +244,83 @@ test("parses boolean CLI values passed as separate arguments", async () => {
 	expect(settings.tagsToPublish).toBe("public,docs");
 	expect(settings.pageFooterMarkdown).toBe("CLI footer");
 	expect(settings.contentRoot).toBe(expectedContentRoot);
+});
+
+test("accepts only recognized boolean literals in both CLI value forms", () => {
+	for (const [literal, expected] of [
+		["true", true],
+		["TRUE", true],
+		["1", true],
+		["yes", true],
+		["on", true],
+		["false", false],
+		["FALSE", false],
+		["0", false],
+		["no", false],
+		["off", false],
+	] as const) {
+		for (const args of [[`--forceOverwrite=${literal}`], ["--fo", literal]])
+			expect(parseConfluenceCommandLineOptions(args)["forceOverwrite"]).toBe(expected);
+	}
+	expect(parseConfluenceCommandLineOptions(["-fo"])["forceOverwrite"]).toBe(true);
+});
+
+test.each([
+	{ args: ["--forceOverwrite=fales"], error: "--forceOverwrite requires a boolean value" },
+	{ args: ["--forceOverwrite", "fales"], error: "--forceOverwrite requires a boolean value" },
+	{ args: ["--forceOverwrite="], error: "--forceOverwrite requires a boolean value" },
+	{ args: ["--parentId"], error: "--parentId requires a value" },
+	{ args: ["--parentId", "--forceOverwrite"], error: "--parentId requires a value" },
+	{ args: ["--parentId="], error: "--parentId requires a value" },
+	{ args: ["--parentId", "-123"], error: "--parentId requires a value" },
+	{ args: ["--config"], error: "--config requires a value" },
+])(
+	"rejects malformed CLI values $args despite valid fallback settings",
+	async ({ args, error }) => {
+		const runtimeEnvironment = makeRuntimeEnvironment({
+			argv: ["node", "markdown-confluence", ...args],
+			cwd: "/settings-test",
+			env: {
+				CONFLUENCE_BASE_URL: "https://example.atlassian.net",
+				CONFLUENCE_PARENT_ID: "fallback-parent",
+				ATLASSIAN_USERNAME: "test@example.com",
+				ATLASSIAN_API_TOKEN: "test-token",
+				CONFLUENCE_FORCE_OVERWRITE: "false",
+			},
+		});
+		await expect(
+			Effect.runPromise(
+				loadConfluenceSettingsEffect().pipe(
+					Effect.provide(
+						Layer.mergeAll(
+							NodeFileSystem.layer,
+							NodePath.layer,
+							Layer.succeed(RuntimeEnvironmentService, runtimeEnvironment),
+						),
+					),
+				),
+			),
+		).rejects.toThrow(error);
+	},
+);
+
+test("keeps inline strings beginning with a dash and existing CLI aliases", () => {
+	expect(
+		parseConfluenceCommandLineOptions([
+			"-b=https://example.atlassian.net",
+			"--p=123",
+			"--fh=false",
+			"-cr",
+			"docs",
+			"--pageHeaderMarkdown=- Published note",
+		]),
+	).toEqual({
+		baseUrl: "https://example.atlassian.net",
+		parentId: "123",
+		firstHeaderPageTitle: false,
+		contentRoot: "docs",
+		pageHeaderMarkdown: "- Published note",
+	});
 });
 
 test("reports shared settings validation issues", () => {

--- a/packages/lib/src/SettingsConfig.ts
+++ b/packages/lib/src/SettingsConfig.ts
@@ -21,7 +21,7 @@ const CONFLUENCE_SETTINGS_KEYS = Object.keys(DEFAULT_SETTINGS) as (keyof Conflue
 type ArgumentDefinition = {
 	name: string;
 	aliases?: string[];
-	type: "boolean" | "string";
+	type: "boolean" | "string" | "flag";
 };
 
 type ArgumentValue = boolean | string | undefined;
@@ -153,14 +153,15 @@ export function makeConfluenceSettingsConfigProvider(): Effect.Effect<
 		const argv = yield* runtimeEnvironment.argv;
 		const envConfigPath = yield* runtimeEnvironment.getEnv("CONFLUENCE_CONFIG_FILE");
 
-		const configPath = yield* Effect.try({
-			try: () => getConfigPath(argv, envConfigPath, cwd, path),
+		const options = yield* Effect.try({
+			try: () => parseArgumentValues(argv.slice(2), CONFLUENCE_ARGUMENT_DEFINITIONS),
 			catch: toError,
 		});
+		const configPath = getConfigPath(options, envConfigPath, cwd, path);
 		const configFileProvider = yield* makeConfigFileProvider(fs, configPath);
 		const environmentProvider = yield* makeEnvironmentProvider(runtimeEnvironment);
 		const commandLineProvider = yield* Effect.try({
-			try: () => makeCommandLineProvider(argv),
+			try: () => makeCommandLineProvider(options),
 			catch: toError,
 		});
 		const defaultProvider = ConfigProvider.fromUnknown({
@@ -200,12 +201,11 @@ function validateConfluenceSettingsEffect(
 }
 
 function getConfigPath(
-	argv: readonly string[],
+	options: Record<string, ArgumentValue>,
 	envConfigPath: string | undefined,
 	cwd: string,
 	path: Path,
 ): string {
-	const options = parseArgumentValues(argv, [{ name: "config", aliases: ["c"], type: "string" }]);
 	const config = options["config"];
 
 	return typeof config === "string"
@@ -298,41 +298,55 @@ function makeEnvironmentProvider(
 	});
 }
 
-function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.ConfigProvider {
-	const options = parseArgumentValues(argv, [
-		{ name: "baseUrl", aliases: ["b"], type: "string" },
-		{ name: "siteUrl", type: "string" },
-		{ name: "parentId", aliases: ["p"], type: "string" },
-		{ name: "mermaidProtocolTimeout", type: "string" },
-		{ name: "userName", aliases: ["u"], type: "string" },
-		{ name: "apiToken", type: "string" },
-		{ name: "authType", type: "string" },
-		{ name: "apiPrefix", type: "string" },
-		{ name: "requestHeaders", type: "string" },
-		{ name: "clientId", type: "string" },
-		{ name: "clientSecret", type: "string" },
-		{ name: "enableFolder", aliases: ["f"], type: "string" },
-		{ name: "mermaidFormat", type: "string" },
-		{ name: "mermaidScale", type: "string" },
-		{ name: "mermaidTheme", type: "string" },
-		{ name: "jiraUrl", type: "string" },
-		{ name: "orderPages", type: "boolean" },
-		{ name: "excludeFolders", type: "string" },
-		{ name: "tagsToPublish", aliases: ["t"], type: "string" },
-		{ name: "contentRoot", aliases: ["cr"], type: "string" },
-		{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
-		{ name: "lockPublishedPages", type: "boolean" },
-		{ name: "forceOverwrite", aliases: ["fo"], type: "boolean" },
-		{ name: "pageHeaderMarkdown", type: "string" },
-		{ name: "pageFooterMarkdown", type: "string" },
-		{ name: "krokiEnabled", type: "boolean" },
-		{ name: "krokiServerUrl", type: "string" },
-		{ name: "krokiFormat", type: "string" },
-		{ name: "krokiTimeoutMs", type: "string" },
-		{ name: "plantumlEnabled", type: "boolean" },
-		{ name: "plantumlServerUrl", type: "string" },
-	]);
+const CONFLUENCE_ARGUMENT_DEFINITIONS: readonly ArgumentDefinition[] = [
+	{ name: "config", aliases: ["c"], type: "string" },
+	{ name: "baseUrl", aliases: ["b"], type: "string" },
+	{ name: "siteUrl", type: "string" },
+	{ name: "parentId", aliases: ["p"], type: "string" },
+	{ name: "mermaidProtocolTimeout", type: "string" },
+	{ name: "userName", aliases: ["u"], type: "string" },
+	{ name: "apiToken", type: "string" },
+	{ name: "authType", type: "string" },
+	{ name: "apiPrefix", type: "string" },
+	{ name: "requestHeaders", type: "string" },
+	{ name: "clientId", type: "string" },
+	{ name: "clientSecret", type: "string" },
+	{ name: "enableFolder", aliases: ["f"], type: "string" },
+	{ name: "mermaidFormat", type: "string" },
+	{ name: "mermaidScale", type: "string" },
+	{ name: "mermaidTheme", type: "string" },
+	{ name: "jiraUrl", type: "string" },
+	{ name: "orderPages", type: "boolean" },
+	{ name: "excludeFolders", type: "string" },
+	{ name: "tagsToPublish", aliases: ["t"], type: "string" },
+	{ name: "contentRoot", aliases: ["cr"], type: "string" },
+	{ name: "firstHeaderPageTitle", aliases: ["fh"], type: "boolean" },
+	{ name: "lockPublishedPages", type: "boolean" },
+	{ name: "forceOverwrite", aliases: ["fo"], type: "boolean" },
+	{ name: "pageHeaderMarkdown", type: "string" },
+	{ name: "pageFooterMarkdown", type: "string" },
+	{ name: "krokiEnabled", type: "boolean" },
+	{ name: "krokiServerUrl", type: "string" },
+	{ name: "krokiFormat", type: "string" },
+	{ name: "krokiTimeoutMs", type: "string" },
+	{ name: "plantumlEnabled", type: "boolean" },
+	{ name: "plantumlServerUrl", type: "string" },
+];
 
+export function parseConfluenceCommandLineOptions(
+	args: readonly string[],
+	extraDefinitions: readonly ArgumentDefinition[] = [],
+): Record<string, ArgumentValue> {
+	return parseArgumentValues(
+		args,
+		[...CONFLUENCE_ARGUMENT_DEFINITIONS, ...extraDefinitions],
+		true,
+	);
+}
+
+function makeCommandLineProvider(
+	options: Record<string, ArgumentValue>,
+): ConfigProvider.ConfigProvider {
 	const mermaid = compactRecord({
 		format: options["mermaidFormat"],
 		scale: options["mermaidScale"],
@@ -387,8 +401,9 @@ function makeCommandLineProvider(argv: readonly string[]): ConfigProvider.Config
 }
 
 function parseArgumentValues(
-	argv: readonly string[],
-	definitions: ArgumentDefinition[],
+	args: readonly string[],
+	definitions: readonly ArgumentDefinition[],
+	strict = false,
 ): Record<string, ArgumentValue> {
 	const definitionsByFlag = new Map<string, ArgumentDefinition>();
 
@@ -401,9 +416,11 @@ function parseArgumentValues(
 	}
 
 	const parsed: Record<string, ArgumentValue> = {};
-	for (let index = 2; index < argv.length; index += 1) {
-		const rawArgument = argv[index];
-		if (!rawArgument || rawArgument === "--") {
+	for (let index = 0; index < args.length; index += 1) {
+		const rawArgument = args[index]!;
+		if (rawArgument === "--") {
+			if (strict && index + 1 < args.length)
+				throw new Error(`Unexpected argument: ${args[index + 1]}`);
 			break;
 		}
 
@@ -412,16 +429,29 @@ function parseArgumentValues(
 		const inlineValue = equalsIndex >= 0 ? rawArgument.slice(equalsIndex + 1) : undefined;
 		const definition = definitionsByFlag.get(flag);
 		if (!definition) {
+			if (strict)
+				throw new Error(
+					rawArgument.startsWith("-")
+						? `Unknown option: ${flag}. Use --help for usage.`
+						: `Unexpected argument: ${rawArgument}. Use --help for usage.`,
+				);
+			continue;
+		}
+
+		if (definition.type === "flag") {
+			if (inlineValue !== undefined) throw new Error(`${flag} does not accept a value.`);
+			parsed[definition.name] = true;
 			continue;
 		}
 
 		if (definition.type === "boolean") {
-			const nextValue = inlineValue === undefined ? argv[index + 1] : undefined;
+			const nextValue = inlineValue === undefined ? args[index + 1] : undefined;
 			const usesSeparateValue =
 				inlineValue === undefined && nextValue !== undefined && !nextValue.startsWith("-");
 
 			parsed[definition.name] = parseBooleanArgument(
 				inlineValue ?? (usesSeparateValue ? nextValue : undefined),
+				flag,
 			);
 			if (usesSeparateValue) {
 				index += 1;
@@ -429,9 +459,9 @@ function parseArgumentValues(
 			continue;
 		}
 
-		const value = inlineValue ?? argv[index + 1];
-		if (value === undefined || value.startsWith("-")) {
-			continue;
+		const value = inlineValue ?? args[index + 1];
+		if (!value || (inlineValue === undefined && value.startsWith("-") && value !== "-")) {
+			throw new Error(`${flag} requires a value.`);
 		}
 
 		parsed[definition.name] = value;
@@ -443,12 +473,15 @@ function parseArgumentValues(
 	return parsed;
 }
 
-function parseBooleanArgument(value: string | undefined): boolean {
+function parseBooleanArgument(value: string | undefined, flag: string): boolean {
 	if (value === undefined) {
 		return true;
 	}
 
-	return !["0", "false", "no", "off"].includes(value.toLowerCase());
+	const literal = value.toLowerCase();
+	if (["1", "true", "yes", "on"].includes(literal)) return true;
+	if (["0", "false", "no", "off"].includes(literal)) return false;
+	throw new Error(`${flag} requires a boolean value (true/false, yes/no, on/off, or 1/0).`);
 }
 
 function pickConfluenceSettings(config: Record<string, unknown>): Partial<ConfluenceSettings> {

--- a/packages/lib/src/TreeConfluence.test.ts
+++ b/packages/lib/src/TreeConfluence.test.ts
@@ -64,7 +64,7 @@ test("does not try to update generated folder placeholder pages", async () => {
 	expect(updateCalls).toEqual([]);
 });
 
-test("clears stale page ids and creates the page by title", async () => {
+test("replaces stale page ids with one final metadata update after title resolution", async () => {
 	const updateCalls: UpdateCall[] = [];
 	const workspace = new TestMarkdownWorkspace(updateCalls);
 	const notFound = Object.assign(new Error("Not Found"), {
@@ -129,14 +129,6 @@ test("clears stale page ids and creates the page by title", async () => {
 				publish: true,
 				pageId: "123456",
 				pageUrl: "https://example.atlassian.net/wiki/spaces/SPACE/pages/123456/",
-			},
-		},
-		{
-			absoluteFilePath: "docs/child.md",
-			values: {
-				publish: false,
-				pageId: undefined,
-				pageUrl: undefined,
 			},
 		},
 		{
@@ -222,6 +214,108 @@ test("creates children in the space resolved from an explicit parent page id", a
 			title: "Child",
 		},
 	]);
+});
+
+test("resolves existing descendants in an explicitly selected cross-space parent tree", async () => {
+	const updateCalls: UpdateCall[] = [];
+	const lookups: unknown[] = [];
+	const client = {
+		content: {
+			getContentById: async ({ id }: { id: string }) =>
+				createContentPage({
+					id,
+					title: "Other parent",
+					spaceKey: "OTHER",
+					ancestors: [{ id: "other-home" }],
+				}),
+			getContent: async (request: unknown) => {
+				lookups.push(request);
+				return {
+					results: [
+						createContentPage({
+							id: "other-child",
+							title: "Child",
+							spaceKey: "OTHER",
+							ancestors: [{ id: "other-parent" }],
+						}),
+					],
+				};
+			},
+		},
+	} as unknown as RequiredConfluenceClient;
+	const pages = await ensureAllFilesExistInConfluence(
+		client,
+		new TestMarkdownWorkspace(updateCalls),
+		createRootNode("docs", [
+			createRootNode(
+				"docs/other/index.md",
+				[createRootNode("docs/other/child.md", { pageTitle: "Child" })],
+				{ pageId: "other-parent" },
+			),
+		]),
+		"SPACE",
+		"123456",
+		"123456",
+		testSettings,
+	);
+	expect(lookups).toMatchObject([{ title: "Child", spaceKey: "OTHER" }]);
+	expect(
+		pages.map((page) => ({
+			id: page.file.pageId,
+			space: page.file.spaceKey,
+			ancestors: page.ancestors,
+		})),
+	).toEqual([
+		{ id: "other-parent", space: "OTHER", ancestors: ["other-home"] },
+		{ id: "other-child", space: "OTHER", ancestors: ["other-parent"] },
+	]);
+	expect(updateCalls).toHaveLength(2);
+});
+
+test("discovers nested missing pages before creating their hierarchy and committing metadata", async () => {
+	const updateCalls: UpdateCall[] = [];
+	const events: string[] = [];
+	const client = {
+		content: {
+			getContent: async ({ title }: { title: string }) => {
+				events.push(`find ${title}`);
+				return { results: [] };
+			},
+			createContent: async ({
+				title,
+				ancestors,
+			}: {
+				title: string;
+				ancestors: { id: string }[];
+			}) => {
+				events.push(`create ${title} under ${ancestors[0]?.id}`);
+				return createContentPage({ id: title, title, spaceKey: "SPACE", ancestors });
+			},
+		},
+	} as unknown as RequiredConfluenceClient;
+	const pages = await ensureAllFilesExistInConfluence(
+		client,
+		new TestMarkdownWorkspace(updateCalls),
+		createRootNode("docs", [
+			createRootNode(
+				"docs/parent",
+				[createRootNode("docs/parent/child.md", { pageTitle: "Child" })],
+				{ pageTitle: "Parent" },
+			),
+		]),
+		"SPACE",
+		"123456",
+		"123456",
+		testSettings,
+	);
+	expect(events).toEqual([
+		"find Parent",
+		"find Child",
+		"create Parent under 123456",
+		"create Child under Parent",
+	]);
+	expect(pages.map((page) => page.ancestors)).toEqual([["123456"], ["123456", "Parent"]]);
+	expect(updateCalls.map((call) => call.absoluteFilePath)).toEqual(["docs/parent/child.md"]);
 });
 
 type UpdateCall = {

--- a/packages/lib/src/TreeConfluence.ts
+++ b/packages/lib/src/TreeConfluence.ts
@@ -5,7 +5,7 @@ import { prepareAdfToUpload } from "./AdfProcessing";
 import { createMissingSpaceKeyError } from "./ConfluenceErrors";
 import { MarkdownConfluencePlatform, runEffect } from "./effects";
 import { ConfluencePerPageAllValues } from "./ConniePageConfig";
-import { RequiredConfluenceClient } from "./ConfluenceClient";
+import { ConfluenceContent, RequiredConfluenceClient } from "./ConfluenceClient";
 import { MarkdownWorkspace, MarkdownWorkspaceService } from "./MarkdownWorkspace";
 import {
 	ConfluenceAdfFile,
@@ -15,6 +15,7 @@ import {
 	LocalAdfFileTreeNode,
 } from "./Publisher";
 import { ConfluenceSettings, resolveSiteUrl } from "./Settings";
+import { assertUniquePageTargets, checkUniquePageIds } from "./TreeLocal";
 
 const blankPageAdf: string = JSON.stringify(doc(p("Page not published yet")));
 
@@ -78,19 +79,56 @@ export function ensureAllFilesExistInConfluenceEffect(
 	settings: ConfluenceSettings,
 ): Effect.Effect<ConfluenceNode[], unknown, MarkdownConfluencePlatform | MarkdownWorkspaceService> {
 	return Effect.gen(function* () {
+		yield* Effect.try({ try: () => checkUniquePageIds(node), catch: toError });
+		const resolvedPages = new Map<LocalAdfFile, PageDetails | undefined>();
+		// Resolve every existing target before creating pages or changing source metadata.
+		// Checking only the final publish queue is too late: hierarchy creation writes too.
+		yield* resolveFileStructureEffect(
+			confluenceClient,
+			node,
+			spaceKey,
+			parentPageId,
+			topPageId,
+			settings,
+			resolvedPages,
+			true,
+		);
+		yield* Effect.try({
+			try: () =>
+				assertUniquePageTargets(
+					Array.from(resolvedPages, ([file, page]) => ({
+						absoluteFilePath: file.absoluteFilePath,
+						pageId: page?.id,
+					})),
+				),
+			catch: toError,
+		});
 		const confluenceNode = yield* createFileStructureInConfluenceEffect(
 			settings,
 			confluenceClient,
 			node,
 			spaceKey,
 			parentPageId,
-			topPageId,
 			false,
+			resolvedPages,
 		);
 
 		const pages = flattenTree(confluenceNode, [], confluenceNode.version > 0);
+		yield* Effect.try({
+			try: () => assertUniquePageTargets(pages.map((page) => page.file)),
+			catch: toError,
+		});
 
 		yield* Effect.sync(() => prepareAdfToUpload(pages, settings));
+		for (const page of pages) {
+			if (isMarkdownBackedFile(page.file)) {
+				yield* updateMarkdownValuesEffect(page.file.absoluteFilePath, {
+					publish: true,
+					pageId: page.file.pageId,
+					pageUrl: page.file.pageUrl,
+				});
+			}
+		}
 
 		return pages;
 	});
@@ -117,14 +155,55 @@ export function ensureAllFilesExistInConfluence(
 	);
 }
 
+function resolveFileStructureEffect(
+	confluenceClient: RequiredConfluenceClient,
+	node: LocalAdfFileTreeNode,
+	spaceKey: string,
+	parentPageId: string,
+	topPageId: string,
+	settings: ConfluenceSettings,
+	resolvedPages: Map<LocalAdfFile, PageDetails | undefined>,
+	root: boolean,
+): Effect.Effect<void, unknown> {
+	return Effect.gen(function* () {
+		if (!node.file) return yield* Effect.fail(new Error("Missing file on node"));
+		const page = root
+			? isMarkdownBackedFile(node.file)
+				? yield* getPageDetailsByIdEffect(confluenceClient, parentPageId, settings)
+				: undefined
+			: yield* findExistingPageEffect(
+					confluenceClient,
+					node.file,
+					settings,
+					spaceKey,
+					topPageId,
+				);
+		resolvedPages.set(node.file, page);
+		const childSpaceKey = page?.spaceKey ?? spaceKey;
+		const childTopPageId = page && childSpaceKey !== spaceKey ? page.id : topPageId;
+		for (const child of node.children) {
+			yield* resolveFileStructureEffect(
+				confluenceClient,
+				child,
+				childSpaceKey,
+				page?.id ?? parentPageId,
+				childTopPageId,
+				settings,
+				resolvedPages,
+				false,
+			);
+		}
+	});
+}
+
 function createFileStructureInConfluenceEffect(
 	settings: ConfluenceSettings,
 	confluenceClient: RequiredConfluenceClient,
 	node: LocalAdfFileTreeNode,
 	spaceKey: string,
 	parentPageId: string,
-	topPageId: string,
 	createPage: boolean,
+	resolvedPages: ReadonlyMap<LocalAdfFile, PageDetails | undefined>,
 ): Effect.Effect<
 	ConfluenceTreeNode,
 	unknown,
@@ -149,14 +228,9 @@ function createFileStructureInConfluenceEffect(
 		};
 
 		if (createPage) {
-			const pageDetails = yield* ensurePageExistsEffect(
-				confluenceClient,
-				node.file,
-				settings,
-				spaceKey,
-				parentPageId,
-				topPageId,
-			);
+			const pageDetails =
+				resolvedPages.get(node.file) ??
+				(yield* createPageEffect(confluenceClient, node.file, spaceKey, parentPageId));
 			file.pageId = pageDetails.id;
 			file.spaceKey = pageDetails.spaceKey;
 			version = pageDetails.version;
@@ -170,16 +244,9 @@ function createFileStructureInConfluenceEffect(
 			contentType = pageDetails.contentType;
 		} else {
 			if (isMarkdownBackedFile(node.file)) {
-				const pageDetails = yield* getPageDetailsByIdEffect(
-					confluenceClient,
-					parentPageId,
-					settings,
-				);
-				yield* updateMarkdownValuesEffect(node.file.absoluteFilePath, {
-					publish: true,
-					pageId: pageDetails.id,
-					pageUrl: buildPageUrl(settings, pageDetails.spaceKey, pageDetails.id),
-				});
+				const pageDetails = resolvedPages.get(node.file);
+				if (!pageDetails)
+					return yield* Effect.fail(new Error("Missing resolved root page"));
 
 				file = {
 					...file,
@@ -205,7 +272,6 @@ function createFileStructureInConfluenceEffect(
 			}
 		}
 
-		const childTopPageId = file.spaceKey === spaceKey ? topPageId : file.pageId;
 		const childDetails: ConfluenceTreeNode[] = yield* Effect.all(
 			node.children.map((childNode) =>
 				createFileStructureInConfluenceEffect(
@@ -214,8 +280,8 @@ function createFileStructureInConfluenceEffect(
 					childNode,
 					file.spaceKey,
 					file.pageId,
-					childTopPageId,
 					true,
+					resolvedPages,
 				),
 			),
 			// Serial traversal bounds requests across every tree depth. Per-parent
@@ -283,172 +349,104 @@ function buildPageUrl(settings: ConfluenceSettings, spaceKey: string, pageId: st
 	return `${resolveSiteUrl(settings)}/wiki/spaces/${spaceKey}/pages/${pageId}/`;
 }
 
-function ensurePageExistsEffect(
+function findExistingPageEffect(
 	confluenceClient: RequiredConfluenceClient,
 	file: LocalAdfFile,
 	settings: ConfluenceSettings,
 	spaceKey: string,
-	parentPageId: string,
 	topPageId: string,
-): Effect.Effect<PageDetails, unknown, MarkdownConfluencePlatform | MarkdownWorkspaceService> {
-	if (file.pageId) {
-		const pageId = file.pageId;
-
-		return getPageDetailsByIdEffect(confluenceClient, pageId, settings).pipe(
-			Effect.flatMap((pageDetails) =>
-				updateMarkdownValuesEffect(file.absoluteFilePath, {
-					publish: true,
-					pageId: pageDetails.id,
-					pageUrl: buildPageUrl(settings, pageDetails.spaceKey, pageDetails.id),
-				}).pipe(
-					Effect.as({
-						id: pageDetails.id,
-						title: file.pageTitle,
-						version: pageDetails.version,
-						lastUpdatedBy: pageDetails.lastUpdatedBy,
-						existingAdf: pageDetails.existingAdf,
-						spaceKey: pageDetails.spaceKey,
-						pageTitle: pageDetails.pageTitle,
-						ancestors: pageDetails.ancestors,
-						contentType: pageDetails.contentType,
-					}),
-				),
-			),
-			Effect.catch((error) => {
-				if (isNotFoundError(error)) {
-					return updateMarkdownValuesEffect(file.absoluteFilePath, {
-						publish: false,
-						pageId: undefined,
-						pageUrl: undefined,
-					}).pipe(
-						Effect.andThen(
-							findOrCreatePageByTitleEffect(
-								confluenceClient,
-								file,
-								settings,
-								spaceKey,
-								parentPageId,
-								topPageId,
-							),
-						),
-					);
-				}
-
-				return Effect.fail(error);
-			}),
-		);
-	}
-
-	return findOrCreatePageByTitleEffect(
-		confluenceClient,
-		file,
-		settings,
-		spaceKey,
-		parentPageId,
-		topPageId,
+): Effect.Effect<PageDetails | undefined, unknown> {
+	const findByTitle = () => findPageByTitleEffect(confluenceClient, file, spaceKey, topPageId);
+	if (!file.pageId) return findByTitle();
+	return getPageDetailsByIdEffect(confluenceClient, file.pageId, settings).pipe(
+		// A stale ID is an in-memory resolution state. Preserve the user's publication
+		// intent and previous target metadata until a replacement has been resolved.
+		Effect.catch((error) => (isNotFoundError(error) ? findByTitle() : Effect.fail(error))),
 	);
 }
 
-function findOrCreatePageByTitleEffect(
+function findPageByTitleEffect(
 	confluenceClient: RequiredConfluenceClient,
 	file: LocalAdfFile,
-	settings: ConfluenceSettings,
 	spaceKey: string,
-	parentPageId: string,
 	topPageId: string,
-): Effect.Effect<PageDetails, unknown, MarkdownConfluencePlatform | MarkdownWorkspaceService> {
-	const searchParams = {
-		type: file.contentType,
-		spaceKey,
-		title: file.pageTitle,
-		expand: ["version", "body.atlas_doc_format", "ancestors"],
-	};
-
+): Effect.Effect<PageDetails | undefined, unknown> {
 	return Effect.tryPromise({
-		try: () => confluenceClient.content.getContent(searchParams),
+		try: () =>
+			confluenceClient.content.getContent({
+				type: file.contentType,
+				spaceKey,
+				title: file.pageTitle,
+				expand: ["version", "body.atlas_doc_format", "ancestors"],
+			}),
 		catch: identity,
 	}).pipe(
 		Effect.flatMap((contentByTitle) => {
 			const currentPage = contentByTitle.results[0];
-
-			if (currentPage) {
-				if (
-					file.contentType === "page" &&
-					!currentPage.ancestors?.some((ancestor) => ancestor.id == topPageId)
-				) {
-					return Effect.fail(
-						new Error(
-							`${file.pageTitle} is trying to overwrite a page outside the page tree from the selected top page`,
-						),
-					);
-				}
-
-				return updateMarkdownValuesEffect(file.absoluteFilePath, {
-					publish: true,
-					pageId: currentPage.id,
-					pageUrl: buildPageUrl(settings, spaceKey, currentPage.id),
-				}).pipe(
-					Effect.as({
-						id: currentPage.id,
-						title: file.pageTitle,
-						version: currentPage.version?.number ?? 1,
-						lastUpdatedBy: currentPage.version?.by?.accountId ?? "NO ACCOUNT ID",
-						existingAdf: currentPage.body?.atlas_doc_format?.value,
-						pageTitle: currentPage.title,
-						spaceKey,
-						ancestors:
-							currentPage.ancestors?.map((ancestor) => ({
-								id: ancestor.id,
-							})) ?? [],
-						contentType: currentPage.type,
-					}),
+			if (!currentPage) return Effect.succeed(undefined);
+			if (contentByTitle.results.length > 1) {
+				return Effect.fail(
+					new Error(
+						`Page title "${file.pageTitle}" is ambiguous; assign a connie-page-id before publishing`,
+					),
 				);
 			}
+			if (
+				file.contentType === "page" &&
+				!currentPage.ancestors?.some((ancestor) => ancestor.id === topPageId)
+			) {
+				return Effect.fail(
+					new Error(
+						`${file.pageTitle} is trying to overwrite a page outside the page tree from the selected top page`,
+					),
+				);
+			}
+			return Effect.succeed(pageDetailsFromContent(currentPage, file, spaceKey));
+		}),
+	);
+}
 
-			const creatingBlankPageRequest = {
+function createPageEffect(
+	confluenceClient: RequiredConfluenceClient,
+	file: LocalAdfFile,
+	spaceKey: string,
+	parentPageId: string,
+): Effect.Effect<PageDetails, unknown> {
+	return Effect.tryPromise({
+		try: () =>
+			confluenceClient.content.createContent({
 				space: { key: spaceKey },
 				...(file.contentType === "page" ? { ancestors: [{ id: parentPageId }] } : {}),
 				title: file.pageTitle,
 				type: file.contentType,
 				body: {
-					// eslint-disable-next-line @typescript-eslint/naming-convention
 					atlas_doc_format: {
 						value: blankPageAdf,
 						representation: "atlas_doc_format",
 					},
 				},
 				expand: ["version", "body.atlas_doc_format", "ancestors"],
-			};
+			}),
+		catch: identity,
+	}).pipe(Effect.map((page) => pageDetailsFromContent(page, file, spaceKey)));
+}
 
-			return Effect.tryPromise({
-				try: () => confluenceClient.content.createContent(creatingBlankPageRequest),
-				catch: identity,
-			}).pipe(
-				Effect.flatMap((pageDetails) =>
-					updateMarkdownValuesEffect(file.absoluteFilePath, {
-						publish: true,
-						pageId: pageDetails.id,
-						pageUrl: buildPageUrl(settings, spaceKey, pageDetails.id),
-					}).pipe(
-						Effect.as({
-							id: pageDetails.id,
-							title: file.pageTitle,
-							version: pageDetails.version?.number ?? 1,
-							lastUpdatedBy: pageDetails.version?.by?.accountId ?? "NO ACCOUNT ID",
-							existingAdf: pageDetails.body?.atlas_doc_format?.value,
-							pageTitle: pageDetails.title,
-							ancestors:
-								pageDetails.ancestors?.map((ancestor) => ({
-									id: ancestor.id,
-								})) ?? [],
-							spaceKey,
-							contentType: pageDetails.type,
-						}),
-					),
-				),
-			);
-		}),
-	);
+function pageDetailsFromContent(
+	page: ConfluenceContent,
+	file: LocalAdfFile,
+	spaceKey: string,
+): PageDetails {
+	return {
+		id: page.id,
+		title: file.pageTitle,
+		version: page.version?.number ?? 1,
+		lastUpdatedBy: page.version?.by?.accountId ?? "NO ACCOUNT ID",
+		existingAdf: page.body?.atlas_doc_format?.value,
+		pageTitle: page.title,
+		ancestors: page.ancestors?.map((ancestor) => ({ id: ancestor.id })) ?? [],
+		spaceKey,
+		contentType: page.type,
+	};
 }
 
 function updateMarkdownValuesEffect(

--- a/packages/lib/src/TreeLocal.ts
+++ b/packages/lib/src/TreeLocal.ts
@@ -169,10 +169,37 @@ export const createFolderStructureEffect = (
 
 		processNode(treeRootPath, rootNode, path);
 
+		checkUniquePageIds(rootNode);
 		checkUniquePageTitle(rootNode);
 
 		return rootNode;
 	}).pipe(Effect.mapError(toError));
+
+export function checkUniquePageIds(rootNode: LocalAdfFileTreeNode): void {
+	const targets: { pageId: string | undefined; absoluteFilePath: string }[] = [];
+	const visit = (node: LocalAdfFileTreeNode) => {
+		if (node.file) targets.push(node.file);
+		node.children.forEach(visit);
+	};
+	visit(rootNode);
+	assertUniquePageTargets(targets);
+}
+
+export function assertUniquePageTargets(
+	files: Iterable<{ pageId: string | undefined; absoluteFilePath: string }>,
+): void {
+	const sourcesByPageId = new Map<string, string>();
+	for (const file of files) {
+		if (!file.pageId) continue;
+		const existingSource = sourcesByPageId.get(file.pageId);
+		if (existingSource !== undefined) {
+			throw new Error(
+				`Confluence page ID "${file.pageId}" is targeted by both "${existingSource}" and "${file.absoluteFilePath}". Each page must have only one source file.`,
+			);
+		}
+		sourcesByPageId.set(file.pageId, file.absoluteFilePath);
+	}
+}
 
 function checkUniquePageTitle(
 	rootNode: LocalAdfFileTreeNode,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -90,6 +90,7 @@ import {
 	loadConfluenceSettingsEffect,
 	makeConfluenceSettingsConfigProvider,
 	parseConfluenceSettingsEffect,
+	parseConfluenceCommandLineOptions,
 } from "./SettingsConfig";
 
 export {
@@ -147,6 +148,7 @@ export {
 	normalizeConfluenceApiPrefix,
 	parseConfluenceSettingsEffect,
 	parseMarkdownToADF,
+	parseConfluenceCommandLineOptions,
 	renderADFDoc,
 	runEffect,
 	shouldPublishMarkdownFile,

--- a/packages/obsidian/src/PublishingCommands.test.ts
+++ b/packages/obsidian/src/PublishingCommands.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, expect, test, vi } from "@effect/vitest";
+import type { App, Command, PluginManifest, TFile } from "obsidian";
+import { shouldPublishMarkdownFile } from "@markdown-confluence/lib";
+import type { ObsidianPluginSettings } from "./main";
+
+const notices: string[] = [];
+const openResults = vi.fn();
+
+class ObsidianPlugin {
+	commands = new Map<string, Command>();
+	statusBar = { setText: vi.fn(), empty: vi.fn(), onclick: undefined };
+	constructor(public app: App) {}
+	loadData = vi.fn().mockResolvedValue(undefined);
+	addStatusBarItem = () => this.statusBar;
+	addCommand = (command: Command) => this.commands.set(command.id, command);
+	addRibbonIcon = vi.fn();
+	addSettingTab = vi.fn();
+}
+
+vi.doMock("obsidian", () => ({
+	Plugin: ObsidianPlugin,
+	Notice: class {
+		constructor(message: string) {
+			notices.push(message);
+		}
+	},
+	MarkdownView: class {},
+	loadMermaid: vi.fn(),
+}));
+vi.doMock("./ConfluenceSettingTab", () => ({ ConfluenceSettingTab: class {} }));
+vi.doMock("./CompletedModal", () => ({
+	CompletedModal: class {
+		open = openResults;
+	},
+}));
+vi.doMock("./ConfluencePerPageForm", () => ({
+	ConfluencePerPageForm: class {},
+	mapFrontmatterToConfluencePerPageUIValues: vi.fn(),
+}));
+vi.doMock("./BrowserOAuth", () => ({
+	BrowserOAuth: class {
+		cancel = vi.fn();
+	},
+}));
+vi.doMock("./ObsidianAuthentication", () => ({ createObsidianConfluenceClient: vi.fn() }));
+vi.doMock("./effects/ObsidianPlatform", () => ({ ObsidianPlatformLive: vi.fn() }));
+vi.doMock("@markdown-confluence/mermaid-electron-renderer", () => ({
+	ElectronMermaidRenderer: class {},
+	ElectronMathRenderer: class {},
+}));
+vi.doMock("@markdown-confluence/plantuml-renderer", () => ({ HttpPlantumlRenderer: class {} }));
+const { default: ConfluencePlugin } = await import("./main");
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.clearAllMocks();
+	notices.length = 0;
+});
+
+async function setup(
+	filePath = "Docs/note.md",
+	frontmatter: Record<string, unknown> = {},
+	settings: Partial<ObsidianPluginSettings> = {},
+) {
+	const file = { path: filePath } as TFile;
+	const processFrontMatter = vi.fn(
+		async (_file: TFile, update: (values: Record<string, unknown>) => void) => {
+			update(frontmatter);
+		},
+	);
+	const app = {
+		metadataCache: { getCache: () => ({ frontmatter }) },
+		fileManager: { processFrontMatter },
+	} as unknown as App;
+	const plugin = new ConfluencePlugin(app, {} as PluginManifest);
+	await plugin.loadSettings();
+	Object.assign(plugin.settings, { folderToPublish: "Docs" }, settings);
+	vi.spyOn(plugin, "init").mockResolvedValue(undefined);
+	await plugin.onload();
+	const mockPlugin = plugin as unknown as ObsidianPlugin;
+	const invoke = (id: string, checking: boolean, selectedFile: TFile | null = file) =>
+		mockPlugin.commands.get(id)!.editorCheckCallback!(
+			checking,
+			{} as never,
+			{
+				file: selectedFile,
+			} as never,
+		);
+	return { plugin, mockPlugin, file, frontmatter, processFrontMatter, invoke };
+}
+
+test.each([
+	{
+		name: "a matching publish tag outside the folder",
+		path: "Notes/tagged.md",
+		frontmatter: { tags: ["public"] },
+		settings: { tagsToPublish: "public" },
+	},
+	{
+		name: "the root publish folder",
+		path: "Notes/root.md",
+		frontmatter: {},
+		settings: { folderToPublish: "." },
+	},
+	{
+		name: "an explicit opt-in outside the folder",
+		path: "Notes/explicit.md",
+		frontmatter: { "connie-publish": true },
+		settings: {},
+	},
+])("disable persists an opt-out for $name", async ({ path, frontmatter, settings }) => {
+	const fixture = await setup(path, frontmatter, settings);
+	expect(fixture.invoke("disable-publishing", true)).toBe(true);
+	expect(fixture.processFrontMatter).not.toHaveBeenCalled();
+	expect(fixture.invoke("disable-publishing", false)).toBe(true);
+	await fixture.processFrontMatter.mock.results[0].value;
+	expect(frontmatter["connie-publish"]).toBe(false);
+	expect(shouldPublishMarkdownFile(path, frontmatter, fixture.plugin.settings)).toBe(false);
+	expect(fixture.invoke("disable-publishing", true)).toBe(false);
+});
+
+test.each([
+	{ path: "Docs-private/note.md", frontmatter: {} },
+	{ path: "Docs/note.md", frontmatter: { "connie-publish": false } },
+])("enable persists an opt-in for $path", async ({ path, frontmatter }) => {
+	const fixture = await setup(path, frontmatter);
+	expect(fixture.invoke("enable-publishing", true)).toBe(true);
+	expect(fixture.processFrontMatter).not.toHaveBeenCalled();
+	expect(fixture.invoke("enable-publishing", false)).toBe(true);
+	await fixture.processFrontMatter.mock.results[0].value;
+	expect(frontmatter["connie-publish"]).toBe(true);
+	expect(shouldPublishMarkdownFile(path, frontmatter, fixture.plugin.settings)).toBe(true);
+	expect(fixture.invoke("enable-publishing", true)).toBe(false);
+});
+
+test("exclusions and a missing file cannot be enabled or disabled", async () => {
+	const fixture = await setup("Docs/Private/note.md", {}, { foldersToExclude: ["Docs/Private"] });
+	for (const command of ["enable-publishing", "disable-publishing"]) {
+		for (const checking of [true, false]) {
+			expect(fixture.invoke(command, checking)).toBe(false);
+			expect(fixture.invoke(command, checking, null)).toBe(false);
+		}
+	}
+	expect(fixture.processFrontMatter).not.toHaveBeenCalled();
+});
+
+test("execution rechecks publication policy after a command becomes available", async () => {
+	const fixture = await setup("Notes/note.md");
+	expect(fixture.invoke("enable-publishing", true)).toBe(true);
+	fixture.plugin.settings.foldersToExclude = ["Notes"];
+	expect(fixture.invoke("enable-publishing", false)).toBe(false);
+	expect(fixture.processFrontMatter).not.toHaveBeenCalled();
+});
+
+test("frontmatter write failures produce a notice", async () => {
+	const fixture = await setup();
+	fixture.processFrontMatter.mockRejectedValue(new Error("Vault is read-only"));
+	expect(fixture.invoke("disable-publishing", false)).toBe(true);
+	await Promise.resolve();
+	expect(notices).toEqual(["Could not update publishing: Vault is read-only"]);
+});
+
+test.each([false, true])(
+	"unload cancels publishing and suppresses late UI (failure: %s)",
+	async (fails) => {
+		const fixture = await setup();
+		const result = Promise.withResolvers<Awaited<ReturnType<ConfluencePlugin["doPublish"]>>>();
+		vi.spyOn(fixture.plugin, "doPublish").mockReturnValue(result.promise);
+		const publishing = fixture.plugin as unknown as {
+			runPublish(): Promise<void>;
+			publishAbort: AbortController | undefined;
+		};
+		const completion = publishing.runPublish();
+		const signal = publishing.publishAbort!.signal;
+		await fixture.plugin.onunload();
+		expect(signal.aborted).toBe(true);
+		expect(fixture.plugin.browserOAuth.cancel).toHaveBeenCalledOnce();
+		if (fails) result.reject(new Error("Request cancelled"));
+		else result.resolve({ errorMessage: null, failedFiles: [], filesUploadResult: [] });
+		await completion;
+		expect(openResults).not.toHaveBeenCalled();
+		expect(notices).toEqual([]);
+		expect(fixture.mockPlugin.statusBar.empty).not.toHaveBeenCalled();
+		expect(fixture.invoke("disable-publishing", false)).toBe(false);
+		await publishing.runPublish();
+		expect(fixture.plugin.doPublish).toHaveBeenCalledOnce();
+	},
+);

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -4,7 +4,7 @@ import {
 	HttpKrokiRenderer,
 	DEFAULT_KROKI_SETTINGS,
 } from "@markdown-confluence/lib";
-import { Plugin, Notice, MarkdownView, Workspace, loadMermaid } from "obsidian";
+import { Plugin, Notice, MarkdownView, Workspace, loadMermaid, type TFile } from "obsidian";
 import {
 	ADFProcessingPlugin,
 	ConfluenceUploadSettings,
@@ -117,6 +117,7 @@ export default class ConfluencePlugin extends Plugin {
 	}
 
 	private isSyncing = false;
+	private isUnloaded = false;
 	private platform!: Layer.Layer<MarkdownConfluencePlatform>;
 	private settingsLayer!: Layer.Layer<ConfluenceUploadSettings.ConfluenceSettingsService>;
 	workspace!: Workspace;
@@ -139,7 +140,9 @@ export default class ConfluencePlugin extends Plugin {
 
 	private async createPublisher() {
 		const confluenceClient = await this.authenticationClient();
+		if (this.isUnloaded) throw new Error("The Confluence plugin was unloaded.");
 		const mermaidItems = await this.getMermaidItems();
+		if (this.isUnloaded) throw new Error("The Confluence plugin was unloaded.");
 		const mermaidRenderer = new ElectronMermaidRenderer(
 			mermaidItems.extraStyleSheets,
 			mermaidItems.extraStyles,
@@ -290,7 +293,9 @@ export default class ConfluencePlugin extends Plugin {
 	}
 
 	override async onload() {
+		this.isUnloaded = false;
 		await this.init();
+		if (this.isUnloaded) return;
 		this.publishStatus = this.addStatusBarItem();
 		this.publishStatus.onclick = () => this.publishAbort?.abort();
 		this.addCommand({
@@ -333,65 +338,15 @@ export default class ConfluencePlugin extends Plugin {
 		this.addCommand({
 			id: "enable-publishing",
 			name: "Enable publishing to Confluence",
-			editorCheckCallback: (checking, _editor, view) => {
-				if (!view.file) {
-					return false;
-				}
-
-				if (checking) {
-					const frontMatter = this.app.metadataCache.getCache(
-						view.file.path,
-					)?.frontmatter;
-					const file = view.file;
-					const enabledForPublishing = shouldPublishMarkdownFile(
-						file.path,
-						frontMatter,
-						this.settings,
-					);
-					return !enabledForPublishing;
-				}
-
-				this.app.fileManager.processFrontMatter(view.file, (frontmatter) => {
-					if (view.file && view.file.path.startsWith(this.settings.folderToPublish)) {
-						delete frontmatter["connie-publish"];
-					} else {
-						frontmatter["connie-publish"] = true;
-					}
-				});
-				return true;
-			},
+			editorCheckCallback: (checking, _editor, view) =>
+				this.setPublishingEnabled(checking, view.file, true),
 		});
 
 		this.addCommand({
 			id: "disable-publishing",
 			name: "Disable publishing to Confluence",
-			editorCheckCallback: (checking, _editor, view) => {
-				if (!view.file) {
-					return false;
-				}
-
-				if (checking) {
-					const frontMatter = this.app.metadataCache.getCache(
-						view.file.path,
-					)?.frontmatter;
-					const file = view.file;
-					const enabledForPublishing = shouldPublishMarkdownFile(
-						file.path,
-						frontMatter,
-						this.settings,
-					);
-					return enabledForPublishing;
-				}
-
-				this.app.fileManager.processFrontMatter(view.file, (frontmatter) => {
-					if (view.file && view.file.path.startsWith(this.settings.folderToPublish)) {
-						frontmatter["connie-publish"] = false;
-					} else {
-						delete frontmatter["connie-publish"];
-					}
-				});
-				return true;
-			},
+			editorCheckCallback: (checking, _editor, view) =>
+				this.setPublishingEnabled(checking, view.file, false),
 		});
 
 		this.addCommand({
@@ -441,7 +396,36 @@ export default class ConfluencePlugin extends Plugin {
 	}
 
 	override async onunload() {
+		this.isUnloaded = true;
+		this.publishAbort?.abort();
+		this.publishStatus = undefined;
 		this.browserOAuth.cancel();
+	}
+
+	private setPublishingEnabled(checking: boolean, file: TFile | null, enabled: boolean) {
+		if (!file || this.isUnloaded) return false;
+		const frontmatter = this.app.metadataCache.getCache(file.path)?.frontmatter;
+		if (
+			shouldPublishMarkdownFile(file.path, frontmatter, this.settings) === enabled ||
+			(enabled &&
+				!shouldPublishMarkdownFile(
+					file.path,
+					{ ...frontmatter, "connie-publish": true },
+					this.settings,
+				))
+		)
+			return false;
+		if (!checking) {
+			void this.app.fileManager
+				.processFrontMatter(file, (values) => {
+					values["connie-publish"] = enabled;
+				})
+				.catch((error: unknown) => {
+					if (!this.isUnloaded)
+						new Notice(`Could not update publishing: ${toError(error).message}`);
+				});
+		}
+		return true;
 	}
 
 	async loadSettings() {
@@ -498,6 +482,7 @@ export default class ConfluencePlugin extends Plugin {
 	}
 
 	private async runPublish(publishFilter?: string): Promise<void> {
+		if (this.isUnloaded) return;
 		if (this.isSyncing) {
 			new Notice("A Confluence publish is already in progress.");
 			return;
@@ -526,6 +511,7 @@ export default class ConfluencePlugin extends Plugin {
 	}
 
 	private showPublishResults(uploadResults: UploadResults) {
+		if (this.isUnloaded) return;
 		if (this.settings.showPublishResultsModal) {
 			new CompletedModal(this.app, {
 				uploadResults,

--- a/scripts/integration-tests.js
+++ b/scripts/integration-tests.js
@@ -43,19 +43,27 @@ Reports: reports/integration/. See documentation/TESTING.md for coverage and set
 function command(executable, args, options = {}, timeout = "15 minutes") {
 	return Effect.scoped(
 		Effect.gen(function* () {
+			const { expectedStderr, ...childOptions } = options;
 			const child = yield* ChildProcess.make(executable, args, {
 				cwd: repositoryRoot,
 				extendEnv: true,
 				stdin: "ignore",
 				stdout: options.capture ? "pipe" : "inherit",
-				stderr: "inherit",
-				...options,
+				stderr: expectedStderr ? "pipe" : "inherit",
+				...childOptions,
 			});
-			const [exitCode, output] = yield* Effect.all(
+			const [exitCode, output, stderr] = yield* Effect.all(
 				[
 					child.exitCode,
 					options.capture
 						? child.stdout.pipe(
+								Stream.decodeText(),
+								Stream.runCollect,
+								Effect.map((chunks) => chunks.join("")),
+							)
+						: Effect.succeed(""),
+					expectedStderr
+						? child.stderr.pipe(
 								Stream.decodeText(),
 								Stream.runCollect,
 								Effect.map((chunks) => chunks.join("")),
@@ -69,6 +77,11 @@ function command(executable, args, options = {}, timeout = "15 minutes") {
 					new Error(
 						`${executable} exited ${exitCode}; expected ${options.expectedExitCode ?? 0}`,
 					),
+				);
+			if (expectedStderr)
+				assert.ok(
+					stderr.includes(expectedStderr),
+					`Expected validation diagnostic: ${expectedStderr}`,
 				);
 			return output;
 		}),
@@ -242,6 +255,34 @@ function verifyCli(node, cliPath, cwd, libraryUrl) {
 			expectedExitCode: 1,
 		});
 		assert.ok(!invalid.trim(), "Failed conversion must not emit an ADF document");
+		for (const { args, diagnostic } of [
+			{ args: ["valdiate"], diagnostic: "Unknown command: valdiate" },
+			{ args: ["--dry-run"], diagnostic: "Unknown option: --dry-run" },
+			{
+				args: ["--forceOverwrite=fales"],
+				diagnostic: "--forceOverwrite requires a boolean value",
+			},
+			{
+				args: ["--forceOverwrite", "fales"],
+				diagnostic: "--forceOverwrite requires a boolean value",
+			},
+			{ args: ["--parentId"], diagnostic: "--parentId requires a value" },
+		]) {
+			const rejected = yield* command(node, [cliPath, ...args], {
+				cwd,
+				capture: true,
+				expectedExitCode: 1,
+				expectedStderr: diagnostic,
+			});
+			assert.equal(
+				rejected.trim(),
+				"",
+				`Rejected command ${JSON.stringify(args)} must not produce publishing output`,
+			);
+		}
+		yield* Console.log(
+			"Unknown commands, unsupported publishing options, malformed booleans and missing values fail without publishing output.",
+		);
 		yield* Console.log(
 			`Built CLI matches the library for ${count} Markdown fixtures; CommonJS import and failure exit verified.`,
 		);


### PR DESCRIPTION
Publishing could target the same Confluence page from multiple notes, expose hidden HTML-comment content, or lose inline nodes and existing attachment references. Mistyped CLI commands could also fall through to publication. This change rejects unsafe targets and arguments before mutations and preserves document content throughout publication.

- Resolve existing page targets before creating pages or writing frontmatter; reject duplicate explicit, title-resolved, and mapped-root targets. Preserve source metadata during stale-ID recovery until resolution succeeds.
- Keep existing remote attachments intact, merge only adjacent compatible text, and preserve overlapping inline-comment annotations without duplicate marks.
- Strip hidden comments using Markdown block and table-cell boundaries while preserving literal code and LF/CRLF/CR input.
- Persist explicit false frontmatter values and use the shared selection policy for Obsidian publishing commands.
- Enforce cancellation before each HTTP dispatch and retry using isolated transports. Let dispatched writes finish; cancel publishing and suppress late UI on Obsidian unload.
- Reject unknown CLI commands/options, missing values, and malformed booleans before settings or publishers run. Retain integration checks for the expected rejection diagnostics.

## Validation

- Node 24.15.0; Vite+ with pinned pnpm 11.1.2.
- `vp run check`, `vp run fmt:check`, `vp run build`, and `git diff --check` passed.
- `vp test run`: 528 passed, one existing integration test skipped, 49 test files.
- Fresh built and packaged CLI checks passed using all five local npm tarballs in an isolated consumer, real Chromium/LaTeX rendering, 12 Markdown fixtures, rich ADF round trips, and invalid-command diagnostics.
- Live Basic and OAuth publishing, blogs, Kroki, feature integrations, ordering, cancellation/restart, and real inline-comment preservation passed in the dedicated test space.
- Actual Obsidian and Dataview integration plus publishing-command acceptance passed.
- The current candidate Docker image passed all 166 notes and 17 Mermaid diagrams, unchanged body/version/attachment comparisons, real inline comments, and Mermaid/timeout/math failure recovery. Its CLI checksum matched the fresh host build.
- Additional live acceptance verified zero writes for duplicate targets, unchanged republishing of exported remote media, persisted opt-outs, and cancellation preserving a completed PUT while preventing subsequent requests.

One configuration-related integration failure remains: OAuth edit locking returned HTTP 401 because the configured service-account token lacks content-restriction scopes. Basic and desktop edit locking passed. No credentials or grants were changed. Verification ran on macOS Apple Silicon and the local Linux ARM64 candidate container.
