### PR TITLE
test: use native paths for publisher safety fixtures

### DIFF
--- a/packages/lib/src/PublisherErrors.test.ts
+++ b/packages/lib/src/PublisherErrors.test.ts
@@ -1,11 +1,15 @@
 import { expect, test, vi } from "@effect/vitest";
+import { NodePath } from "@effect/platform-node";
 import { Effect } from "effect";
+import { Path } from "effect/Path";
 import { runEffect } from "./effects";
 import { MarkdownFile, MarkdownWorkspace, MarkdownWorkspaceService } from "./MarkdownWorkspace";
 import { validatePublishingFiles } from "./PublishingReport";
 import { RequiredConfluenceClient } from "./ConfluenceClient";
 import { Publisher } from "./Publisher";
 import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
+
+const filesystemPath = Effect.runSync(Path.pipe(Effect.provide(NodePath.layer)));
 
 test("explains how to resolve a missing parent page space key", async () => {
 	const publisher = new Publisher(testSettings, createConfluenceClientWithoutParentSpace(), []);
@@ -62,8 +66,8 @@ test.each([
 		const files = [publishingFile(first, frontmatter), publishingFile(second, frontmatter)];
 		const validation = validatePublishingFiles(files, testSettings);
 		expect(validation.valid).toBe(false);
-		expect(validation.errors.join(" ")).toContain(first);
-		expect(validation.errors.join(" ")).toContain(second);
+		expect(validation.errors.join(" ")).toContain(filesystemPath.normalize(first));
+		expect(validation.errors.join(" ")).toContain(filesystemPath.normalize(second));
 		const fixture = publishingFixture(files);
 		await expect(fixture.publish()).rejects.toThrow('Confluence page ID "2"');
 		expect(fixture.createContent).not.toHaveBeenCalled();
@@ -164,11 +168,14 @@ test.each(["lookup", "create"])(
 		fixture.getContent.mockResolvedValue({ results: [remotePage("3", "one")] });
 		const results = await fixture.publish();
 		expect(results[0]?.successfulUploadResult).toBeDefined();
-		expect(fixture.metadata).toHaveBeenCalledExactlyOnceWith("/docs/one.md", {
-			publish: true,
-			pageId: "3",
-			pageUrl: "https://example.atlassian.net/wiki/spaces/SPACE/pages/3/",
-		});
+		expect(fixture.metadata).toHaveBeenCalledExactlyOnceWith(
+			filesystemPath.normalize("/docs/one.md"),
+			{
+				publish: true,
+				pageId: "3",
+				pageUrl: "https://example.atlassian.net/wiki/spaces/SPACE/pages/3/",
+			},
+		);
 	},
 );
 
@@ -187,10 +194,11 @@ test("a metadata write failure does not trigger stale-ID recovery or clear publi
 });
 
 function publishingFile(source: string, frontmatter: Record<string, unknown> = {}): MarkdownFile {
-	const fileName = source.split("/").at(-1)!;
+	const absoluteFilePath = filesystemPath.normalize(source);
+	const fileName = filesystemPath.basename(absoluteFilePath);
 	return {
-		folderName: "docs",
-		absoluteFilePath: source,
+		folderName: filesystemPath.basename(filesystemPath.dirname(absoluteFilePath)),
+		absoluteFilePath,
 		fileName,
 		contents: `Body of ${source}`,
 		pageTitle: fileName.replace(/\.md$/, ""),


### PR DESCRIPTION
Windows CI failed six publisher safety tests because their hardcoded slash-separated paths were passed to the native Windows path service. Tree construction produced synthetic parent folders and failed title validation before reaching the intended duplicate page ID checks.

Normalize the fixture paths with the same native Effect path service used by the publisher, derive matching file and folder names, and update exact path assertions. All duplicate-target and no-write assertions remain in place.

Validation:
- Reproduced all six failures locally using `NodePath.layerWin32`; the native and Windows-path fixture suites then passed all 26 cases.
- `vp run check` and `vp run fmt:check` passed.
- `vp test run`: 528 passed, 1 existing skip.
- [Windows CI](https://github.com/markdown-confluence/markdown-confluence/actions/runs/34237459131/job/102098762877) passed all 528 tests (1 existing skip), package imports, Markdown/TOC, the PlantUML contract, real Chromium Mermaid/LaTeX rendering, and the CLI integration round. Linux verification also passed.
