### PR TITLE
ci: fix mutation testing timeouts with the Vitest runner

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,9 +43,16 @@ jobs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: reports/mutation/incremental.json
-        key: stryker-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'stryker.config.mjs', 'packages/lib/src/**/*.ts') }}
-        restore-keys: |
-          stryker-${{ runner.os }}-
+        # Reuse only results from the same runner, toolchain, source, and tests.
+        # A partial-key restore could retain stale results after test or dependency changes.
+        key: >-
+          stryker-vitest-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(
+            'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc', '.node-version', '.tool-versions',
+            'package.json', 'manifest.json', '*config*', '.github/workflows/mutation.yml',
+            'packages/*/package.json', 'packages/*/*config*', 'packages/*/src/**',
+            'packages/*/test/**', 'packages/*/tests/**', 'packages/*/fixtures/**',
+            'scripts/**', 'config/**', 'test-fixtures/**', 'patches/**', '.build/**', 'vite.package-build.ts'
+          ) }}
 
     - name: Run mutation tests
       run: vp run mutation

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -16,9 +16,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mutation:
+  mutation-shard:
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
 
     steps:
     - name: Harden Runner
@@ -46,7 +51,7 @@ jobs:
         # Reuse only results from the same runner, toolchain, source, and tests.
         # A partial-key restore could retain stale results after test or dependency changes.
         key: >-
-          stryker-vitest-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(
+          stryker-vitest-shards-v1-${{ matrix.shard }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(
             'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc', '.node-version', '.tool-versions',
             'package.json', 'manifest.json', '*config*', '.github/workflows/mutation.yml',
             'packages/*/package.json', 'packages/*/*config*', 'packages/*/src/**',
@@ -54,10 +59,56 @@ jobs:
             'scripts/**', 'config/**', 'test-fixtures/**', 'patches/**', '.build/**', 'vite.package-build.ts'
           ) }}
 
-    - name: Run mutation tests
-      run: vp run mutation
+    - name: Run mutation shard
+      run: vp run mutation:shard -- ${{ matrix.shard }}
 
     - name: Upload mutation report
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: mutation-shard-${{ matrix.shard }}
+        path: reports/mutation
+        if-no-files-found: ignore
+
+  mutation:
+    if: ${{ always() }}
+    needs: mutation-shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Require every mutation shard to pass
+      env:
+        SHARD_RESULT: ${{ needs.mutation-shard.result }}
+      run: test "$SHARD_RESULT" = success
+
+    - name: Harden Runner
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    - name: Check out repository code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up Vite+
+      uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+      with:
+        node-version: "24.15.0"
+        cache: true
+        run-install: false
+
+    - name: Install dependencies
+      run: vp install --frozen-lockfile
+
+    - name: Download mutation shards
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: mutation-shard-*
+        path: reports/mutation-shards
+
+    - name: Validate and combine mutation reports
+      run: vp run mutation:aggregate
+
+    - name: Upload combined mutation report
       if: ${{ always() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/documentation/TESTING.md
+++ b/documentation/TESTING.md
@@ -222,6 +222,26 @@ See [DATAVIEW.md](DATAVIEW.md) for setup, supported query forms and hook details
 
 ## GitHub Actions
 
+### Mutation testing
+
+`vp run mutation` runs the complete library mutation scope locally. CI distributes
+that same scope across eight jobs using `vp run mutation:shard -- 1` through `8`.
+`vp run mutation:plan` shows the deterministic groups, balanced by source size from
+tracked files and the include/exclude patterns in `stryker.config.mjs`.
+
+The Vitest runner selects covering tests and related test files. Static mutations
+and TypeScript checking remain enabled. Workspace tests inject their relative path
+base so they can run in worker threads without changing the process directory.
+
+The final `mutation` check requires all eight jobs to succeed. It verifies each
+completion manifest against the expected source scope and mutant counts, combines
+the reports, and applies the configured score threshold to the combined result.
+The `mutation-report` artifact contains the combined HTML, JSON, and metrics;
+individual `mutation-shard-*` artifacts retain the detailed reports. Incremental
+caches are reused only for identical source, tests, tooling and configuration.
+
+### Integration testing
+
 Pull requests run package integration on Linux and the built CLI/Chromium check
 on Windows. Both reuse the existing workflows and upload reports even on failure.
 Release publication tests the packed npm artifacts before publishing them.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"@effect/vitest": "4.0.0-rc.112",
 		"@stryker-mutator/core": "9.6.1",
 		"@stryker-mutator/typescript-checker": "9.6.1",
+		"@stryker-mutator/vitest-runner": "9.6.1",
 		"@types/node": "^25.9.1",
 		"@vitest/runner": "4.1.11",
 		"effect": "4.0.0-rc.112",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
 		"test:integration:live": "vp run test:integration live",
 		"test:integration:docker": "vp run test:integration docker",
 		"test:integration:obsidian": "vp run test:integration obsidian",
-		"test:vault": "vp run test:integration vault"
+		"test:vault": "vp run test:integration vault",
+		"mutation:plan": "node scripts/mutation-ci.js plan",
+		"mutation:shard": "node scripts/mutation-ci.js run",
+		"mutation:aggregate": "node scripts/mutation-ci.js aggregate"
 	},
 	"devDependencies": {
 		"@effect-oxlint/effect-oxlint": "jsr:^0.2.0",
@@ -44,6 +47,9 @@
 		"@vitest/runner": "4.1.11",
 		"effect": "4.0.0-rc.112",
 		"husky": "^9.1.7",
+		"minimatch": "10.2.6",
+		"mutation-testing-elements": "3.7.3",
+		"mutation-testing-metrics": "3.7.3",
 		"oxlint": "1.66.0",
 		"tslib": "2.8.1",
 		"typescript": "^6.0.3",

--- a/packages/lib/src/MarkdownWorkspace.test.ts
+++ b/packages/lib/src/MarkdownWorkspace.test.ts
@@ -3,7 +3,7 @@ import { Path } from "effect/Path";
 import { afterEach, expect, test } from "@effect/vitest";
 import { Effect } from "effect";
 import { ConfluenceSettings, DEFAULT_SETTINGS } from "./Settings";
-import { RuntimeEnvironmentService, runEffect } from "./effects";
+import { runEffect } from "./effects";
 import {
 	loadMarkdownWorkspace,
 	shouldPublishMarkdownFile,
@@ -24,18 +24,11 @@ test("folder selection respects directory boundaries on all platforms", () => {
 });
 
 let tmpRoot: string | undefined;
-let originalWorkingDirectory: string | undefined;
 
 afterEach(async () => {
 	await runEffect(
 		Effect.gen(function* () {
 			const fs = yield* FileSystem;
-			const runtimeEnvironment = yield* RuntimeEnvironmentService;
-
-			if (originalWorkingDirectory) {
-				yield* runtimeEnvironment.chdir(originalWorkingDirectory);
-				originalWorkingDirectory = undefined;
-			}
 
 			if (tmpRoot) {
 				yield* fs.remove(tmpRoot, { recursive: true, force: true });
@@ -45,27 +38,44 @@ afterEach(async () => {
 	);
 });
 
+async function loadMarkdownWorkspaceFrom(workingDirectory: string, settings: ConfluenceSettings) {
+	return runEffect(
+		Effect.gen(function* () {
+			const path = yield* Path;
+			// Model relative paths without changing the process cwd shared by test workers.
+			return yield* makeMarkdownWorkspaceEffect(settings).pipe(
+				Effect.provideService(Path, {
+					...path,
+					resolve: (...segments) => path.resolve(workingDirectory, ...segments),
+				}),
+			);
+		}),
+	);
+}
+
 test("matches folderToPublish under a relative contentRoot", async () => {
 	const expectedFilePath = await runEffect(
 		Effect.gen(function* () {
 			const fs = yield* FileSystem;
 			const path = yield* Path;
-			const runtimeEnvironment = yield* RuntimeEnvironmentService;
 
 			const workspaceRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-" });
 			tmpRoot = workspaceRoot;
-			originalWorkingDirectory = yield* runtimeEnvironment.cwd;
-			yield* runtimeEnvironment.chdir(workspaceRoot);
 
-			yield* fs.makeDirectory(path.join("phil", "thingy"), { recursive: true });
-			yield* fs.writeFileString(path.join("phil", "index.md"), "# Index");
-			yield* fs.writeFileString(path.join("phil", "thingy", "mydude.md"), "# My Dude");
+			yield* fs.makeDirectory(path.join(workspaceRoot, "phil", "thingy"), {
+				recursive: true,
+			});
+			yield* fs.writeFileString(path.join(workspaceRoot, "phil", "index.md"), "# Index");
+			yield* fs.writeFileString(
+				path.join(workspaceRoot, "phil", "thingy", "mydude.md"),
+				"# My Dude",
+			);
 
 			return path.join("thingy", "mydude.md");
 		}),
 	);
 
-	const workspace = await loadMarkdownWorkspace({
+	const workspace = await loadMarkdownWorkspaceFrom(tmpRoot!, {
 		...testSettings,
 		contentRoot: "./phil/",
 		folderToPublish: "thingy",
@@ -81,29 +91,29 @@ test("matches tagsToPublish outside the configured publish folder", async () => 
 		Effect.gen(function* () {
 			const fs = yield* FileSystem;
 			const path = yield* Path;
-			const runtimeEnvironment = yield* RuntimeEnvironmentService;
 
 			const workspaceRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-" });
 			tmpRoot = workspaceRoot;
-			originalWorkingDirectory = yield* runtimeEnvironment.cwd;
-			yield* runtimeEnvironment.chdir(workspaceRoot);
 
-			yield* fs.makeDirectory("Notes", { recursive: true });
+			yield* fs.makeDirectory(path.join(workspaceRoot, "Notes"), { recursive: true });
 			yield* fs.writeFileString(
-				path.join("Notes", "publish-me.md"),
+				path.join(workspaceRoot, "Notes", "publish-me.md"),
 				"---\ntags:\n  - public\n---\n# Public",
 			);
 			yield* fs.writeFileString(
-				path.join("Notes", "skip-me.md"),
+				path.join(workspaceRoot, "Notes", "skip-me.md"),
 				"---\ntags:\n  - public\nconnie-publish: false\n---\n# Private",
 			);
-			yield* fs.writeFileString(path.join("Notes", "untagged.md"), "# Untagged");
+			yield* fs.writeFileString(
+				path.join(workspaceRoot, "Notes", "untagged.md"),
+				"# Untagged",
+			);
 
 			return path.join("Notes", "publish-me.md");
 		}),
 	);
 
-	const workspace = await loadMarkdownWorkspace({
+	const workspace = await loadMarkdownWorkspaceFrom(tmpRoot!, {
 		...testSettings,
 		folderToPublish: "Confluence Pages",
 		tagsToPublish: "public",
@@ -119,21 +129,20 @@ test("expands Obsidian markdown embeds from outside the publish folder", async (
 		Effect.gen(function* () {
 			const fs = yield* FileSystem;
 			const path = yield* Path;
-			const runtimeEnvironment = yield* RuntimeEnvironmentService;
 
 			const workspaceRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-" });
 			tmpRoot = workspaceRoot;
-			originalWorkingDirectory = yield* runtimeEnvironment.cwd;
-			yield* runtimeEnvironment.chdir(workspaceRoot);
 
-			yield* fs.makeDirectory("Confluence Pages", { recursive: true });
-			yield* fs.makeDirectory("Notes", { recursive: true });
+			yield* fs.makeDirectory(path.join(workspaceRoot, "Confluence Pages"), {
+				recursive: true,
+			});
+			yield* fs.makeDirectory(path.join(workspaceRoot, "Notes"), { recursive: true });
 			yield* fs.writeFileString(
-				path.join("Confluence Pages", "page.md"),
+				path.join(workspaceRoot, "Confluence Pages", "page.md"),
 				"# Page\n\nBefore\n\n![[Notes/embed]]\n\nAfter",
 			);
 			yield* fs.writeFileString(
-				path.join("Notes", "embed.md"),
+				path.join(workspaceRoot, "Notes", "embed.md"),
 				"---\ntags:\n  - private\n---\n## Embedded content",
 			);
 
@@ -141,7 +150,7 @@ test("expands Obsidian markdown embeds from outside the publish folder", async (
 		}),
 	);
 
-	const workspace = await loadMarkdownWorkspace({
+	const workspace = await loadMarkdownWorkspaceFrom(tmpRoot!, {
 		...testSettings,
 		folderToPublish: "Confluence Pages",
 	});
@@ -159,15 +168,17 @@ test("updates markdown values for a cwd-relative file path inside contentRoot", 
 		Effect.gen(function* () {
 			const fs = yield* FileSystem;
 			const path = yield* Path;
-			const runtimeEnvironment = yield* RuntimeEnvironmentService;
 
 			const workspaceRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-" });
 			tmpRoot = workspaceRoot;
-			originalWorkingDirectory = yield* runtimeEnvironment.cwd;
-			yield* runtimeEnvironment.chdir(workspaceRoot);
 
-			yield* fs.makeDirectory(path.join("src", "development"), { recursive: true });
-			yield* fs.writeFileString(path.join("src", "development", "page.md"), "# Page");
+			yield* fs.makeDirectory(path.join(workspaceRoot, "src", "development"), {
+				recursive: true,
+			});
+			yield* fs.writeFileString(
+				path.join(workspaceRoot, "src", "development", "page.md"),
+				"# Page",
+			);
 
 			return {
 				updatePath: path.join("src", "development", "page.md"),
@@ -176,7 +187,7 @@ test("updates markdown values for a cwd-relative file path inside contentRoot", 
 		}),
 	);
 
-	const workspace = await loadMarkdownWorkspace({
+	const workspace = await loadMarkdownWorkspaceFrom(tmpRoot!, {
 		...testSettings,
 		contentRoot: "./src/",
 	});
@@ -202,21 +213,23 @@ test("updates markdown values for an absolute file path inside contentRoot", asy
 		Effect.gen(function* () {
 			const fs = yield* FileSystem;
 			const path = yield* Path;
-			const runtimeEnvironment = yield* RuntimeEnvironmentService;
 
 			const workspaceRoot = yield* fs.makeTempDirectory({ prefix: "markdown-confluence-" });
 			tmpRoot = workspaceRoot;
-			originalWorkingDirectory = yield* runtimeEnvironment.cwd;
-			yield* runtimeEnvironment.chdir(workspaceRoot);
 
-			yield* fs.makeDirectory(path.join("src", "development"), { recursive: true });
-			yield* fs.writeFileString(path.join("src", "development", "page.md"), "# Page");
+			yield* fs.makeDirectory(path.join(workspaceRoot, "src", "development"), {
+				recursive: true,
+			});
+			yield* fs.writeFileString(
+				path.join(workspaceRoot, "src", "development", "page.md"),
+				"# Page",
+			);
 
 			return path.join(workspaceRoot, "src", "development", "page.md");
 		}),
 	);
 
-	const workspace = await loadMarkdownWorkspace({
+	const workspace = await loadMarkdownWorkspaceFrom(tmpRoot!, {
 		...testSettings,
 		contentRoot: "./src/",
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,15 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      minimatch:
+        specifier: 10.2.6
+        version: 10.2.6
+      mutation-testing-elements:
+        specifier: 3.7.3
+        version: 3.7.3
+      mutation-testing-metrics:
+        specifier: 3.7.3
+        version: 3.7.3
       oxlint:
         specifier: 1.66.0
         version: 1.66.0(oxlint-tsgolint@7.0.2001)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@stryker-mutator/typescript-checker':
         specifier: 9.6.1
         version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.9.5))(typescript@6.0.3)
+      '@stryker-mutator/vitest-runner':
+        specifier: 9.6.1
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.9.5))(vitest@4.1.11)
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.5
@@ -1239,6 +1242,13 @@ packages:
 
   '@stryker-mutator/util@9.6.1':
     resolution: {integrity: sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==}
+
+  '@stryker-mutator/vitest-runner@9.6.1':
+    resolution: {integrity: sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==}
+    engines: {node: '>=14.18.0'}
+    peerDependencies:
+      '@stryker-mutator/core': 9.6.1
+      vitest: 4.1.11
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4086,6 +4096,15 @@ snapshots:
       typescript: 6.0.3
 
   '@stryker-mutator/util@9.6.1': {}
+
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.9.5))(vitest@4.1.11)':
+    dependencies:
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/core': 9.6.1(@types/node@25.9.5)
+      '@stryker-mutator/util': 9.6.1
+      semver: 7.8.5
+      tslib: 2.8.1
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/browser-preview@4.1.11)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@25.9.5)(typescript@6.0.3)(yaml@2.9.0))
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/scripts/check-descriptive-names.js
+++ b/scripts/check-descriptive-names.js
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 const skippedDirectoryNames = new Set([
 	".git",
 	".release-repo",
+	".stryker-tmp",
 	".husky",
 	"coverage",
 	"dev-vault",

--- a/scripts/mutation-ci.js
+++ b/scripts/mutation-ci.js
@@ -1,0 +1,142 @@
+import { fileURLToPath } from "node:url";
+import { Console, Effect, Stream } from "effect";
+import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
+import { ChildProcess } from "effect/unstable/process";
+import { NodeRuntime, NodeServices } from "@effect/platform-node";
+import {
+	RuntimeEnvironmentLive,
+	RuntimeEnvironmentService,
+} from "../packages/lib/src/effects/index.ts";
+import config from "../stryker.config.mjs";
+import {
+	planMutationShards,
+	combineMutationShards,
+	mutationReportHtml,
+} from "./mutation-shards.js";
+
+function readMutationPlan() {
+	return Effect.scoped(
+		Effect.gen(function* () {
+			const filesystem = yield* FileSystem;
+			const child = yield* ChildProcess.make("git", ["ls-files", "-z"], {
+				stdout: "pipe",
+				stderr: "inherit",
+			});
+			const [exitCode, output] = yield* Effect.all(
+				[
+					child.exitCode,
+					child.stdout.pipe(
+						Stream.decodeText(),
+						Stream.runCollect,
+						Effect.map((chunks) => chunks.join("")),
+					),
+				],
+				{ concurrency: "unbounded" },
+			);
+			if (exitCode !== 0)
+				return yield* Effect.fail(new Error("Cannot enumerate mutation source files"));
+			const files = yield* Effect.forEach(
+				output.split("\0").filter(Boolean),
+				(name) =>
+					filesystem
+						.stat(name)
+						.pipe(Effect.map((stat) => ({ name, size: Number(stat.size) }))),
+				{ concurrency: 16 },
+			);
+			return planMutationShards(files, config.mutate);
+		}),
+	);
+}
+
+function runMutationCi() {
+	return Effect.gen(function* () {
+		const filesystem = yield* FileSystem;
+		const path = yield* Path;
+		const runtime = yield* RuntimeEnvironmentService;
+		const [command, argument] = (yield* runtime.argv)
+			.slice(2)
+			.filter((value) => value !== "--");
+		const plan = yield* readMutationPlan();
+		if (command === "plan") return yield* Console.log(JSON.stringify(plan, null, 2));
+		if (command === "run") {
+			const shard = plan.find(({ id }) => String(id) === argument);
+			if (!shard) return yield* Effect.fail(new Error("Invalid mutation shard number"));
+			yield* filesystem.makeDirectory("reports/mutation", { recursive: true });
+			yield* filesystem.remove("reports/mutation/complete.json", { force: true });
+			yield* Console.log(
+				`Mutation shard ${shard.id}/${plan.length}: ${shard.files.join(", ")}`,
+			);
+			const { Stryker } = yield* Effect.promise(() => import("@stryker-mutator/core"));
+			const results = yield* Effect.promise(() =>
+				new Stryker({
+					mutate: shard.files,
+					// Enforce the configured score once, on the combined report.
+					thresholds: { ...config.thresholds, break: null },
+				}).runMutationTest(),
+			);
+			const mutantCounts = Object.fromEntries(shard.files.map((name) => [name, 0]));
+			for (const result of results) {
+				const filename = path
+					.relative(yield* runtime.cwd, result.fileName)
+					.split(path.sep)
+					.join("/");
+				if (!(filename in mutantCounts))
+					return yield* Effect.fail(new Error(`Unexpected mutant file: ${filename}`));
+				mutantCounts[filename]++;
+			}
+			yield* filesystem.writeFileString(
+				"reports/mutation/complete.json",
+				JSON.stringify({ ...shard, mutantCounts }),
+			);
+			return;
+		}
+		if (command !== "aggregate")
+			return yield* Effect.fail(new Error("Expected plan, run <shard>, or aggregate"));
+		const completed = yield* Effect.forEach(plan, (shard) =>
+			Effect.gen(function* () {
+				const directory = `reports/mutation-shards/mutation-shard-${shard.id}`;
+				return {
+					manifest: JSON.parse(
+						yield* filesystem.readFileString(`${directory}/complete.json`),
+					),
+					report: JSON.parse(
+						yield* filesystem.readFileString(`${directory}/mutation.json`),
+					),
+				};
+			}),
+		);
+		const { report, metrics } = combineMutationShards(plan, completed, config.thresholds);
+		const componentScript = yield* filesystem.readFileString(
+			fileURLToPath(
+				import.meta.resolve("mutation-testing-elements/mutation-test-elements.js"),
+			),
+		);
+		yield* filesystem.makeDirectory("reports/mutation", { recursive: true });
+		yield* filesystem.writeFileString("reports/mutation/mutation.json", JSON.stringify(report));
+		yield* filesystem.writeFileString(
+			"reports/mutation/mutation.html",
+			mutationReportHtml(report, componentScript),
+		);
+		const summary = `Mutation testing: ${metrics.totalMutants} mutants across ${plan.length} shards; score ${metrics.mutationScore.toFixed(2)}%.\n`;
+		yield* filesystem.writeFileString(
+			"reports/mutation/summary.json",
+			JSON.stringify(metrics, null, 2),
+		);
+		const summaryPath = yield* runtime.getEnv("GITHUB_STEP_SUMMARY");
+		if (summaryPath) yield* filesystem.writeFileString(summaryPath, summary, { flag: "a" });
+		yield* Console.log(summary);
+		if (metrics.mutationScore < config.thresholds.break)
+			return yield* Effect.fail(
+				new Error(`Mutation score is below ${config.thresholds.break}%`),
+			);
+	});
+}
+
+if (import.meta.main)
+	NodeRuntime.runMain(
+		runMutationCi().pipe(
+			Effect.provide(NodeServices.layer),
+			Effect.provide(RuntimeEnvironmentLive),
+		),
+	);

--- a/scripts/mutation-shards.js
+++ b/scripts/mutation-shards.js
@@ -1,0 +1,82 @@
+import { minimatch } from "minimatch";
+import { aggregateResultsByModule, calculateMutationTestMetrics } from "mutation-testing-metrics";
+
+export const mutationShardCount = 8;
+
+export function planMutationShards(sourceFiles, patterns, count = mutationShardCount) {
+	if (!Number.isInteger(count) || count < 1) throw new Error("Invalid mutation shard count");
+	const included = patterns.filter((pattern) => !pattern.startsWith("!"));
+	const excluded = patterns
+		.filter((pattern) => pattern.startsWith("!"))
+		.map((pattern) => pattern.slice(1));
+	const selected = sourceFiles.filter(
+		({ name }) =>
+			included.some((pattern) => minimatch(name, pattern)) &&
+			!excluded.some((pattern) => minimatch(name, pattern)),
+	);
+	if (new Set(selected.map(({ name }) => name)).size !== selected.length)
+		throw new Error("Duplicate mutation source file");
+	if (selected.length < count) throw new Error("Not enough mutation source files for all shards");
+	const shards = Array.from({ length: count }, (_, index) => ({
+		id: index + 1,
+		files: [],
+		size: 0,
+	}));
+	selected.sort(
+		(left, right) => right.size - left.size || left.name.localeCompare(right.name, "en"),
+	);
+	for (const source of selected) {
+		const shard = shards.reduce((smallest, current) =>
+			current.size < smallest.size ? current : smallest,
+		);
+		shard.files.push(source.name);
+		shard.size += source.size;
+	}
+	return shards.map((shard) => ({ ...shard, files: shard.files.sort() }));
+}
+
+export function combineMutationShards(plan, completed, thresholds) {
+	if (completed.length !== plan.length) throw new Error("Missing mutation shard reports");
+	const reports = {};
+	const completedStatuses = new Set([
+		"Killed",
+		"Survived",
+		"Timeout",
+		"NoCoverage",
+		"CompileError",
+		"RuntimeError",
+		"Ignored",
+	]);
+	for (const shard of plan) {
+		const entries = completed.filter(({ manifest }) => manifest.id === shard.id);
+		if (entries.length !== 1)
+			throw new Error(`Missing or duplicate mutation shard ${shard.id}`);
+		const { manifest, report } = entries[0];
+		if (JSON.stringify(manifest.files) !== JSON.stringify(shard.files))
+			throw new Error(`Mutation scope mismatch in shard ${shard.id}`);
+		if (Object.keys(report.files).some((name) => !shard.files.includes(name)))
+			throw new Error(`Unexpected mutation source in shard ${shard.id}`);
+		for (const filename of shard.files) {
+			const expected = manifest.mutantCounts[filename];
+			const mutants = report.files[filename]?.mutants ?? [];
+			if (
+				!Number.isInteger(expected) ||
+				expected < 0 ||
+				mutants.length !== expected ||
+				mutants.some(({ status }) => !completedStatuses.has(status))
+			)
+				throw new Error(`Incomplete mutation report for ${filename}`);
+		}
+		reports[`shard-${shard.id}`] = report;
+	}
+	const report = aggregateResultsByModule(reports);
+	report.thresholds = thresholds;
+	const metrics = calculateMutationTestMetrics(report).systemUnderTestMetrics.metrics;
+	if (metrics.totalMutants === 0) throw new Error("Mutation reports contain no mutants");
+	return { report, metrics };
+}
+
+export function mutationReportHtml(report, componentScript) {
+	const reportJson = JSON.stringify(report).replaceAll("<", "\\u003c");
+	return `<!doctype html><html><head><meta charset="utf-8"><title>Mutation testing</title><script>${componentScript}</script></head><body><mutation-test-report-app></mutation-test-report-app><script>document.querySelector('mutation-test-report-app').report = ${reportJson};</script></body></html>`;
+}

--- a/scripts/mutation-shards.test.js
+++ b/scripts/mutation-shards.test.js
@@ -1,0 +1,112 @@
+import { expect, test } from "@effect/vitest";
+import {
+	planMutationShards,
+	combineMutationShards,
+	mutationReportHtml,
+} from "./mutation-shards.js";
+
+test("partitions the configured scope exactly once, including nested index files", () => {
+	const files = [
+		"src/large.ts",
+		"src/a.ts",
+		"src/nested/index.ts",
+		"src/a.test.ts",
+		"src/index.ts",
+		"outside.ts",
+	].map((name, index) => ({ name, size: 100 - index * 10 }));
+	const patterns = ["src/**/*.ts", "!src/**/*.test.ts", "!src/index.ts"];
+	const shards = planMutationShards(files, patterns, 2);
+	expect(shards.flatMap(({ files: names }) => names).sort()).toEqual([
+		"src/a.ts",
+		"src/large.ts",
+		"src/nested/index.ts",
+	]);
+	expect(planMutationShards([...files].reverse(), patterns, 2)).toEqual(shards);
+	expect(shards.every(({ files: names }) => names.length > 0)).toBe(true);
+});
+
+const plan = [
+	{ id: 1, files: ["src/a.ts", "src/types.ts"] },
+	{ id: 2, files: ["src/b.ts"] },
+];
+function completedReports() {
+	return plan.map((shard) => ({
+		manifest: {
+			...shard,
+			mutantCounts: Object.fromEntries(
+				shard.files.map((name) => [name, name.endsWith("types.ts") ? 0 : 1]),
+			),
+		},
+		report: {
+			schemaVersion: "1.0",
+			files: {
+				[shard.files[0]]: {
+					source: "const value = true;",
+					language: "typescript",
+					mutants: [
+						{
+							id: "0",
+							status: shard.id === 1 ? "Killed" : "Survived",
+							mutatorName: "BooleanLiteral",
+							replacement: "false",
+							location: {
+								start: { line: 1, column: 15 },
+								end: { line: 1, column: 19 },
+							},
+							coveredBy: ["0"],
+							killedBy: shard.id === 1 ? ["0"] : [],
+						},
+					],
+				},
+			},
+			testFiles: { "src/test.ts": { tests: [{ id: "0", name: "checks value" }] } },
+		},
+	}));
+}
+
+test("combines scores and namespaces colliding mutant and test ids", () => {
+	const { report, metrics } = combineMutationShards(plan, completedReports(), {
+		high: 80,
+		low: 60,
+		break: 0,
+	});
+	expect(metrics.totalMutants).toBe(2);
+	expect(metrics.mutationScore).toBe(50);
+	expect(report.files["shard-1/a.ts"].mutants[0].id).not.toBe(
+		report.files["shard-2/b.ts"].mutants[0].id,
+	);
+	expect(report.files["shard-1/a.ts"].mutants[0].killedBy).toEqual([
+		report.testFiles["shard-1/test.ts"].tests[0].id,
+	]);
+});
+
+test("rejects missing shards, mismatched scope, truncated and unfinished reports", () => {
+	expect(() => combineMutationShards(plan, completedReports().slice(1), {})).toThrow("Missing");
+	for (const damage of [
+		(entries) => {
+			entries[1].manifest.id = 1;
+		},
+		(entries) => {
+			entries[0].manifest.files = ["src/wrong.ts"];
+		},
+		(entries) => {
+			entries[0].report.files["src/a.ts"].mutants = [];
+		},
+		(entries) => {
+			entries[0].report.files["src/a.ts"].mutants[0].status = "Pending";
+		},
+	]) {
+		const entries = completedReports();
+		damage(entries);
+		expect(() => combineMutationShards(plan, entries, {})).toThrow();
+	}
+});
+
+test("escapes source text that could close the report script element", () => {
+	const html = mutationReportHtml(
+		{ source: "</script><script>alert(1)</script>" },
+		"componentCode();",
+	);
+	expect(html).not.toContain("</script><script>alert(1)");
+	expect(html).toContain("\\u003c/script>");
+});

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,11 +1,12 @@
 export default {
 	packageManager: "pnpm",
-	plugins: ["@stryker-mutator/typescript-checker"],
-	testRunner: "command",
-	commandRunner: {
-		command: "vp test run",
+	plugins: ["@stryker-mutator/typescript-checker", "@stryker-mutator/vitest-runner"],
+	testRunner: "vitest",
+	vitest: {
+		configFile: "vitest.config.ts",
+		related: true,
 	},
-	coverageAnalysis: "off",
+	coverageAnalysis: "perTest",
 	checkers: ["typescript"],
 	tsconfigFile: "packages/lib/tsconfig.json",
 	concurrency: "50%",


### PR DESCRIPTION
Release #922 mutation testing timed out after four hours with only 2,746 of 8,979 mutants completed. The command runner restarted the entire Vite+ test suite for every mutation, and cancelled runs never produced a reusable incremental report.

Use the matching Stryker Vitest runner with per-test coverage and dependency selection. Split the unchanged library mutation scope into eight deterministic groups balanced by source size. The final `mutation` check requires every shard to pass, validates completion manifests and mutant counts, combines JSON/HTML reports, and applies the existing score threshold to the aggregate. Static mutations and TypeScript checking remain enabled.

Workspace fixtures inject their relative path base instead of changing process cwd, allowing Vitest worker threads. Cache keys now require identical source, tests, configuration and dependencies for each shard. The descriptive-name check ignores generated Stryker sandboxes.

Validation:
- Frozen-lockfile install, formatting/lint checks, and all 532 unit tests pass (one existing skip).
- All 11 workspace tests pass in normal and threads pools.
- Coverage comparison is exact: both dependency-selection modes cover 7,818 mutants, with identical maps for 441 covering tests and all 795 static mutants.
- Real source partition contains all 57 files exactly once across eight jobs.
- Synthetic end-to-end run executes all eight shard commands and aggregates all 16 expected mutants at 100%; removing a completion manifest correctly fails aggregation.
- Full Linux, Windows, and eight-shard mutation CI must pass on the final PR head before merging.
